### PR TITLE
gitignore: add hakyll site files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ result
 result-*
 _cache/
 _site/
+/site
+*.hi
+*.o


### PR DESCRIPTION
This will ignore the files generated by Hakyll if using a nix-shell
rather than a nix-build every time the site changes.