### PR TITLE
Add (wip) Sponsors section

### DIFF
--- a/css/_tiers.scss
+++ b/css/_tiers.scss
@@ -1,0 +1,112 @@
+//@import "math";
+@debug percentage(0.2);
+@debug unit(300px);
+
+// todo dry.
+$fg: #404040;
+$bg: #F2F2F2;
+//
+// Tier colors
+$bronze: #AD8A56;
+$silver: #C0C0C0;
+$gold: #D4AF37;
+$platinum: #E5E4E2;
+
+// data
+$tiers: (
+  bronze: (
+    'color': $bronze,
+    'scale': 1.309
+  ),
+  silver: (
+    'color': $silver,
+    'scale': 1.618,
+    'max-columns': 4
+  ),
+  gold: (
+    'color': $gold,
+    'scale': 1.927,
+    'max-columns': 2
+  ),
+  platinum: (
+    'color': $platinum,
+    'max-columns': 1,
+    'scale': 2.237
+  )
+);
+// could calculate scale inside mixin, using 'relative magnitude'
+
+// limit max-width?
+//$base-width: 325px;
+
+// generate grid customizations for the tiers
+@mixin cards($name, $color: #FF0000, $scale: 1, $max-columns: 0) {
+
+  @debug $name;
+  @debug $scale;
+  @debug 1px * $scale;
+  @debug 1rem * $scale;
+
+  @if $max-columns == 0 {
+    .grid.#{$name} {
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+  } @else {
+    .grid.#{$name} {
+      grid-template-columns: repeat(#{$max-columns}, minmax(200px, 1fr))!important;
+    }
+  }
+
+  .card.#{$name}, .#{$name} > li {
+    margin-top: 0.7rem * $scale;
+    border-color: $color;
+  }
+
+  .#{$name} > .card-title, .#{$name} > li > .card-title {
+    font-size: #{$scale}em;
+    padding: 0.6rem * $scale;
+  }
+
+  .#{$name} > .card-body, .#{$name} > li > .card-body {
+    border-color: $color;
+    border-top: solid $color
+  }
+}
+
+@each $name, $attr in $tiers {
+  @include cards($name, $attr...)
+}
+
+.card.platinum {
+  border-width: thick;
+}
+
+.grid {
+  list-style: none;
+  background: $bg;
+  color: $fg;
+  //margin: 2em;
+  display: grid;
+  gap: 1rem;
+  > li {
+    border-radius: 0.2rem;
+    border-style: solid;
+    padding: 0.2rem;
+    display: flex;
+    flex-direction: column;
+    > h4 {
+      padding: 0.4rem;
+    }
+    > .body {
+      padding: 0.4rem;
+      //border: #0A0AFF;
+      //border-style: solid;
+    }
+  }
+}
+
+img > .responsive-img {
+    max-width: 100%;
+    height: auto;
+}
+//body > ul:nth-child(3) > li:nth-child(2) > div.image > img

--- a/css/default.scss
+++ b/css/default.scss
@@ -246,6 +246,13 @@ main {
   }
 }
 
