### PR TITLE
Say timezone (UTC+0) for schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,8 @@
     <div class="container">
         <h3>Talks 16-17 October (Fri/Saturday)</h3>
         <p><a href="https://cfp.nixcon.org/nixcon2020/schedule/">See the schedule here.</a></p>
+        <br>
+        <p class="text-prominent">* Times shown in UTC+0 *</p>
         <pretalx-schedule-widget event="https://cfp.nixcon.org/nixcon2020/"></pretalx-schedule-widget>
         <noscript>
            <div class="pretalx-widget">


### PR DESCRIPTION
This states the timezone so that people can interpret the times in their local time.

Ideally, we would also just translate and show their local time alongside this. I may have time to attempt that later in the week.