### PR TITLE
Update all timezone information

### DIFF
--- a/css/default.scss
+++ b/css/default.scss
@@ -305,6 +305,10 @@ section {
   font-size: 1.5rem;
 }
 
+.text-center {
+  text-align: center;
+}
+
 #player {
     width: 100%;
     height: auto;

--- a/index.html
+++ b/index.html
@@ -79,9 +79,15 @@
 <section id="program" class="section-dark">
     <div class="container">
         <h3>Talks 16-17 October (Fri/Saturday)</h3>
-        <p><a href="https://cfp.nixcon.org/nixcon2020/schedule/">See the schedule here.</a></p>
+        <p class="text-prominent text-center">* Times shown below are localized to your timezone. *</p>
+        <p> Beware there is a bug with dates on this widget:
+          <a href="https://github.com/nixcon/2020.nixcon.org/issues/31">
+            Calendar dates incorrect on homepage</a> when viewed from certain timezones.</a>
+        </p>
         <br>
-        <p class="text-prominent">* Times shown in UTC+0 *</p>
+        <p>
+          To view in UTC, <a href="https://cfp.nixcon.org/nixcon2020/schedule/">visit the schedule on the CfP site.</a>
+        </p>
         <pretalx-schedule-widget event="https://cfp.nixcon.org/nixcon2020/"></pretalx-schedule-widget>
         <noscript>
            <div class="pretalx-widget">


### PR DESCRIPTION
Retract previous statement about homepage widget in UTC. Those times are
always localized to the visitor's timezone.

The days are indeed wrong in many cases, and now that is also noted.