+#irc-widget {
+  background-color: transparent;
+  border: none;
+  height: 500px;
+  width: 100%;
+}
+
 svg {
   &.divider {
     display: block;

--- a/css/default.scss
+++ b/css/default.scss
@@ -87,7 +87,7 @@ a {
 }
 
 nav {
-  @media (max-width: $mobile-breakpoint) {
+  @media screen and (max-width: $mobile-breakpoint) {
     box-shadow: none;
     border-radius: 0;
     margin: 0;
@@ -98,7 +98,7 @@ nav {
   overflow: hidden;
   margin: 1rem auto;
   .mobile-control {
-    @media (min-width: $mobile-breakpoint) {
+    @media screen and (min-width: $mobile-breakpoint + 1) {
         display: none;
     }
     display: grid;
@@ -118,7 +118,7 @@ nav {
     }
   }
   ul {
-    @media (max-width: $mobile-breakpoint) {
+    @media screen and (max-width: $mobile-breakpoint) {
       margin: 0;
       display: none;
     }
@@ -126,12 +126,12 @@ nav {
     margin: 0 1rem;
     width: auto;
     > li {
-      @media (max-width: $mobile-breakpoint) {
+      @media screen and (max-width: $mobile-breakpoint) {
         float: none;
       }
       float: left;
       > a {
-        @media (max-width: $mobile-breakpoint) {
+        @media screen and (max-width: $mobile-breakpoint) {
           margin: 0;
         }
         display: block;
@@ -149,8 +149,14 @@ nav {
   }
 }
 
+.ribbon {
+  @media screen and (max-width: $mobile-breakpoint) {
+    display: none;
+  }
+}
+
 .container {
-  @media (max-width: $mobile-breakpoint) {
+  @media screen and (max-width: $mobile-breakpoint) {
     padding: 0 0.5rem;
   }
   margin-left: auto;
@@ -185,7 +191,7 @@ main {
   @media (min-width: $mobile-breakpoint) {
     min-height: 60vh;
   }
-  @media (max-width: $mobile-breakpoint) {
+  @media screen and (max-width: $mobile-breakpoint) {
     margin: 5rem 0;
   }
   display: flex;
@@ -199,26 +205,26 @@ main {
   margin: auto;
   display: grid;
   color: $blue-dark;
-  @media (max-width: $mobile-breakpoint + 100) {
+  @media screen and (max-width: $mobile-breakpoint + 100) {
     grid-template-columns: 1fr;
   }
   grid-template-columns: min-content max-content;
   .hero-text {
     h1 {
-      @media (max-width: $mobile-breakpoint) {
+      @media screen and (max-width: $mobile-breakpoint) {
         font-size: 3rem;
       }
       font-size: 6rem;
       margin-bottom: 0;
     }
     .hero-text-sub {
-      @media (max-width: $mobile-breakpoint) {
+      @media screen and (max-width: $mobile-breakpoint) {
         font-size: 1.5rem;
       }
       font-size: 2rem;
     }
     .hero-text-badge {
-      @media (max-width: $mobile-breakpoint) {
+      @media screen and (max-width: $mobile-breakpoint) {
         font-size: 1.25rem;
       }
       font-size: 1.5rem;
@@ -268,7 +274,7 @@ section {
     }
   }
   &.section-dark {
-    @media (max-width: $mobile-breakpoint + 100) {
+    @media screen and (max-width: $mobile-breakpoint + 100) {
       padding: 1rem 0;
     }
     :first-child {

--- a/css/default.scss
+++ b/css/default.scss
@@ -1,3 +1,5 @@
+@import 'tiers';
+
 // TODO: move fonts to local folder
 /* hind-madurai-regular - latin */
 @font-face {

--- a/index.html
+++ b/index.html
@@ -106,9 +106,16 @@
 <section id="Location" class="section-white">
     <div class="container">
         <h3>Location</h3>
-        <address>
-            Online
-        </address>
+        <p>
+            NixCon takes place online this year.
+            Talks will be streamed live here and also viewable on youtube. Links to the
+            viewing URLS will be posted here as we approach the event.
+        </p>
+        <p>
+            There is no registration and participation is free.
+        <br>
+            If you wish to contribute financially, consider supporting <a href="https://opencollective.com/nixos">the NixOS Foundation</a>.
+        </p>
     </div>
 </section>
 
@@ -117,26 +124,13 @@
         fill="#5277C3" />
 </svg>
 
-<section id="registration" class="section-dark">
+<section id="sponsors" class="section-dark">
     <div class="container">
-        <h3>Registration</h3>
+        <h3>Sponsors</h3>
         <p>
-            *not open yet*
+            Thank you to our wonderful and supportive sponsors! Whose contributtions nourished this online edition of NixCon.
         </p>
-        <!--<pretix-widget event="https://tickets.nixcon.org/nixcon/2020/"></pretix-widget>-->
-        <noscript>
-            <div class="pretix-widget">
-                <div class="pretix-widget-info-message">
-                    *not open yet* JavaScript is disabled in your browser. To access our ticket shop without
-                    JavaScript, please
-                    <a target="_blank" rel="noopener" href="https://tickets.nixcon.org/nixcon/2020/">click here</a>.
-                </div>
-            </div>
-        </noscript>
-        <p>
-            <!--If you have any questions see our <a href="https://tickets.nixcon.org/nixcon/2020/page/faq/" target="_blank">FAQ</a> or .-->
-            <a href="/#contact">contact us</a>
-        </p>
+        <!-- todo: insert note on how to sponsor -->
     </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -160,7 +160,8 @@
         <!--  Ofc we can always add this ^ back in, don't want to publish a promise I cannot keep yet -->
 
         <p>The organisers also hang on #nixcon on FreeNode:</p>
-        <iframe allowtransparency="true" class="col s12 m12" frameborder="0" height=500 scrolling=no
+        <!-- remove the scrollbar -->
+        <iframe title="Freenode.net webchat IRC widget" id="irc-widget"
             src="https://webchat.freenode.net?channels=%23nixcon&uio=MTE9MjE131"></iframe>
     </div>
 </section>

--- a/index.html
+++ b/index.html
@@ -130,7 +130,17 @@
         <p>
             Thank you to our wonderful and supportive sponsors! Whose contributtions nourished this online edition of NixCon.
         </p>
-        <!-- todo: insert note on how to sponsor -->
+        <a href="sponsoring.html">Learn about sponsoring.</a>
+        <!--<ul class="grid gold">-->
+            <!--<li>-->
+                <!--<div class="card-title">-->
+                <!--Test 1-->
+                <!--</div>-->
+                <!--<div class="card-body">-->
+                    <!--foo-->
+                <!--</div>-->
+            <!--</li>-->
+        <!--</ul>-->
     </div>
 </section>
 
@@ -155,9 +165,8 @@
             For any questions, send us an email to
             <a class="contact-email" href="mail:orgateam(at)nixcon.org">orgateam (at) nixcon.org</a>
             .
+            We will respond within 24h.
         </p>
-        <!--  We will respond within 24h. -->
-        <!--  Ofc we can always add this ^ back in, don't want to publish a promise I cannot keep yet -->
 
         <p>The organisers also hang on #nixcon on FreeNode:</p>
         <!-- remove the scrollbar -->

--- a/sponsoring.html
+++ b/sponsoring.html
@@ -1,3 +1,8 @@
+<svg class="divider divider-top" viewBox="0 0 1920 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M1920 31.7527C1638.36 11.5721 1310.26 0 960 0C609.741 0 281.642 11.5721 0 31.7527V50H1920V31.7527Z"
+        fill="#5277C3" />
+</svg>
+
 <section id="sponsoring" class="section-dark section-center">
     <div class="container">
         <h1>Sponsoring NixCon 2020</h1>
@@ -113,3 +118,9 @@
         <!--</ul>-->
     </div>
 </section>
+
+<svg class="divider divider-bottom" viewBox="0 0 1920 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+        d="M2.77591e-06 18.2472C281.642 38.4278 609.741 49.9999 960 50C1310.26 50 1638.36 38.4279 1920 18.2473L1920 6.10352e-05L4.37114e-06 -0.000106817L2.77591e-06 18.2472Z"
+        fill="#5277C3" />
+</svg>

--- a/sponsoring.html
+++ b/sponsoring.html
@@ -1,0 +1,115 @@
+<section id="sponsoring" class="section-dark section-center">
+    <div class="container">
+        <h1>Sponsoring NixCon 2020</h1>
+        <p>
+            NixCon is a volunteer run community conference that depends on sponsorship to happen.
+            And it runs on NixOS!<!--<a href="./#infra">¹</a>-->
+            <!-- ??? NixCon 2020 runs on Free Software. todo, verify we can back this statement up-->
+        </p>
+        <br>
+        <p>
+            2020 is and has been a challenging year for many. NixCon is online because of the COVID-19 pandemic. Virtual experiences cannot substitute for in-person interactions. We are aiming to simulate the good parts. The perks reflect that by being digitally-focused.
+        </p>
+        <h4>
+            To confirm your sponsorship, please send the following information to orgateam@nixcon.org
+        </h4>
+        <ul>
+            <!--todo: style like not a list-->
+            <li>Contact name and email</li>
+            <li>Company name</li>
+            <li>Company address</li>
+            <li>EU/UK entities: Company VAT number</li>
+            <li>Sponsorship package type</li>
+            <li>Media contact name and email and/or information for your perks</li>
+        </ul>
+
+        <h1>Sponsor Perks</h1>
+        <p>
+            Various units of sponsorship are available. In-kind donations are also welcome, such as person-time or compute-time. For sponsoring, you will receive:
+            <ul>
+              <li>Shout outs of gratitude (at opening and closing)</li>
+              <li>Your logo will appear as part of the stream's background image.</li>
+              <!--todo: check on link-->
+              <li>Branding space on the&nbsp;
+                  <a href="#sponsors" target="_blank">2020.nixcon.org</a>&nbsp;website</li>
+            </ul>
+        </p>
+
+        <p>plus...</p>
+        <ul class="grid">
+          <!--todo format currency values according to Unicode CLDR/i18n-->
+          <!--'card' class not currently defined.-->
+          <li class="card platinum">
+              <div class="card-title">Platinum €3000</div>
+              <div class="card-body">
+                <ul>
+                  <li>Gold perks plus:</li>
+                  <li>"Sponsored by ..."</li>
+                  <li>Your idea here (within certain limits)</li>
+                </ul>
+              </div>
+            </li>
+            <li class="card gold">
+              <div class="card-title">Gold €2000</div>
+              <div class="card-body">
+                <ul>
+                  <li>Logo (prominent)<br></li>
+                  <li>Paragraph [60 words] on the website<br></li>
+                  <li>
+                    A dedicated read-out on the stream​​​​​​​​​​​​​​<br>
+                    <ul>
+                      <li>
+                        <div>
+                          <div>
+                            <div>
+                              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus feugiat laoreet dui, in ornare odio pretium et. Mauris viverra justo magna, sit amet malesuada urna iaculis eget. Pellentesque vel tristique turpis. Nunc sed neque vestibulum, eleifend nisl vel, accumsan ligula. Fusce eget odio non est dignissim dictum sit amet ac lectus. Vivamus euismod tincidunt odio eu mattis. Donec diam dui.<br></p>
+                            </div>
+                          </div>
+                        </div>
+                        <br>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="card silver">
+              <div class="card-title">Silver €1000</div>
+              <div class="card-body">
+                <ul>
+                  <li>Logo (medium)<br></li>
+                  <li>Sentence [15 words] on the website<br></li>
+                  <li>
+                    A dedicated read-out on the stream​​​​​​​<br>
+                    <ul>
+                      <li>
+                        <div>
+                          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras vel efficitur libero. Mauris efficitur maximus.<br></p>
+                        </div>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li class="card bronze">
+              <div class="card-title">Bronze 500€</div>
+              <div class="card-body">Logo on the 2020 website.</div>
+            </li>
+        </ul>
+
+        <p><br></p>
+        <h3>Read-Out</h3>
+        <p>A "read-out" is a spoken script up-to 60 seconds of read-time. You can describe all the important aspects of your company however you like. You may record this and provide a digital file, or the NixCon MC will pre-record a reading. The read-out will broadcast during the live stream spaced out in between talks.<br></p>
+        <p><br></p>
+        <h3>Pick-a-perk</h3>
+        <p>Platinum limits: We're not exactly sure how to define this. One example of a perk that would not be approved is buying a talk slot.</p>
+        <p></p>
+
+        <!--todo: github links to nixcon-av, vps.-->
+        <!--<a name="infra">NixCon 2020 Infrastructure</a>-->
+        <!--<ul>-->
+            <!--<li>foo</li>-->
+        <!--</ul>-->
+    </div>
+</section>

--- a/templates/default.html
+++ b/templates/default.html
@@ -11,9 +11,6 @@
   <link type="text/css" rel="stylesheet" href="css/default.css" media="screen,projection" />
   <script type="text/javascript" src="js/index.js" async></script>
   <link rel="shortcut icon" type="image/png" href="/favicon.png" />
-  <!--<link rel="stylesheet" type="text/css" href="https://tickets.nixcon.org/nixcon/2019/widget/v1.css">-->
-  <!-- following script gave a timeout -->
-  <!--<script type="text/javascript" src="https://tickets.nixcon.org/widget/v1.en.js" async></script> -->
 </head>
 
 <body>
@@ -39,7 +36,7 @@
         <a href="/#location">Location</a>
       </li>
       <li>
-        <a href="/#registration">Registration</a>
+        <a href="/#sponsors">Sponsors</a>
       </li>
       <!--<li>-->
       <!--<a href="https://tickets.nixcon.org/nixcon/2019/page/faq/" target="_blank">FAQ</a>-->
@@ -47,21 +44,13 @@
       <li>
         <a href="/#contact">Contact us</a>
       </li>
-      <!--<li>-->
-      <!--<a href="/#sponsors">Sponsors</a>-->
-      <!--</li>-->
-      <!-- <li>
-        <a href="https://twitter.com/nixconf">
-          <i class="fa fa-twitter fa-fw"></i>
-        </a>
-      </li> -->
     </ul>
     </div>
   </nav>
-  <!-- <a href="https://github.com/nixcon/2020.nixcon.org">
-    <img style="position: absolute; top: 0; right: 0; border: 0; z-index: 9000;" src="images/fork-me-on-github.png"
-      alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png">
-  </a> -->
+  <a class="ribbon" href="https://github.com/nixcon/2020.nixcon.org">
+    <img class="ribbon" style="position: absolute; top: 0; right: 0; border: 0; z-index: 9000;" src="images/fork-me-on-github.png"
+      alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png">
+  </a>
   <main>
     $body$
   </main>

--- a/templates/default.html
+++ b/templates/default.html
@@ -69,6 +69,11 @@
       <a href="http://nixcon2017.org/">2017</a> -
       <a href="https://nixos.github.io/nixcon/2015/index.html">2015</a>
       </p>
+      <p>
+      <a href="https://github.com/nixcon/2020.nixcon.org">
+      Edit this site on github
+      </a>
+      </p>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
Target: issue #8.

Replacing 'registration' with sponsors. Added brief text into the
location section explaining how to view the conference and info that
registration is not a thing for this year.

Added github ribbon and footnote.

Fix missing nav quirk when view width is exactly 1080 pixels. Thank you
to samueldr for pointing that out.