### PR TITLE
logo: Add monochrome variant source files

### DIFF
--- a/logo/nixcon2020-logo--monochrome.src.svg
+++ b/logo/nixcon2020-logo--monochrome.src.svg
@@ -1,0 +1,4452 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="297.83499"
+   inkscape:export-xdpi="297.83499"
+   inkscape:export-filename="/Users/samuel/Projects/nixos/nixcon/2020.nixcon.org/logo/nixcon2020-logo--monochrome.png"
+   width="141.5919mm"
+   height="122.80626mm"
+   viewBox="0 0 501.70361 435.14028"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="nixcon2020-logo--monochrome.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5562">
+      <stop
+         style="stop-color:#699ad7;stop-opacity:1"
+         offset="0"
+         id="stop5564" />
+      <stop
+         id="stop5566"
+         offset="0.24345198"
+         style="stop-color:#7eb1dd;stop-opacity:1" />
+      <stop
+         style="stop-color:#7ebae4;stop-opacity:1"
+         offset="1"
+         id="stop5568" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5053">
+      <stop
+         style="stop-color:#415e9a;stop-opacity:1"
+         offset="0"
+         id="stop5055" />
+      <stop
+         id="stop5057"
+         offset="0.23168644"
+         style="stop-color:#4a6baf;stop-opacity:1" />
+      <stop
+         style="stop-color:#5277c3;stop-opacity:1"
+         offset="1"
+         id="stop5059" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5960"
+       inkscape:collect="always">
+      <stop
+         id="stop5962"
+         offset="0"
+         style="stop-color:#637ddf;stop-opacity:1" />
+      <stop
+         style="stop-color:#649afa;stop-opacity:1"
+         offset="0.23168644"
+         id="stop5964" />
+      <stop
+         id="stop5966"
+         offset="1"
+         style="stop-color:#719efa;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5867">
+      <stop
+         style="stop-color:#7363df;stop-opacity:1"
+         offset="0"
+         id="stop5869" />
+      <stop
+         id="stop5871"
+         offset="0.23168644"
+         style="stop-color:#6478fa;stop-opacity:1" />
+      <stop
+         style="stop-color:#719efa;stop-opacity:1"
+         offset="1"
+         id="stop5873" />
+    </linearGradient>
+    <linearGradient
+       y2="515.97058"
+       x2="282.26105"
+       y1="338.62445"
+       x1="213.95642"
+       gradientTransform="translate(-197.75174,-337.1451)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5855-8"
+       xlink:href="#linearGradient5867"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="247.58188"
+       x2="-702.75317"
+       y1="102.74675"
+       x1="-775.20807"
+       gradientTransform="translate(983.36076,601.38885)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4544"
+       xlink:href="#linearGradient5960"
+       inkscape:collect="always" />
+    <clipPath
+       id="clipPath4501"
+       clipPathUnits="userSpaceOnUse">
+      <circle
+         r="241.06563"
+         cy="686.09473"
+         cx="335.13995"
+         id="circle4503"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#adadad;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </clipPath>
+    <clipPath
+       id="clipPath5410"
+       clipPathUnits="userSpaceOnUse">
+      <circle
+         r="241.13741"
+         cy="340.98975"
+         cx="335.98114"
+         id="circle5412"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5053"
+       id="linearGradient5137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(864.55062,-2197.497)"
+       x1="-584.19934"
+       y1="782.33563"
+       x2="-496.29703"
+       y2="937.71399" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5053"
+       id="linearGradient5147"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(864.55062,-2197.497)"
+       x1="-584.19934"
+       y1="782.33563"
+       x2="-496.29703"
+       y2="937.71399" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5562"
+       id="linearGradient5162"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(70.505061,-1761.3076)"
+       x1="200.59668"
+       y1="351.41116"
+       x2="290.08701"
+       y2="506.18814" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5562"
+       id="linearGradient5172"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(70.505061,-1761.3076)"
+       x1="200.59668"
+       y1="351.41116"
+       x2="290.08701"
+       y2="506.18814" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5562"
+       id="linearGradient5182"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(70.505061,-1761.3076)"
+       x1="200.59668"
+       y1="351.41116"
+       x2="290.08701"
+       y2="506.18814" />
+    <linearGradient
+       y2="506.18814"
+       x2="290.08701"
+       y1="351.41116"
+       x1="200.59668"
+       gradientTransform="translate(70.505061,-1761.3076)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5201"
+       xlink:href="#linearGradient5562"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="937.71399"
+       x2="-496.29703"
+       y1="782.33563"
+       x1="-584.19934"
+       gradientTransform="translate(864.55062,-2197.497)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5205"
+       xlink:href="#linearGradient5053"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5562"
+       id="linearGradient4328"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(70.650339,-1055.1511)"
+       x1="200.59668"
+       y1="351.41116"
+       x2="290.08701"
+       y2="506.18814" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5053"
+       id="linearGradient4330"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(864.69589,-1491.3405)"
+       x1="-584.19934"
+       y1="782.33563"
+       x2="-496.29703"
+       y2="937.71399" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0195,0,0,-0.0195,770.9,757.886)"
+       r="17925.004"
+       cy="-7278.2686"
+       cx="6611.7559"
+       id="path125302_1_">
+      <stop
+         id="stop5456"
+         style="stop-color:#0101FF"
+         offset="0" />
+      <stop
+         id="stop5458"
+         style="stop-color:#000080"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0194,0,0,-0.0205,772.9011,743.9232)"
+       r="16567.537"
+       cy="-7131.8633"
+       cx="7553.0029"
+       id="polygon8_1_">
+      <stop
+         id="stop5831"
+         style="stop-color:#0101FF"
+         offset="0" />
+      <stop
+         id="stop5833"
+         style="stop-color:#000080"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0222,0,0,-0.0248,721.1671,674.6745)"
+       r="13293.867"
+       cy="-10508.842"
+       cx="7976.3457"
+       id="polygon413_1_">
+      <stop
+         id="stop5838"
+         style="stop-color:#80FF80"
+         offset="0" />
+      <stop
+         id="stop5840"
+         style="stop-color:#0f0"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       id="path3517_1_"
+       cx="6513.3086"
+       cy="-7210.5059"
+       r="17986.939"
+       gradientTransform="matrix(0.0195,1.352274e-4,1.352237e-4,-0.0195,774.1678,756.2928)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#000;stop-opacity:0"
+         id="stop5845" />
+      <stop
+         offset="1"
+         style="stop-color:#000;stop-opacity:0.498"
+         id="stop5847" />
+    </radialGradient>
+    <linearGradient
+       y2="460.51822"
+       x2="389.57562"
+       y1="351.41116"
+       x1="200.59668"
+       gradientTransform="translate(210.82018,-765.27605)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1713"
+       xlink:href="#main"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       id="main">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="0"
+         id="stop915" />
+      <stop
+         id="stop917"
+         offset="0.23168644"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop919" />
+    </linearGradient>
+    <linearGradient
+       y2="880.37714"
+       x2="-414.38654"
+       y1="782.33563"
+       x1="-584.19934"
+       gradientTransform="translate(864.69589,-1491.3405)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1299"
+       xlink:href="#main"
+       inkscape:collect="always" />
+    <radialGradient
+       id="path125302_1_-0"
+       cx="6611.7559"
+       cy="-7278.2686"
+       r="17925.004"
+       gradientTransform="matrix(0.0195,0,0,-0.0195,770.9,757.886)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#0101FF"
+         id="stop5456-9" />
+      <stop
+         offset="1"
+         style="stop-color:#000080"
+         id="stop5458-3" />
+    </radialGradient>
+    <radialGradient
+       id="polygon8_1_-6"
+       cx="7553.0029"
+       cy="-7131.8633"
+       r="16567.537"
+       gradientTransform="matrix(0.0194,0,0,-0.0205,772.9011,743.9232)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#0101FF"
+         id="stop5831-0" />
+      <stop
+         offset="1"
+         style="stop-color:#000080"
+         id="stop5833-6" />
+    </radialGradient>
+    <radialGradient
+       id="polygon413_1_-2"
+       cx="7976.3457"
+       cy="-10508.842"
+       r="13293.867"
+       gradientTransform="matrix(0.0222,0,0,-0.0248,721.1671,674.6745)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#80FF80"
+         id="stop5838-6" />
+      <stop
+         offset="1"
+         style="stop-color:#0f0"
+         id="stop5840-1" />
+    </radialGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0195,1.352274e-4,1.352237e-4,-0.0195,774.1678,756.2928)"
+       r="17986.939"
+       cy="-7210.5059"
+       cx="6513.3086"
+       id="path3517_1_-8">
+      <stop
+         id="stop5845-7"
+         style="stop-color:#000;stop-opacity:0"
+         offset="0" />
+      <stop
+         offset="0.60000002"
+         style="stop-color:#000000;stop-opacity:0.044"
+         id="stop1686" />
+      <stop
+         id="stop5847-9"
+         style="stop-color:#000000;stop-opacity:0.82903226"
+         offset="1" />
+    </radialGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="332.34842"
+     inkscape:cy="179.30375"
+     inkscape:document-units="px"
+     inkscape:current-layer="g7683-2"
+     showgrid="false"
+     inkscape:window-width="2556"
+     inkscape:window-height="1407"
+     inkscape:window-x="1680"
+     inkscape:window-y="605"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:snap-nodes="false"
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="true"
+     borderlayer="true" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer7"
+     inkscape:label="bg"
+     style="display:inline"
+     transform="translate(-23.75651,-24.84972)"
+     sodipodi:insensitive="true">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.79136;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect5389"
+       width="550.31128"
+       height="483.7439"
+       x="-9.0332031e-07"
+       y="0.26189968" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="gradient-logo"
+     style="display:none;opacity:1"
+     sodipodi:insensitive="true"
+     transform="translate(-156.33871,933.1905)">
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       id="path3336-6"
+       d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
+       style="opacity:1;fill:url(#linearGradient4328);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <use
+       height="100%"
+       width="100%"
+       transform="rotate(60,407.11155,-715.78724)"
+       id="use3439-6"
+       inkscape:transform-center-y="151.59082"
+       inkscape:transform-center-x="124.43045"
+       xlink:href="#path3336-6"
+       y="0"
+       x="0" />
+    <use
+       height="100%"
+       width="100%"
+       transform="rotate(-60,407.31177,-715.70016)"
+       id="use3445-0"
+       inkscape:transform-center-y="75.573958"
+       inkscape:transform-center-x="-168.20651"
+       xlink:href="#path3336-6"
+       y="0"
+       x="0" />
+    <use
+       height="100%"
+       width="100%"
+       transform="rotate(180,407.41868,-715.7565)"
+       id="use3449-5"
+       inkscape:transform-center-y="-139.94592"
+       inkscape:transform-center-x="59.669705"
+       xlink:href="#path3336-6"
+       y="0"
+       x="0" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4330);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
+       id="path4260-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <use
+       height="100%"
+       width="100%"
+       transform="rotate(120,407.33916,-716.08356)"
+       id="use4354-5"
+       xlink:href="#path4260-0"
+       y="0"
+       x="0"
+       style="display:inline" />
+    <use
+       height="100%"
+       width="100%"
+       transform="rotate(-120,407.28823,-715.86995)"
+       id="use4362-2"
+       xlink:href="#path4260-0"
+       y="0"
+       x="0"
+       style="display:inline" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="white-logo"
+     sodipodi:insensitive="true">
+    <g
+       id="g1331"
+       style="display:inline"
+       transform="translate(0.13650198,0.07013057)">
+      <g
+         style="display:none"
+         transform="matrix(0.09048806,0,0,0.09048806,-14.15991,84.454917)"
+         inkscape:label="(pdf) background"
+         id="layer1-7">
+        <rect
+           y="-2102.4253"
+           x="-1045.6049"
+           height="7145.4614"
+           width="7947.0356"
+           id="rect995"
+           style="opacity:1;fill:#040404;fill-opacity:1;stroke-width:10.3605" />
+      </g>
+      <g
+         transform="translate(-156.48372,537.56136)"
+         style="display:inline;opacity:1"
+         inkscape:label="gradient-logo"
+         id="layer3-3">
+        <g
+           style="stroke-width:11.0512"
+           transform="matrix(0.09048806,0,0,0.09048806,142.32381,-453.10644)"
+           id="g955">
+          <g
+             transform="matrix(11.047619,0,0,11.047619,-1572.2888,9377.7107)"
+             id="g869">
+            <g
+               transform="rotate(-60,226.35754,-449.37199)"
+               id="g932"
+               style="stroke-width:11.0512">
+              <path
+                 sodipodi:nodetypes="cccccccccc"
+                 inkscape:connector-curvature="0"
+                 id="path3336-6-5"
+                 d="m 449.71876,-420.51322 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8257 z"
+                 style="opacity:1;fill:url(#linearGradient1713);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:33.1535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            </g>
+            <path
+               sodipodi:nodetypes="cccccccccc"
+               inkscape:connector-curvature="0"
+               id="path4260-0-6"
+               d="m 309.54892,-710.38827 122.19683,211.67512 -56.15706,0.5268 -32.6236,-56.8692 -32.85645,56.5653 -27.90237,-0.011 -14.29086,-24.6896 46.81047,-80.4901 -33.22946,-57.8256 z"
+               style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1299);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:33.1535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+            <use
+               x="0"
+               y="0"
+               xlink:href="#path3336-6-5"
+               inkscape:transform-center-x="124.43045"
+               inkscape:transform-center-y="151.59082"
+               id="use3439-6-2"
+               transform="rotate(60,728.23563,-692.24036)"
+               width="100%"
+               height="100%"
+               style="stroke-width:11.0512" />
+            <use
+               x="0"
+               y="0"
+               xlink:href="#path3336-6-5"
+               inkscape:transform-center-x="59.669705"
+               inkscape:transform-center-y="-139.94592"
+               id="use3449-5-9"
+               transform="rotate(180,477.5036,-570.81898)"
+               width="100%"
+               height="100%"
+               style="stroke-width:11.0512" />
+            <use
+               style="display:inline;stroke-width:11.0512"
+               x="0"
+               y="0"
+               xlink:href="#path4260-0-6"
+               id="use4354-5-1"
+               transform="rotate(120,407.33916,-716.08356)"
+               width="100%"
+               height="100%" />
+            <use
+               style="display:inline;stroke-width:11.0512"
+               x="0"
+               y="0"
+               xlink:href="#path4260-0-6"
+               id="use4362-2-2"
+               transform="rotate(-120,407.28823,-715.86995)"
+               width="100%"
+               height="100%" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="globe (colours)"
+     sodipodi:insensitive="true"
+     style="display:none">
+    <g
+       transform="matrix(0.23553622,0,0,0.23553622,38.625256,4.6984575)"
+       id="g7683">
+      <g
+         id="layer8">
+        <radialGradient
+           gradientUnits="userSpaceOnUse"
+           gradientTransform="matrix(0.0195,0,0,-0.0195,770.9,757.886)"
+           r="17925.004"
+           cy="-7278.2686"
+           cx="6611.7559"
+           id="radialGradient8123">
+          <stop
+             id="stop8119"
+             style="stop-color:#0101FF"
+             offset="0" />
+          <stop
+             id="stop8121"
+             style="stop-color:#000080"
+             offset="1" />
+        </radialGradient>
+        <path
+           style="fill:url(#path125302_1_)"
+           inkscape:connector-curvature="0"
+           d="m 1250,900 c 0,193.3 -156.701,350 -350,350 -193.3,0 -350,-156.7 -350,-350 0,-193.3 156.7,-350 350,-350 193.299,0 350,156.7 350,350 z"
+           id="path125302" />
+      </g>
+      <g
+         id="layer9">
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1058.456,587.924 -4.442,-2.216 -4.931,-2.369 -2.926,-1.361 -2.383,-1.084 -0.302,-0.135 -2.006,-0.895 -1.82,-0.798 1.232,0.539 -2.489,-1.083 -5.279,-2.222 -3.805,-1.538 5.467,2.227 -1.812,-0.75 -4.051,-1.634 2.525,1.012 1.911,0.781 1.396,0.579 -0.57,-0.238 -4.806,-1.952 3.92,1.586 -2.005,-0.818 2.842,1.164 -1.145,-0.472 1.367,0.565 1.709,0.716 -1.613,-0.676 -1.881,-0.776 0.127,0.053 -1.889,-0.768 -2.91,-1.157 0.884,0.348 -2.64,-1.032 3.294,1.292 -0.579,-0.229 3.352,1.347 -6.096,-2.42 8.953,3.601 0.013,0.005 2.229,0.942 0.181,0.077 3.246,1.406 1.71,0.756 3.918,1.774 -3.626,-1.644 2.951,1.334 2.511,1.161 0.996,0.467 3.643,1.742 0.01,0.003 3.925,1.935 -0.677,-0.338 2.213,1.113 1.422,0.725 -0.917,-0.469 -1.395,-0.706 3.513,1.793 -0.449,-0.232 1.187,0.615 -0.438,-0.228 3.684,1.939 -2.331,-1.234 1.015,0.534 6.16,3.336 2.787,1.563 0.68,0.386 3.52,2.032 -0.824,-0.481 3.08,1.812 0.293,0.175 -1.801,-1.066 2.302,1.366 -2.318,-1.376 1.702,1.008 2.138,1.284 0.306,0.186 3.081,1.892 -0.045,-0.028 -1.346,-0.832 6.817,4.3 -0.906,-0.585 1.797,1.163 -3.312,-2.13 9.036,5.939 -1.417,-0.959 -5.027,-3.318 -1.427,-0.919 2.375,1.536 -0.184,-0.12 1.117,0.731 -1.167,-0.763 2.86,1.883 5.063,3.432 1.408,0.979 -0.964,-0.671 3.156,2.213 -4.351,-3.038 3.933,2.742 2.376,1.695 -0.437,-0.313 3.043,2.208 -2.081,-1.516 1.168,0.848 -3.848,-2.766 -3.046,-2.134 -0.98,-0.676 1.354,0.935 -2.46,-1.693 3.201,2.209 0.806,0.564 3.469,2.469 0.117,0.084 5.851,4.314 5.422,4.17 -5.168,-3.979 -4.247,-3.156 1.746,1.285 -0.94,-0.694 1.504,1.113 -1.645,-1.217 1.819,1.347 3.198,2.412 1.939,1.491 2.695,2.108 0.873,0.691 -2.134,-1.683 -1.603,-1.247 2.313,1.804 3.861,3.082 -1.041,-0.839 7.889,6.531 1.363,1.169 -0.738,-0.634 2.123,1.834 0.763,0.666 0.396,0.348 3.3,2.936 3.028,2.762 1.401,1.301 2.45,2.308 -1.567,-1.482 -1.718,-1.603 1.074,1 3.38,3.203 -0.282,-0.271 6.513,6.402 -0.134,-0.135 1.878,1.907 1.691,1.744 2.414,2.53 0.363,0.386 -3.265,-3.42 -0.397,-0.41 3.426,3.58 -0.466,-0.493 4.845,5.221 1.521,1.685 3.182,3.595 2.563,2.967 1.038,1.223 2.154,2.572 1.092,1.324 -1.084,-1.313 1.329,1.613 1.414,1.737 -1.057,-1.301 2,2.473 1.802,2.267 -1.321,-1.667 -1.91,-2.373 1.433,1.776 -1.284,-1.592 0.494,0.61 -6.703,-8.053 -5.271,-6.004 -0.07,-0.078 3.089,3.482 1.909,2.199 1.585,1.855 -1.743,-2.039 1.494,1.745 -0.719,-0.842 -1.089,-1.267 0.631,0.733 1.823,2.138 0.271,0.322 1.406,1.678 -0.28,-0.336 -1.457,-1.734 -1.692,-1.984 0.98,1.145 2.262,2.685 -2.045,-2.43 0.502,0.592 2.225,2.656 0.866,1.049 -1.699,-2.05 3.757,4.575 -2.791,-3.415 0.924,1.121 3.712,4.599 0.891,1.128 1.02,1.302 0.097,0.124 3.159,4.122 -2.212,-2.899 2.071,2.712 -1.122,-1.476 1.196,1.575 0.542,0.72 0.577,0.771 2.522,3.42 1.51,2.089 -1.018,-1.412 1.515,2.108 1.29,1.821 -0.757,-1.071 1.165,1.652 -0.087,-0.124 0.941,1.349 -0.086,-0.124 2.176,3.169 -0.55,-0.808 2.063,3.056 -0.01,-0.011 2.44,3.708 -1.342,-2.05 1.903,2.917 0.205,0.319 0.188,0.294 2.359,3.725 -1.01,-1.608 2.486,3.993 -0.92,-1.491 1.335,2.168 0.231,0.38 0.865,1.43 -0.549,-0.909 3.586,6.052 -0.521,-0.897 -2.142,-3.623 2.022,3.418 1.228,2.121 -0.608,-1.055 1.435,2.499 1.273,2.261 0.177,0.318 0.315,0.566 0.424,0.767 -0.202,-0.367 1.639,2.998 0.521,0.969 -0.221,-0.411 0.67,1.251 0.149,0.281 0.129,0.243 0.518,0.979 0.67,1.279 -1.107,-2.106 1.131,2.151 0.86,1.663 -0.292,-0.567 0.685,1.331 -0.35,-0.681 0.933,1.827 -1.114,-2.181 -0.696,-1.344 0.212,0.409 -0.993,-1.899 0.53,1.009 1.311,2.533 -0.403,-0.785 1.463,2.869 v -0.006 l 0.587,1.169 0.404,0.813 -0.813,-1.626 1.273,2.558 0.376,0.765 -0.823,-1.669 1.317,2.683 -2.533,-5.11 3.574,7.274 0.317,0.665 -1.338,-2.786 1.566,3.269 -0.454,-0.956 0.729,1.54 0.055,0.117 1.011,2.171 0.299,0.647 -1.113,-2.4 -3.258,-6.766 -0.532,-1.071 -2.2,-4.334 3.188,6.331 -0.585,-1.187 1.242,2.532 -1.193,-2.434 1.579,3.229 1.44,3.021 0.994,2.13 1.648,3.616 -1.134,-2.5 -2.069,-4.431 -0.8,-1.67 -3.772,-7.59 -2.037,-3.915 -0.485,-0.915 0.317,0.598 -1.526,-2.851 -1.062,-1.947 0.623,1.139 -1.843,-3.338 0.262,0.468 -1.72,-3.051 -0.965,-1.681 0.576,1.002 -6.11,-10.25 0.173,0.279 -5.012,-7.872 -2.558,-3.845 -1.851,-2.715 -0.153,-0.222 -1.414,-2.035 -0.104,-0.148 -1.186,-1.681 -1.852,-2.583 1.065,1.479 10.059,14.85 2.491,3.945 2.502,4.084 -0.208,-0.343 -0.974,-1.601 1.53,2.524 -8.667,-13.703 0.957,1.446 -1.151,-1.736 3.088,4.711 1.117,1.747 1.914,3.046 3.442,5.66 1.78,3.025 -0.859,-1.469 2.666,4.611 1.439,2.561 -0.71,-1.27 1.382,2.48 3.051,5.651 3.139,6.088 0.714,1.426 -2.219,-4.38 1.896,3.735 0.964,1.943 0.633,1.291 -0.588,-1.2 1.95,4.028 -1.356,-2.816 1.64,3.412 -0.237,-0.5 4.451,9.734 0.964,2.217 -0.412,-0.954 2.587,6.115 -1.034,-2.481 0.87,2.084 -0.487,-1.171 -1.882,-4.422 -2.583,-5.809 0.063,0.139 -2.623,-5.631 2.878,6.192 5.104,11.848 -0.49,-1.19 0.5,1.213 0.67,1.65 0.611,1.527 0.112,0.282 1.113,2.842 -0.292,-0.75 0.823,2.133 0.46,1.213 0.668,1.784 0.924,2.516 0.576,1.603 0.844,2.387 -0.861,-2.438 2.188,6.31 0.064,0.193 0.984,2.98 -0.15,-0.46 2.194,6.956 1.038,3.478 2.048,7.288 0.26,0.971 1.284,4.968 0.707,2.871 -0.366,-1.499 1.114,4.663 0.108,0.467 0.124,0.542 0.517,2.291 -0.347,-1.545 1.006,4.581 -0.052,-0.239 0.755,3.635 0.098,0.481 2.284,12.573 1.313,8.761 -0.107,-0.783 0.856,6.611 0.348,3.011 1.205,13.056 0.533,8.783 -0.107,-2.098 0.186,3.811 -0.041,-0.925 0.022,0.496 0.266,8.069 -0.146,-5.088 0.147,5.168 -0.188,-6.241 -0.197,-4.374 -0.332,-5.566 -0.146,-2.076 -0.356,-4.458 -0.339,-3.695 -0.122,-1.233 -0.369,-3.489 -1.165,-9.371 -1.37,-9.042 -0.787,-4.578 -0.584,-3.191 -0.567,-2.946 -0.274,-1.377 -2.803,-12.702 -0.162,-0.673 1.396,5.994 0.245,1.105 0.967,4.53 1.128,5.701 -0.119,-0.63 -1.17,-5.847 -0.557,-2.616 -0.398,-1.814 -0.998,-4.354 -0.406,-1.704 0.282,1.178 -0.513,-2.128 -0.035,-0.146 -0.67,-2.691 0.649,2.608 -1.214,-4.81 -0.128,-0.491 -1.448,-5.364 -1.461,-5.095 1.231,4.275 -1.174,-4.082 1.593,5.585 -0.477,-1.707 0.193,0.687 0.263,0.944 -0.499,-1.785 0.333,1.188 2.003,7.515 0.841,3.373 -0.363,-1.474 0.521,2.123 0.321,1.336 -1.212,-4.935 0.492,1.966 0.682,2.807 0.585,2.495 0.766,3.396 -0.489,-2.19 0.467,2.089 -0.549,-2.446 0.048,0.208 -0.953,-4.077 -0.386,-1.592 -0.17,-0.689 -0.564,-2.249 0.119,0.467 -0.664,-2.587 0.248,0.958 -0.573,-2.195 -0.348,-1.301 -0.082,-0.304 -1.108,-4.012 -0.489,-1.715 0.158,0.551 -0.397,-1.378 -0.254,-0.866 -0.294,-0.996 -1.512,-4.958 -0.907,-2.854 1.416,4.493 -2.545,-7.932 -1.409,-4.136 -1.006,-2.852 0.437,1.227 -3.045,-8.28 -2.811,-7.123 0.335,0.827 -0.948,-2.323 -1.768,-4.206 0.279,0.656 -0.976,-2.271 1.034,2.408 -1.736,-4.015 -0.191,-0.435 0.18,0.408 -1.194,-2.684 -2.082,-4.538 0.218,0.466 0.938,2.033 -0.344,-0.751 0.605,1.323 -1.962,-4.232 0.5,1.064 2.289,4.995 -0.966,-2.131 1.384,3.068 -0.362,-0.812 -5.234,-11.147 1.673,3.453 -0.792,-1.647 0.829,1.726 0.473,0.994 -0.417,-0.876 -2.1,-4.328 1.124,2.298 -2.333,-4.719 -5.816,-11.057 2.166,4.007 1.167,2.211 0.088,0.167 v -0.004 l 2.749,5.372 1.602,3.24 -1.914,-3.862 1.223,2.454 1.412,2.894 2.545,5.396 2.382,5.278 1.869,4.312 0.183,0.431 2.07,4.992 3.858,9.942 1.868,5.164 0.565,1.615 -0.537,-1.535 1.051,3.024 0.424,1.244 1.963,5.98 1.214,3.893 0.683,2.263 -0.868,-2.868 1.452,4.847 -0.098,-0.333 0.588,2.03 -0.281,-0.979 0.699,2.449 -0.445,-1.564 0.621,2.193 0.02,0.068 0.663,2.409 -0.979,-3.529 1.246,4.52 -1.123,-4.083 -0.047,-0.167 -0.703,-2.458 -1.085,-3.67 -0.476,-1.56 -0.362,-1.174 -1.404,-4.416 -1.529,-4.595 -0.352,-1.023 -1.316,-3.755 2.342,6.779 1.227,3.74 5.753,19.893 2.007,8.206 -0.39,-1.663 0.583,2.505 2.11,9.853 0.685,3.536 0.915,5.061 -0.263,-1.5 0.7,4.084 -0.291,-1.735 0.432,2.589 1.269,8.425 0.871,6.798 0.658,6.015 v -0.03 l 0.337,3.519 -0.345,-3.593 0.216,2.208 0.286,3.176 0.024,0.291 -0.137,-1.574 -0.836,-8.271 -0.366,-3.109 -0.841,-6.39 0.469,3.449 -0.226,-1.694 0.882,7.03 0.237,2.114 0.491,4.813 0.153,1.658 0.653,8.344 0.338,5.838 0.116,2.541 0.193,5.684 0.036,1.524 -0.037,-1.588 0.089,4.563 -0.044,-2.606 0.028,1.551 -0.01,11.643 -0.454,12.79 -0.489,7.56 -0.63,7.32 -0.557,5.331 -0.991,8.002 -0.599,4.219 -1.388,8.634 -0.703,3.917 -1.866,9.353 -1.469,6.566 0.297,-1.279 -3.599,14.269 -1.597,5.628 0.611,-2.112 -1.243,4.246 -1.624,5.268 -2.764,8.356 -4.428,12.113 -2.644,6.636 -1.317,3.167 -1.188,2.784 0.975,-2.278 -1.135,2.647 0.251,-0.581 -2.131,4.841 0.463,-1.035 -0.869,1.938 0.38,-0.844 -0.837,1.85 0.1,-0.22 -0.702,1.531 1.355,-2.974 -0.898,1.979 v 0.01 l -1.121,2.426 -0.616,1.313 0.635,-1.352 -0.712,1.516 0.684,-1.456 -1.976,4.16 -0.288,0.594 -0.895,1.83 -0.082,0.167 -1.967,3.924 0.378,-0.745 -0.773,1.52 -0.966,1.873 -1.083,2.066 -0.342,0.645 -2.706,4.998 0.196,-0.355 3.251,-6.046 3.084,-6.012 1.143,-2.305 7.049,-15.253 3.684,-8.83 -0.912,2.252 1.036,-2.562 -0.466,1.157 0.744,-1.854 -0.818,2.037 0.321,-0.797 -0.513,1.271 -0.147,0.36 0.66,-1.629 -1.117,2.744 -1.013,2.432 0.91,-2.183 0.57,-1.389 -0.338,0.824 0.512,-1.251 -0.322,0.79 0.803,-1.98 -0.272,0.676 1.265,-3.172 0.698,-1.791 -0.483,1.245 0.813,-2.1 -1.081,2.781 0.892,-2.287 -0.418,1.08 -0.337,0.86 -0.886,2.236 -4.609,10.968 0.261,-0.593 -1.353,3.048 -0.35,0.775 0.194,-0.431 -0.921,2.026 0.454,-0.994 -2.638,5.666 -0.508,1.06 -2.597,5.29 -1.443,2.846 -2.255,4.32 0.166,-0.313 -0.963,1.808 -3.459,6.288 -2.417,4.219 -3.19,5.371 -3.521,5.687 -5.364,8.222 -8.323,11.838 -5.99,7.919 -6.712,8.35 -9.737,11.245 -6.515,7.013 -2.004,2.07 -2.114,2.162 -2.767,2.546 1.679,-1.687 0.92,-1.38 8.717,-9.585 4.422,-5.998 6.484,-8.38 12.571,-16.45 7.58,-10.271 4.397,-6.79 7.532,-10.854 -0.748,1.209 0.306,-0.098 9.183,-17.275 4.562,-7.737 2.182,-3.323 1.785,-3.544 -0.019,-0.085 3.96,-9.114 2.6,-6.112 6.076,-17.13 3.579,-10.626 2.32,-6.675 0.486,-1.737 1.493,-5.192 1.032,-3.989 -0.163,0.644 1.5,-6.125 0.67,-2.904 -0.238,1.049 1.124,-5.067 0.301,-1.423 1.569,-7.94 2.13,-12.788 0.74,-5.294 0.093,-0.709 0.25,-1.969 1.982,-21.236 0.659,-17.623 -0.214,-17.237 -2.943,-34.127 -0.625,-4.397 -0.393,-2.572 0.25,1.622 -1.221,-7.5 0.207,1.199 1.302,8.241 1.132,8.483 0.677,6.039 0.16,1.588 0.622,7.025 -0.027,-0.345 0.213,2.823 -0.428,-5.416 -0.188,-2.089 -0.188,-1.956 0.205,2.148 -0.129,-1.374 0.235,2.546 -0.994,-9.656 0.04,0.343 -1.291,-9.895 -0.01,-0.043 -0.473,-3.159 0.029,0.192 -0.632,-3.956 -0.165,-0.987 -0.094,-0.552 -1.91,-10.29 -0.427,-2.085 -0.856,-4.005 0.848,3.964 0.104,0.504 -2.409,-10.821 1.821,8.027 -0.429,-1.968 1.325,6.274 0.612,3.113 -0.172,-0.888 0.738,3.905 1.027,5.897 0.078,0.48 1.043,6.774 0.983,7.387 0.947,8.632 -0.678,-6.365 -0.63,-5.116 -2.251,-14.774 -0.939,-5.161 -3.231,-15.182 -1.166,-4.788 -3.238,-11.994 -1.512,-5.083 -1.207,-3.869 -1.705,-5.212 -1.693,-4.922 -1.898,-5.254 -1.063,-2.831 -0.131,-0.346 -4.89,-12.131 -0.653,-1.528 1.663,3.928 -0.106,-0.254 -1.437,-3.395 -1.644,-3.766 7.262,17.661 1.872,5.049 1.053,2.947 0.446,1.275 -2.813,-7.791 0.661,1.781 2.188,6.119 -0.932,-2.648 -1.19,-3.29 0.209,0.57 -1.763,-4.713 0.482,1.27 -0.905,-2.372 -0.534,-1.376 -1.146,-2.896 -0.678,-1.675 -0.232,-0.568 -1.059,-2.56 1.923,4.69 -0.998,-2.458 -0.276,-0.671 -1.214,-2.904 -4.136,-9.383 1.544,3.417 -5.851,-12.47 -9.834,-18.509 1.282,2.268 -1.105,-1.957 1.478,2.622 -1.783,-3.158 1.037,1.828 -1.749,-3.068 1.543,2.701 -0.043,-0.075 -2.743,-4.765 1.48,2.551 2.896,5.137 -0.284,-0.236 -3.724,-6.36 -2.788,-4.939 -1.179,-1.799 1.496,2.445 0.592,1.085 -0.883,-1.364 1.504,2.545 0.355,0.934 2.42,4.511 4.721,12.281 0.455,12.158 0.32,7.235 -2.059,0.173 -1.735,-3.145 -1.081,-3.466 -2.901,-4.275 0.667,0.093 -1.86,-4.645 -1.786,-2.174 -1.014,-5.348 -3.596,-8.628 -1.428,-6.277 -1.476,-3.09 -2.083,-2.36 -1.829,-3.347 -3.588,-4.354 -0.725,-1.867 -7.784,-10.543 -4.742,-6.795 -5.41,-6.039 -3.698,-4.806 -0.541,-1.713 -3.714,-3.835 -1.699,-2.43 0.392,1.624 -2.3,-2.89 -0.533,0.537 -0.897,-1.677 -0.053,0.62 -1.686,-2.006 -0.467,0.168 -1.448,-2.262 -0.029,1.177 -2.653,-3.645 0.733,1.785 -1.034,-1.092 -0.544,-1.639 -2.816,-2.079 -0.749,5.137 -1.847,-2.197 1.025,1.772 -2.655,-1.263 -0.263,1.185 2.212,1.498 -1.106,0.595 -1.349,-2.235 0.433,5.101 3.468,6.858 -1.93,-2.157 1.454,2.209 -1.315,-1.643 -0.901,0.465 -1.163,-1.875 -0.915,0.568 -1.701,-2.601 -2.765,-2.229 0.413,-0.857 -1.034,0.274 -2.278,-2.349 -0.77,-2.453 -0.832,2.423 -1.745,-1.197 1.682,6.171 -0.163,4.174 -0.841,-1.867 -1.116,3.246 1.599,4.107 -1.393,-0.145 2.728,5.165 0.081,2.658 -1.198,-1.975 3.537,10.021 -1.854,-1.779 -5.691,4.148 -1.245,8.685 -3.117,4.767 -10.527,1.884 -2.149,-2.805 -1.633,0.583 3.845,-4.751 -0.497,-7.678 1.341,-2.779 7.02,-2.705 5.232,1.427 1.496,-7.504 2.874,1.711 -0.402,-4.284 -5.413,-9.565 -0.637,-4.194 -4.926,-3.258 1.356,3.624 -4.396,-2.478 -3.603,0.062 -1.342,4.069 -2.28,-2.182 0.184,2.533 -1.349,-1.404 -5.535,0.086 2.141,5.581 -2.384,-0.885 -4.914,-4.56 1.453,-1.732 -3.075,0.351 1.259,-1.825 -1.979,0.529 1.084,-0.978 -2.053,-0.45 1.585,-0.195 -1.705,-0.595 -0.011,-1.115 -2.468,-0.289 -9.563,-7.47 -1.738,-5.291 -1.4,-0.597 0.715,-8.66 2.318,-2.02 5.258,-0.119 5.092,-3.977 -2.483,-3.876 -3.546,-2.63 -0.465,-1.499 -1.142,-0.248 0.558,-0.746 -3.513,-1.368 -2.696,-2.503 -3.407,-1.465 -0.794,-1.257 -2.348,0.456 -2.596,-1.932 -1.437,0.199 2.085,2.268 -0.525,1.771 -1.795,-0.697 -1.734,-3.863 -0.081,0.569 -6.282,-3.123 -0.486,-0.932 -3.254,-0.874 -0.413,-0.915 -2.604,-0.479 -0.742,-2.012 -0.503,1.012 -1.164,-1.169 -1.148,0.11 -0.066,-2.446 -3.816,1.033 0.172,-0.686 -3.21,-1.775 -0.226,0.705 -2.565,-1.713 -1.084,0.327 -5.021,-2.178 -1.557,-1.248 1.265,-0.165 -4.2,-1.558 -0.887,-1.122 -0.979,0.337 -3.355,-2.28 1.602,-0.19 -4.541,-1.29 0.125,-0.846 -2.159,-0.472 0.26,-0.835 -2.057,-0.319 -0.655,-1.235 -1.442,0.279 0.069,-1.708 -2.577,-1.318 1.899,0.338 -1.313,-0.374 1.131,-0.568 -2.792,-0.252 -4.943,-3.938 1.197,-0.207 -5.462,-1.554 1.016,-0.722 -2.18,-0.964 1.379,-0.166 -2.867,-0.733 -0.462,-0.851 2.99,0.871 -3.978,-1.684 3.965,-0.017 5.742,1.55 -9.574,-3.54 4.623,-0.676 3.453,0.587 -8.855,-1.551 4.279,-0.617 0.829,-2.524 4.733,0.548 -0.47,-0.568 -6.302,-2.827 0.511,-0.191 -2.646,-0.513 -0.885,-0.841 -5.984,-1.797 -2.402,-0.334 -1.413,-0.92 8.498,1.301 7.968,2.676 0.124,-1.184 4.869,1.063 -1.157,-1.017 -5.797,-1.566 -10.847,-4.005 -4.262,-1.1 -1.018,0.285 5.903,2.261 -3.131,-0.688 4.442,1.649 -12.615,-3.797 -8.467,-1.233 2.753,1.294 -1.981,-0.08 3.022,0.573 1.889,0.861 -2.78,-0.43 1.47,0.434 -2.478,-0.377 -0.66,-0.283 -3.929,-0.294 -0.761,1.14 1.483,-0.137 2.086,0.704 -1.151,0.323 -0.674,-0.477 0.543,0.824 -1.929,-0.304 4.011,2.111 -1.467,0.515 1.699,0.311 -0.955,0.328 -3.897,-1.343 -0.224,0.488 -1.198,-0.865 -1.186,0.301 0.101,-0.623 -3.277,-0.078 -1.124,-0.838 -2.349,-0.053 -3.043,-1.803 0.045,-1.438 3.889,-1.524 4.138,-0.014 -1.033,-0.7 -10.943,-2.492 -0.867,-0.922 -4.572,-0.937 -0.136,-0.303 -2.352,-0.148 -2.867,-0.841 -5.316,0.023 -9.641,-1.24 -13.524,-1.996 -9.571,-0.78 6.271,-0.028 9.708,0.266 4.944,0.239 -0.488,-0.027 1.959,0.111 5.438,0.366 0.397,0.031 -1.699,-0.126 -1.123,-0.079 3.854,0.285 -1.724,-0.133 4.734,0.385 1.345,0.121 2.736,0.262 4.883,0.522 16.957,2.355 3.999,0.68 -1.18,-0.205 2.354,0.414 2.346,0.429 3.49,0.669 2.888,0.581 -3.006,-0.604 -0.754,-0.147 9.913,2.075 0.765,0.172 -2.068,-0.462 1.957,0.438 11.913,2.919 9.523,2.656 -3.927,-1.13 -1.036,-0.29 1.873,0.527 -2.048,-0.575 8.643,2.52 2.2,0.68 2.54,0.805 3.539,1.157 0.956,0.32 -3.265,-1.079 -5.092,-1.613 -5.785,-1.729 -16.651,-4.381 -4.563,-1.049 -5.735,-1.228 -5.156,-1.019 -0.674,-0.127 7.118,1.413 -0.042,-0.009 5.879,1.283 0.682,0.156 7.973,1.927 1.595,0.409 4.19,1.113 -0.186,-0.05 2.681,0.74 -3.652,-1.002 9.729,2.766 2.493,0.758 0.162,0.05 5.43,1.724 -1.467,-0.476 3.275,1.072 6.365,2.185 1.636,0.584 1.495,0.541 10.105,3.864 10.298,4.313 4.777,2.134 1.701,0.78 -0.89,-0.41 -0.403,-0.185 -0.707,-0.323 -3.787,-1.694 0.695,0.307 -2.229,-0.978 9.947,4.509 3.815,1.83 1.09,0.533 2.014,0.998 -1.38,-0.686 4.367,2.195 1.469,0.756 3.683,1.933 0.982,0.525 0.122,0.065 2.222,1.204 -1.966,-1.066 2.686,1.461 0.419,0.23 -1.826,-1 4.082,2.254 -0.575,-0.322 1.737,0.977 2.279,1.301 -3.468,-1.971 -3.81,-2.105 -2.107,-1.139 0.305,0.164 -0.706,-0.378 -6.418,-3.357 v 0"
+           id="path130576" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 980.896,1212.152 -2.02,1.006 -1.485,-1.202 -5.012,0.664 -10.71,3.47 -1.309,1.148 -8.205,0.43 -2.948,-0.854 -3.872,1.085 -5.252,-0.102 -2.18,0.864 -5.206,-2.121 -12.506,-2.132 -1.213,-1.509 -7.194,-2.144 -3.15,-0.021 -3.119,-2.003 -6.944,1.149 -0.913,-0.758 -0.729,0.824 -3.546,-1.492 -27.458,4.7 -0.232,4.626 -7.5,5.571 -0.361,4.514 -2.189,-0.473 -5.213,1.958 0.601,5.169 4.135,1.438 -2.098,0.172 -7.916,-3.102 -2.765,-2.76 -2.171,-0.36 1.612,-0.498 -3.157,-2.102 1.173,-0.903 -1.927,-0.495 1.877,-0.875 -2.817,-0.283 1.037,-0.832 2.168,0.832 -0.449,-1.206 2.128,0.073 -1.235,-3.331 1.79,-0.292 -0.904,-0.852 -5.867,0.958 -2.132,-1.617 1.752,-0.04 -1.937,-0.716 0.934,-0.48 -5.94,-2.674 6.039,0.229 -1.175,-1.349 4.525,1.264 -1.807,-2.573 6.531,1.181 3.955,-1.616 -10.512,-2.025 -0.744,-1.818 2.999,-0.549 -3.506,-0.206 -11.246,-6.897 -2.036,0.84 -7.245,-7.236 -2.038,-0.968 0.085,1.047 -3.365,-0.509 -4.449,-5.483 0.566,-2.253 4.902,0.318 3.621,2.154 -1.14,-1.35 8.408,-0.049 -3.79,-3.131 2.055,-0.516 -5.195,0.71 -1.545,-2.397 2.113,-1.361 -7.842,-5.12 -1.806,-5.411 -5.542,-7.326 6.383,-4.493 4.27,-5.996 -1.373,-2.202 5.026,0.01 4.032,-4.847 2.273,1.737 3.737,-5.608 1.62,2.282 3.52,-0.393 1.874,-5.485 4.558,1.938 5.655,-2.254 2.089,0.72 9.709,-8.399 5.112,-8.089 7.366,-4.254 1.982,3.085 2.781,-0.276 0.252,-5.426 -4.037,-6.744 -2.531,1.252 0.946,-2.211 -2.176,-2.427 -2.096,0.622 -0.387,-2.776 -2.029,0.51 -4.129,-2.645 -2.17,1.158 -4.531,-5.363 -3.206,-0.832 -0.366,-2.95 1.15,1.623 3.318,-7.639 8.321,-3.023 3.247,-7.07 7.567,-3.428 2.6,-3.838 11.989,-1.116 -0.904,-3.021 7.282,-2.167 -3.561,-1.729 0.335,-1.87 4.333,1.332 19.904,-4.275 4.309,-5.947 0.664,5.176 12.204,-0.237 -1.949,5.125 3.677,1.3 5.483,-3.667 5.33,0.048 1.669,4.218 6.292,-5.316 -2.181,5.712 7.366,3.31 5.378,-2.184 3.276,1.513 4.653,-2.735 3.512,2.407 2.656,7.226 17.701,-3.814 -1.19,3.136 4.801,0.454 0.251,3.656 10.058,-0.022 -3.764,5.302 0.216,3.35 4.456,2.178 2.444,4.394 5.933,-1.563 3.718,7.828 6.251,-0.676 -1.851,2.432 -5.682,2.25 -1.573,3.492 0.898,4.714 -3.457,4.401 -0.404,3.791 2.128,-0.6 -1.271,3.836 5.183,-0.559 3.211,1.601 5.571,-1.604 7.818,14.389 3.63,2.641 2.37,-1.764 4.11,3.975 -2.502,6.223 -4.532,0.941 2.067,1.782 -2.037,1.929 -0.716,-1.129 -2.104,2.26 2.252,1.504 -2.458,1.485 -6.266,8.654 -9.662,4.804 2.974,0.511 -1.245,1.196 4.39,3.136 -1.842,1.477 -3.745,0.242 -0.896,1.726 2.013,1.171 -5.251,2.56 -7.749,6.334 -2.548,7.439 -3.24,2.479 1.872,0.76 -6.59,2.266 -6.915,5.599 -2.644,0.543 -7.475,5.681 2.977,1.816 v 0"
+           id="polygon3" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 870.356,893.079 -8.664,-4.229 2.565,0.918 -1.084,-1.312 -11.291,-0.992 -1.985,-10.84 -3.788,-3.435 1.049,-1.358 -3.848,-7.813 -7.458,-5.508 0.743,-1.678 -4.376,-6.242 -4.658,-13.971 2.34,-8.456 -1.741,-7.9 6.629,-12.293 5.115,-3.67 0.167,-6.84 0.316,1.796 3.078,-3.489 0.112,3.102 1.267,-1.758 1.093,1.066 3.975,-14.054 13.97,-9.06 1.356,-11.231 3.156,-2.798 0.087,-8.284 4.802,-4.588 4.408,1.078 1.205,-8.563 5.896,-11.803 2.433,1.393 0.35,5.489 2.967,3.035 -2.326,0.244 3.117,6.8 -1.167,6.57 6.287,14.313 5.886,-0.431 3.291,-3.5 13.88,-5.19 7.545,-5.174 -3.759,-7.16 1.001,-2.046 -3.272,-0.311 0.038,-2.592 -3.038,-2.439 2.502,-2.44 3.21,3.48 -0.13,-2.354 2.323,0.876 -1.523,-1.442 4.117,2.085 2.817,-1.729 3.524,1.426 1.454,-2.236 2.403,0.911 9.23,-3.289 1.185,1.174 -5.714,1.099 -0.321,2.84 7.667,1.391 1.079,-1.193 2.73,2.242 -0.955,1.33 2.347,-1.19 -0.988,1.641 2.252,-0.076 0.032,3.841 2.903,1.018 2.408,4.909 -3.785,1.581 2.143,3.025 1.932,-1.681 0.826,2.431 0.307,-2.056 3.131,-0.37 1.983,1.945 -1.136,2.23 1.509,-1.528 0.573,1.903 -0.991,-4.583 4.867,-3.588 3.264,-0.6 1.343,2.98 0.553,-1.673 1.649,2.015 1.388,-1.603 0.244,4.227 1.912,-2.164 2.526,3.282 -2.275,1.991 3.865,0.577 -2.567,1.93 3.405,-1.241 1.604,2.611 -0.911,1.706 -1.361,-1.319 1.794,3.29 -3.326,-0.346 3.172,1.595 4.933,-1.299 0.058,2.771 -2.701,0.417 0.009,2.509 2.14,-0.907 -0.287,3.297 4.241,-6.21 3.717,5.715 -1.573,4.555 6.02,9.472 10.63,4.906 8.475,6.974 3.231,-0.613 10.014,10.682 0.933,4.375 2.382,-3.144 0.296,15.359 -6.34,9.647 2.217,-1.596 0.427,1.716 1.871,-3.656 -2.909,5.731 3.891,-1.47 -12.017,14.531 -2.68,7.854 -5.859,7.354 -0.94,8.114 2.913,2.289 -1.803,4.782 -7.828,2.06 -6.225,-1.23 -7.669,-9.351 -17.438,-3.683 -2.604,-6.139 -7.945,-5.841 -25.876,-8.384 -15.987,4.869 0.479,2.634 -3.391,1.41 -4.512,8.465 2.041,-0.04 -4.338,2.327 0.236,-2.874 -9.08,-9.641 0.207,-3.275 -1.281,6.607 2.595,3.631 -0.131,4.67 2.189,-0.011 0.746,2.4 -4.514,-1.156 -1.543,-6.013 -2.454,4.158 2.263,4.913 -3.93,-0.632 -3.128,2.576 -1.019,1.992 0.547,-0.803 -0.649,6.258 -4.063,5.192 -14.108,5.371 -6.837,-5.883 -0.801,1.913 2.242,0.873 -3.99,-0.236 0.666,1.82 -4.107,3.087 0.089,-1.866"
+           id="polygon4" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 840.162,728.83 1.668,-1.605 -1.826,-0.794 4.581,-1.181 -0.159,-2.63 3.872,0.06 2.691,-5.58 5.658,-3.601 1.291,-3.841 -5.46,0.037 1.342,-2.868 11.219,-4.042 -0.315,-3.133 7.734,-5.61 40.418,-11.939 4.741,1.718 -0.354,1.52 4.749,0.674 3.79,4.552 3.996,1.449 2.923,-4.192 1.035,1.937 1.737,-2.375 1.189,-7.72 9.511,-1.084 7.212,2.978 1.748,3.062 -6.239,-0.397 -2.107,3.694 -9.881,-1.705 1.639,3.211 2.723,-1.368 2.984,2.174 4.7,0.25 -5.403,2.116 -0.395,3.832 -3.329,-1.345 -2.141,-4.844 1.128,2.842 -2.145,1.78 -5.846,-0.11 1.9,1.085 -3.534,1.499 -17.757,3.925 0.374,1.803 -1.901,-0.362 -0.185,3.373 -3.198,2.476 2.287,0.664 -4.246,0.904 3.469,0.417 -2.843,1.853 1.107,3.525 -6.539,-1.347 -6.566,6.441 -6.595,-0.695 -2.52,1.42 -4.63,-2.866 7.168,-3.253 -8.954,0.587 1.812,-1.647 -3.242,0.465 1.729,-2.977 -5.222,2.238 0.779,-2.011 -0.972,1.383 -1.322,-1.417 -0.633,1.964 -7.373,2.081 -9.555,11.298 -11.952,2.463 -2.643,2.195 -4.085,-2.04 5.129,-1.362 0.034,-0.004"
+           id="polygon7" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1047.553,715.374 -6.958,-6.394 1.03,-1.018 -1.203,0.14 -1.529,-4.151 2.471,-1.2 -2.959,-4.268 -1.106,0.583 -4.019,-3.415 0.873,-3.869 -3.258,-4.09 0.822,-1.322 -2.683,0.781 -3.622,-1.756 6.515,-2.36 0.591,-1.324 -2.048,-1.094 5.939,-4.139 -4.255,-1.364 2.222,-1.664 -6.759,-2.584 2.32,-1.705 -6.547,-3.684 5.068,-0.73 2.345,1.282 -0.468,-1.79 2.567,1.358 -1.141,-2.492 3.129,-1.587 2.014,2.449 0.237,-1.943 5.297,7.571 2.772,1.529 -1.267,0.399 1.353,1.783 7.792,3.683 5.373,7.987 8.714,4.998 1.546,6.608 6.77,0.94 1.282,-1.268 3.938,5.703 0.017,3.884 -1.945,0.713 0.893,2.802 -2.534,0.099 1.826,0.319 -2.097,0.75 1.085,1.842 -2.754,-1.888 -1.809,8.319 -7.672,-3.536 -1.202,3.357 -5.954,-5.104 -3.257,-0.015 -0.163,1.499 -4.896,-2.092 -0.491,3.898 -2.198,-1.418 -0.01,-0.012"
+           id="polygon9" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 920.309,564.506 -4.666,-1.138 1.92,-0.542 -1.133,-0.684 -0.822,0.503 -0.509,-0.405 -1.932,0.23 1.835,0.382 -6.1,-0.19 -2.63,-0.901 -0.465,0.843 -1.672,-1.058 -2.54,0.161 -0.513,-0.82 -1.715,0.154 1.183,1.046 -4.841,-1.21 1.534,-0.88 -2.036,-0.993 0.381,-1.584 -2.908,-0.053 -2.432,-1.444 3.049,-1.959 2.878,-0.026 -1.4,0.529 3.666,-0.397 2.204,0.618 0.741,0.71 -1.716,-0.077 -0.16,0.344 3.25,1.807 10.291,2.025 2.24,-0.367 -2.436,-0.661 2.881,0.297 3.747,2.568 14.737,0.981 11.679,3.115 0.012,0.625 -6.149,-0.453 -1.563,-1.038 -0.643,0.449 -8.423,-1.722 -5.748,-0.313 1.645,1.477 -3.403,0.587 -1.308,-0.529 -0.01,-0.007"
+           id="polygon14" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1022.229,713.473 0.1,3.056 -5.889,-1.261 2.043,-12.74 -3.236,-2.438 -1.962,0.016 1.003,4.395 -4.139,1.541 0.273,3.587 -2.7,0.076 -0.541,-2.143 -4.484,-1.307 4.093,-3.202 -1.609,-2.422 7.037,-4.99 -2.195,0.039 -10.389,-7.727 10.674,2.309 3.067,3.656 2.41,0.449 3.568,-2.891 -1.428,-5.252 -23.296,-4.692 -5.104,-6.819 7.222,5.151 17.699,1.23 1.811,3.16 1.811,-0.621 1.38,1.542 1.171,4.097 1.333,-0.112 -1.547,3.649 0.835,-0.83 2.254,3.042 -0.18,3.446 3.375,5.088 -1.111,3.614 -3.294,-0.873 -0.05,7.179 v -0.002"
+           id="polygon17" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1104.841,743.663 -3.093,1.753 0.406,-1.989 -3.235,0.01 -0.491,-2.082 -2.357,1.309 -1.104,-13.985 2.503,-3 3.884,1.209 0.624,1.822 -0.753,-2.854 2,0.455 0.647,-4.373 5.397,1.054 -2.209,-5.685 1.964,-0.315 3.154,3.034 -2.069,-2.078 0.947,-0.75 2.408,0.773 6.394,-3.56 0.61,2.536 5.311,-3.271 7.115,0.053 -0.709,-1.887 3.262,-1.582 9.886,4.701 -0.988,3.213 -5.55,0.707 -3.656,4.067 -4.689,-0.237 -1.46,5.963 -5.562,2.184 -6.276,8.137 -12.307,4.666 v 0.002"
+           id="polygon18" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1214.737,1033.074 2.082,-9.48 15.724,-37.886 1.769,-4.286 0.681,-3.141 2.208,-5.021 0.176,-1.513 -0.929,1.528 0.898,-3.623 3.623,-8.872 0.957,-0.538 0.456,-1.911 -0.688,4.343 -1.266,3.904 -0.712,4.072 0.249,0.408 -0.955,2.456 -0.037,0.993 -1.365,4.813 0.648,-1.781 -0.914,3.846 -0.425,0.693 -0.32,1.812 0.681,-2.066 -0.663,3.213 -0.796,2.051 0.367,-0.07 -1.649,8.685 -2.602,7.599 -4.54,8.67 -3.428,9.212 -2.459,5.196 -6.022,8.149 -0.75,-1.449 10e-4,-0.01"
+           id="polygon19" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 748.734,936.726 1.885,1.101 -1.608,2.828 -3.56,-0.792 -8.843,-9.553 -3.808,1.3 -5.415,-6.912 1.816,-1.938 4.336,1.262 3.491,-4.104 -0.369,-7.622 1.243,4.304 2.892,-3.713 -1.918,-2.541 1.146,-4.008 -1.369,-3.732 1.276,0.568 1.832,-4.483 1.127,1.042 -0.35,-3.774 1.588,-0.584 -1.86,13.686 -0.234,-2.477 -1.932,2.481 1.054,2.12 0.787,-1.644 -0.123,3.982 -1.756,0.848 1.576,-0.701 -0.167,4.984 3.706,5.125 4.289,1.158 -3.609,5.987 2.859,5.79 0.018,0.012"
+           id="polygon20" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 994.018,629.089 -0.299,1.52 -0.828,-2.08 2.458,0.468 1.108,-1.622 -2.592,-1.029 1.389,-0.534 2.561,0.006 0.967,1.591 1.649,-1.945 2.995,0.882 0.271,1.285 2.988,-1.151 1.13,-2.998 -6.895,-6.636 1.31,-2.63 -1.354,-2.173 9.224,1.462 2.544,8.254 2.856,-0.1 0.98,1.667 -1.185,3.723 -1.999,0.856 -0.646,-1.558 -2.166,0.128 2.3,3.42 -3.636,-0.043 -2.782,-1.917 -4.429,1.965 0.011,-2.865 -4.058,2.636 -3.871,-0.583 -10e-4,0.001"
+           id="polygon23" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 990.114,656.457 -1.595,-1.267 -0.621,2.162 -1.832,-2.051 1.705,-2.897 -1.997,-2.698 -2.738,3.828 0.107,-2.642 -2.713,-1.987 1.008,-4.792 1.81,-0.165 -0.901,-2.928 4.355,-1.34 -0.373,3.352 4.328,0.607 0.442,2.074 2.063,-0.026 4.325,3.394 -1.11,-2.136 2.582,-0.715 6.877,4.465 2.087,3.918 -1.427,0.539 -2.943,-4.17 -4.433,0.851 -1.726,-2.203 -3.241,1.207 1.385,4.382 -5.419,1.235 -0.005,0.003"
+           id="polygon24" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 778.997,958.978 -3.606,-1.151 -6.262,-9.797 -3.56,0.742 1.194,-2.968 -1.214,2.968 -3.304,1.063 1.093,-1.884 -1.633,-2.706 -8.794,-5.45 -1.352,-2.912 1.714,-0.309 -2.195,-0.935 5.034,0.069 0.625,-4.702 -1.544,-0.225 3.991,0.494 10.155,10.752 7.692,2.826 3.358,-0.938 7.633,4.719 -0.102,2.113 1.073,-1.331 2.27,5.017 -3.754,0.966 -3.965,4.673 -4.537,-1.086 -0.01,-0.008"
+           id="polygon28" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 885.214,553.677 -3.065,-0.614 -7.933,0.107 2.581,-0.125 -0.107,-0.641 2.323,0.122 4.616,-0.333 8.183,-1.036 1.891,1.267 4.771,-0.056 -0.811,0.254 3.129,0.282 -0.718,0.89 -5.48,-0.181 4.088,-0.414 -0.827,-0.27 -2.389,0.25 -2.969,-0.234 -7.283,0.732 v 0"
+           id="polygon39" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 809.728,1234.884 4.308,1.66 -10.268,-2.616 -6.15,-1.147 -4.824,-1.927 1.452,0.046 3.652,1.294 -0.826,-0.847 4.447,1.236 -0.612,-0.446 -1.239,-0.094 -0.367,-0.365 -4.737,-1.331 3.616,0.932 -1.782,-0.731 -0.968,-0.068 -2.684,-1.36 16.977,5.766 h 0.005"
+           id="polygon42" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1051.708,740.11 -3.291,-0.162 1.208,-4.696 6.98,1.986 3.6,-3.513 8.261,0.646 3.107,3.892 7.757,2.342 3.482,-1.744 11.684,2.963 0.982,3.6 2.85,2.624 -6.602,-1.764 0.346,2.34 -7.487,-1.246 -5.196,-2.742 -9.896,-0.588 -17.775,-3.928 -0.01,-0.01"
+           id="polygon45" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 891.51,550.961 -2.024,-0.24 -3.664,0.183 -0.299,0.217 -0.755,-0.11 4.852,-0.601 -1.565,-0.169 -4.166,0.155 -3.024,0.212 34.6,-0.266 13.385,0.849 -1.274,-0.103 -2.643,-0.199 -3.268,-0.218 -6.149,-0.328 -4.401,-0.167 -19.599,0.784 -0.006,10e-4"
+           id="polygon49" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 948.644,571.622 -3.695,-1.087 -4.503,-3.319 5.195,-1.079 7.347,1.682 -1.977,0.616 1.538,-0.263 -0.003,0.936 -3.163,-0.546 0.92,-0.703 -1.809,-0.492 -0.67,1.099 3.5,2.648 -2.341,0.239 -1.365,-1.188 1.026,1.457"
+           id="polygon52" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 873.391,921.229 -3.689,2.163 -1.912,-5.433 -3.309,3.364 -1.639,-7.698 -0.548,1.567 0.459,-8.796 6.975,2.425 8.594,-4.169 -0.027,4.609 -3.333,5.917 1.68,-1.089 -0.231,2.63 -3.023,4.509 h 0.003"
+           id="polygon58" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 833.267,708.441 -6.424,-2.203 0.971,-2.109 -2.783,-2.942 1.387,-1.205 4.055,-0.16 -1.11,3.414 4.777,2.503 4.806,-0.421 -0.041,-2.613 1.374,2.475 9.333,-0.727 -7.668,4.452 -8.675,-0.446 -0.002,-0.018"
+           id="polygon61" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 972.768,681.361 0.452,-3.51 -5.95,0.425 4.364,-2.153 -3.067,-1.691 -0.131,-2.365 6.535,3.916 -2.318,-2.131 0.359,-4.123 3.353,5.865 -1.549,5.674 -4.707,2.622 2.657,-2.519 0.002,-0.01"
+           id="polygon69" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 935.786,566.73 -3.05,-1.228 -3.042,0.327 -3.095,-1.208 0.684,-0.636 3.436,-0.013 4.018,1.077 0.866,-0.32 4.997,1.772 -2.1,-0.386 -0.75,1.17 -1.963,-0.547 -0.001,-0.008"
+           id="polygon73" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1200.664,759.246 -3.429,-4.453 -2.263,-5.505 0.639,-4.655 2.414,-1.952 0.981,1.34 -1.252,-0.496 0.948,0.676 2.006,7.811 0.219,-0.553 -0.256,7.784 -0.01,0.003"
+           id="polygon77" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1113.967,1057.18 0.715,-1.696 -2.278,-1.297 2.226,0.175 -1.387,-1.773 1.35,-1.574 0.779,3.411 1.017,-1.754 0.115,1.969 2.139,-1.593 -4.675,4.149 v -0.017"
+           id="polygon79" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 829.933,1242.238 1.416,0.326 -1.655,-0.277 4.292,0.95 -1.119,-0.134 -0.941,-0.288 -3.161,-0.547 0.833,-0.01 -2.156,-0.616 1.702,0.288 0.789,0.305"
+           id="polygon85" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 972.669,694.622 0.495,2.496 -1.559,-2.713 -1.65,1.72 -8.721,-1.673 -5.707,2.004 3.149,-4.056 7.782,0.029 6.205,2.192 0.006,10e-4"
+           id="polygon94" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 799.887,1231.362 2.826,0.61 -0.991,-0.069 1.885,0.687 0.554,-0.071 3.242,0.937 -4.822,-1.065 1.596,0.694 -4.293,-1.723 h 0.003"
+           id="polygon97" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1029.539,652.503 -4.591,-5.273 -5.655,-3.625 0.849,-3.245 0.446,2.729 1.327,-0.549 -0.025,1.777 12.451,11.62 -4.798,-3.436 v 0.002"
+           id="polygon98" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1091.937,726.278 -0.71,-2.402 2.841,0.438 1.352,-3.364 3.537,1.778 1.017,2.58 -3.17,-1.149 -1.051,2.812 -3.815,-0.688 v -0.005"
+           id="polygon100" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 999.532,641.324 -2.263,-3.51 2.064,-0.401 2.269,4.024 2.811,1.485 -3.427,2.462 -1.798,-1.389 0.35,-2.669 -0.006,-0.002"
+           id="polygon108" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1001.248,726.009 0.844,-1.238 2.379,2.987 5.297,1.5 6.299,-0.672 3.383,3.459 -10.598,-1.459 -7.599,-4.577 v 0"
+           id="polygon110" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 771.371,1224.032 1.162,0.612 -4.187,-1.195 1.389,0.232 -2.169,-0.931 2.982,0.968 0.017,0.373 0.803,-0.061 h 0.003"
+           id="polygon115" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1071.091,632.522 -2.664,-0.415 -4.695,-3.25 -4.132,-4.37 0.173,-1.028 8.442,3.45 3.77,3.282 -0.881,2.334 -0.013,-0.003"
+           id="polygon117" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1035.038,737.895 -12.135,-5.689 7.322,-0.928 1.272,1.147 -3.419,1.313 6.571,0.21 1.946,2.064 -1.558,1.879 10e-4,0.004"
+           id="polygon118" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 826.406,1241.457 1.824,0.64 -5.382,-1.233 2.944,0.558 -2.335,-0.531 1.8,0.397 -2.512,-0.74 3.633,0.903 0.028,0.01"
+           id="polygon121" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 992.391,636.137 -3.332,3.253 0.232,-1.406 -1.715,-0.058 1.346,-3.919 3.798,0.042 -0.325,2.085 -0.004,0.003"
+           id="polygon137" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 788.198,1227.821 1.796,1.039 -3.828,-1.173 -1.081,-0.762 2.633,0.752 0.875,0.542 -0.407,-0.402 h 0.012"
+           id="polygon143" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 988.781,634.341 -4.267,0.371 1.066,-4.258 1.994,-1.105 4.98,0.878 -4.115,2.37 0.342,1.744"
+           id="polygon147" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 785.749,1227.705 2.388,0.704 -1.178,-0.217 2.234,1.29 -3.61,-1.436 0.181,-0.338 h -0.015"
+           id="polygon151" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1006.384,640.996 -6.722,-4.154 -0.293,-1.675 1.692,1.006 5.433,-0.694 -0.104,5.521 -0.01,-0.004"
+           id="polygon152" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1003.215,709.3 0.611,3.686 -3.253,-2.782 1.773,-0.215 -0.784,-4.189 1.646,3.493 0.01,0.007"
+           id="polygon153" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1017.87,738.622 -2.658,0.82 -2.017,-1.998 5.277,-2.799 5.542,2.611 -6.137,1.362 -0.01,0.004"
+           id="polygon154" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 994.925,735.047 -18.813,-12.994 12.725,3.298 8.207,6.643 1.002,4.077 -3.103,-1.021 -0.018,-0.003"
+           id="polygon156" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1012.377,632.733 -1.646,2.373 -1.62,-0.497 -1.272,-3.327 6.633,0.086 -2.097,1.353 v 0.012"
+           id="polygon158" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1006.379,602.496 -8.36,-9.743 2.006,-0.302 8.966,6.234 0.982,1.699 -3.59,2.113 v -10e-4"
+           id="polygon159" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 953.685,734.935 0.991,1.168 2.777,-1.792 -3.659,3.768 -3.341,-2.923 3.227,-0.221 h 0.005"
+           id="polygon160" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 683.9,809.026 7.549,-0.011 -6.57,3.152 -0.306,-1.596 2.297,0.183 -2.988,-1.718 0.018,-0.01"
+           id="polygon163" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 934.578,705.397 0.627,4.828 -3.287,-3.736 0.807,-4.121 2.517,1.605 -0.663,1.416 v 0.008"
+           id="polygon168" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 912.083,716.708 -5.768,-1.877 -0.899,-2.472 5.68,-0.125 3.311,4.504 -2.318,-0.034 -0.006,0.004"
+           id="polygon170" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1136.905,729.777 -2.096,0.584 -0.245,-2.124 2.497,-0.855 1.3,1.365 -1.454,1.015 v 0.015"
+           id="polygon178" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1003.634,709.381 -0.117,-1.82 2.107,0.919 0.435,3.364 -1.86,-0.153 -0.564,-2.301 v -0.009"
+           id="polygon179" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 995.121,642.04 -3.336,-1.114 0.043,-1.19 2.306,-0.018 2.188,1.791 -1.193,0.527 -0.008,0.004"
+           id="polygon182" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 809.945,712.987 -2.919,3.729 -2.533,0.059 7.033,-8.135 -1.576,4.343 -0.005,0.004"
+           id="polygon190" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1046.413,736.298 2.597,0.59 -3.446,2.695 -3.141,-3.282 3.985,-0.005 0.01,0.002"
+           id="polygon196" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 781.933,735.365 1.697,-1.342 0.662,1.303 -6.915,3.43 4.532,-3.385 0.024,-0.006"
+           id="polygon198" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 997.225,640.884 -2.439,-1.94 -0.538,-3.565 4.969,8.165 -1.991,-2.653 v -0.007"
+           id="polygon201" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 994.435,633.489 4.094,-2.215 0.696,2.713 -2.271,-1.582 -2.497,1.073 -0.022,0.011"
+           id="polygon202" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 748.664,775.076 -0.425,3.885 -2.622,0.107 2.708,-5.942 0.34,1.944 -10e-4,0.006"
+           id="polygon205" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1085.201,724.732 -1.338,-2.963 3.192,0.308 0.215,3.353 -2.07,-0.682 10e-4,-0.016"
+           id="polygon207" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 692.116,815.749 1.32,-4.801 5.049,1.354 -2.631,3.21 -3.733,0.26 -0.005,-0.023"
+           id="polygon213" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 984.542,697.453 -4.093,2.084 -3.375,-1.745 2.764,-2.188 4.694,1.848 0.01,10e-4"
+           id="polygon219" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 821.468,700.511 13.046,-9.321 -9.185,6.534 -3.053,6.432 -0.833,-3.641 0.025,-0.004"
+           id="polygon220" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 921.247,747.002 0.507,1.375 -3.707,0.179 1.378,-3.545 1.817,1.987 0.005,0.004"
+           id="polygon226" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 853.35,1234.181 1.907,0.829 -2.411,0.111 -1.205,-0.684 1.684,-0.252 h 0.025"
+           id="polygon229" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 875.203,552.705 0.362,0.197 -4.189,-0.208 1.985,-0.171 1.846,0.182 h -0.004"
+           id="polygon231" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1103.472,712.313 -0.723,0.555 v -1.951 l 1.842,1.483 -1.123,-0.089 v 0.002"
+           id="polygon240" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 745.342,781.851 1.287,0.084 -1.069,2.914 -1.8,0.703 1.583,-3.697 -10e-4,-0.004"
+           id="polygon255" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 612.105,704.15 -0.939,1.147 1.689,-2.571 0.526,-0.456 -1.263,1.865 -0.013,0.015"
+           id="polygon258" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1111.847,716.288 1.258,-0.046 0.392,1.489 -3.006,-0.67 1.356,-0.771 v -0.002"
+           id="polygon260" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 977.045,682.786 -1.111,1.531 -2.577,-0.549 2.009,-1.966 1.68,0.93 v 0.054"
+           id="polygon262" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 972.748,687.057 2.21,-0.542 1.487,1.625 -4.6,-0.335 0.897,-0.748 h 0.006"
+           id="polygon264" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 989.623,723.983 -0.463,-1.183 3.294,0.436 1.014,1.753 -3.815,-1.001 -0.03,-0.005"
+           id="polygon266" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1083.176,690.24 0.642,-0.792 1.382,1.53 -0.916,1.277 -1.14,-2.026 0.032,0.011"
+           id="polygon272" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1040.702,737.634 -3.231,-0.103 -0.602,-3.066 2.546,0.181 1.287,2.988"
+           id="polygon274" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 812.739,1180.886 -2.258,0.396 -3.779,-1.36 3.404,-0.475 2.633,1.439"
+           id="polygon281" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 924.414,681.044 -2.327,-0.383 6.212,-1.916 -3.874,2.298 h -0.011"
+           id="polygon288" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 828.903,817.191 -0.253,1.827 -1.618,-5.938 1.866,4.106 0.005,0.005"
+           id="polygon290" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 794.443,1230.412 2.672,0.784 -2.468,-0.31 -0.21,-0.477 h 0.006"
+           id="polygon292" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 984.955,721.333 -6.028,-2.3 5.157,0.351 0.873,1.953 -0.002,-0.004"
+           id="polygon298" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 605.727,712.977 2.284,-3.312 -1.453,2.367 -0.832,0.947 10e-4,-0.002"
+           id="polygon299" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 862.744,902.328 -1.492,0.774 1.567,-3.157 -0.071,2.383 h -0.004"
+           id="polygon301" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 857.644,553.313 -2.064,0.086 4.442,-0.246 -2.374,0.159 -0.004,10e-4"
+           id="polygon302" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 589.357,787.293 0.524,-0.089 -1.134,2.148 0.609,-2.056 10e-4,-0.003"
+           id="polygon303" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 857.377,687.168 -2.647,-0.65 5.639,0.2 -2.981,0.45 h -0.011"
+           id="polygon304" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 959.431,737.838 -3.685,-0.534 1.881,-2.158 1.804,2.678 v 0.014"
+           id="polygon306" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1129.849,735.077 1.56,1.931 -3.008,1.053 1.447,-2.975 10e-4,-0.009"
+           id="polygon307" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1116.459,714.028 1.695,0.647 -0.295,0.734 -1.408,-1.384 0.01,0.003"
+           id="polygon308" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 798.513,720.558 -3.263,1.146 6.351,-5.25 -3.078,4.094 -0.01,0.01"
+           id="polygon311" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1151.307,694.824 0.053,-0.775 0.65,3.051 -0.692,-2.269 -0.011,-0.007"
+           id="polygon312" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 771.209,745.325 -2.189,0.779 6.045,-4.982 -3.854,4.2 -0.002,0.003"
+           id="polygon314" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 958.978,687.773 -0.317,-1.65 3.809,1.433 -3.502,0.225 0.01,-0.008"
+           id="polygon315" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 856.344,1236.894 -0.625,-0.583 3.556,0.846 -2.868,-0.254 -0.063,-0.01"
+           id="polygon318" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 924.448,684.193 -5.526,-0.367 9.1,-0.505 -3.567,0.876 -0.007,-0.004"
+           id="polygon319" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 914.816,875.955 -5.551,-1.461 7.641,-0.093 -2.086,1.558 -0.004,-0.004"
+           id="polygon321" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 958.118,578.458 -1.219,0.179 -1.873,-1.16 3.091,0.978 0.001,0.003"
+           id="polygon322" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1151.047,692.619 -0.512,0.607 -0.745,-2.485 1.253,1.865 v 0.013"
+           id="polygon323" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1058.971,734.14 -4.129,-0.025 -3.231,-2.461 7.35,2.472 0.01,0.014"
+           id="polygon324" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 796.379,724.725 1.157,1.418 -3.34,2.341 2.176,-3.765 0.007,0.006"
+           id="polygon327" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 776.229,735.84 -2.055,2.478 4.227,-7.879 -2.168,5.396 -0.004,0.005"
+           id="polygon328" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 794.816,1230.264 -2.784,-0.735 0.533,-0.068 2.261,0.806 h -0.01"
+           id="polygon330" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 984.641,690.208 3.968,0.955 -6.061,-1.191 2.083,0.235 0.01,10e-4"
+           id="polygon331" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 787.179,727.033 -5.013,3.756 8.197,-7.333 -3.183,3.576 h -10e-4"
+           id="polygon332" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 602.02,720.179 -1.469,1.275 3.99,-6.381 -2.516,5.096 -0.005,0.01"
+           id="polygon336" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1122.668,740.865 1.218,-0.353 -1.407,1.972 0.189,-1.614 v -0.005"
+           id="polygon337" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 774.486,1224.709 1.401,0.558 -1.79,-0.513 0.377,-0.049 h 0.012"
+           id="polygon339" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 771.224,1223.9 -1.419,-0.601 1.291,0.302 0.134,0.301 h -0.006"
+           id="polygon341" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1142.846,725.319 1.351,0.9 -3.458,-0.342 2.104,-0.557 v -0.001"
+           id="polygon342" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 767.189,1222.976 1.947,0.832 -2.177,-0.729 0.236,-0.101 h -0.006"
+           id="polygon343" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 788.188,961.288 -0.131,-2.752 2.467,3.017 -2.333,-0.266 -0.003,10e-4"
+           id="polygon344" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1002.304,692.046 -3.259,-1.762 3.813,0.271 -0.549,1.492 v -10e-4"
+           id="polygon346" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 869.578,552.822 -7.457,0.138 4.082,-0.347 3.38,0.209 h -0.005"
+           id="polygon352" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 833.958,729.109 1.667,-1.725 -2.652,2.873 0.985,-1.144 v -0.004"
+           id="polygon354" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 782.541,1226.397 3.452,1.222 -6.669,-2.271 3.22,1.05 h -0.003"
+           id="polygon355" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 954.751,679.411 -1.787,-1.022 6.561,0.906 -4.73,0.123 -0.044,-0.007"
+           id="polygon357" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 914.073,1248.455 -1.991,0.41 -4.984,0.199 6.971,-0.609 h 0.004"
+           id="polygon358" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 727.219,968.545 -2.252,-0.563 2.001,-1.083 0.249,1.641 0.002,0.005"
+           id="polygon361" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 965.131,583.405 -1.631,-1.088 3.683,2.412 -2.03,-1.312 -0.022,-0.012"
+           id="polygon364" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 753.032,816.52 13.274,-17.503 -3.774,8.668 -9.483,8.833 -0.017,0.002"
+           id="polygon365" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1019.207,665.009 1.053,1.026 -2.513,-1.56 1.455,0.536 v -0.002"
+           id="polygon378" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1226.046,963.96 -0.978,2.848 0.184,-2.387 0.795,-0.468 -10e-4,0.007"
+           id="polygon381" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 851.523,704.216 1.509,-0.397 -1.475,1.799 -0.039,-1.402 h 0.005"
+           id="polygon386" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1098.418,677.062 1.447,1.239 -2.584,-1.688 1.133,0.448 v 10e-4"
+           id="polygon391" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1100.748,717.115 2.533,-0.255 0.311,1.251 -2.854,-0.991 0.01,-0.005"
+           id="polygon393" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1240.388,978.724 -0.084,-0.287 0.372,-1.197 -0.286,1.475 v 0.009"
+           id="polygon394" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 739.464,800.686 -1.583,0.904 0.853,-2.229 0.741,1.312 -0.011,0.013"
+           id="polygon400" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 984.606,692.479 0.555,-1.326 -0.903,2.353 0.326,-1.011 0.022,-0.016"
+           id="polygon401" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 841.395,1230.995 -1.695,0.226 -1.269,-1.193 2.93,0.956 0.034,0.011"
+           id="polygon408" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1114.095,717.409 -1.017,-1.616 1.313,-0.188 -0.274,1.793 -0.022,0.011"
+           id="polygon411" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 971.134,670.506 -1.814,-0.749 -0.023,-2.392 1.838,3.137 v 0.004"
+           id="polygon420" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 872.593,619.563 -0.667,0.763 -1.317,-1.206 1.985,0.438 -0.001,0.005"
+           id="polygon432" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 606.74,749.648 1.135,-1.68 -1.972,3.332 0.832,-1.645 0.005,-0.007"
+           id="polygon436" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 646.987,819.261 -1.527,1.231 2.399,-2.655 -0.869,1.415 -0.003,0.009"
+           id="polygon444" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 849.348,1237.1 0.675,0.383 -3.127,-1.129 2.128,0.693 0.324,0.053"
+           id="polygon446" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 947.16,572.368 -0.444,-0.633 1.206,1.116 -0.761,-0.478 -10e-4,-0.005"
+           id="polygon448" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1225.371,976.813 -1.029,-0.478 1.003,-1.402 0.028,1.869 v 0.011"
+           id="polygon455" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 797.713,727.419 -1.218,1.048 0.077,-1.633 1.14,0.577 10e-4,0.008"
+           id="polygon461" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 609.015,708.267 -0.583,0.639 1.45,-1.755 -0.863,1.114 -0.004,0.002"
+           id="polygon462" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1007.412,656.033 0.322,1.462 -2.184,-1.318 1.856,-0.146 0.01,0.002"
+           id="polygon466" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1016.493,717.227 -0.321,2.439 0.111,-3.696 0.212,1.215 v 0.042"
+           id="polygon470" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 835.328,1222.713 1.699,0.979 -1.474,1.478 -0.361,-2.459 h 0.136"
+           id="polygon477" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 842.798,1232.258 -1.572,-0.244 0.464,-0.712 1.139,0.957 -0.031,-10e-4"
+           id="polygon481" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 998.932,629.907 1.152,-0.2 -2.429,1.063 1.276,-0.856 v -0.007"
+           id="polygon489" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 954.742,683.883 -0.199,-1.79 2.377,0.48 -2.178,1.313 v -0.003"
+           id="polygon500" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1240.287,980.537 v -0.372 l 0.559,-1.878 -0.555,2.242 v 0.008"
+           id="polygon503" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1150.063,712.329 1.077,0.008 -0.379,1.399 -0.697,-1.404 -10e-4,-0.003"
+           id="polygon515" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 995.454,724.87 -0.884,0.927 -0.94,-1.997 1.815,1.068 0.009,0.002"
+           id="polygon518" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 994.111,692.821 -5.459,-1.984 4.668,0.031 0.791,1.953"
+           id="polygon531" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 925.131,563.258 1.452,0.771 -1.477,-0.773 0.025,0.002"
+           id="polygon554" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 763.682,1221.771 1.354,0.592 -1.357,-0.593 0.003,10e-4"
+           id="polygon556" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 774.355,736.763 -1.019,2.629 1.018,-2.638 10e-4,0.009"
+           id="polygon559" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1007.722,711.015 0.211,1.759 -0.215,-1.76 v 10e-4"
+           id="polygon561" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 950.248,569.069 -1.385,-0.457 1.384,0.451 0.001,0.006"
+           id="polygon563" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1128.827,682.523 -0.892,-1.778 0.887,1.752 0.01,0.026"
+           id="polygon565" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 780.499,1226.217 -1.223,-0.383 1.215,0.38 h 0.008"
+           id="polygon568" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1004.637,625.124 0.729,-1.146 -0.726,1.146 v 0"
+           id="polygon570" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 736.782,910.205 -0.613,1.24 0.61,-1.242 0.003,0.002"
+           id="polygon572" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 801.475,721.958 -1.118,1.73 1.117,-1.739 10e-4,0.009"
+           id="polygon573" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 921.093,733.139 -0.007,-0.007 -1.67,-2.371 1.677,2.378"
+           id="polygon574" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1104.528,719.741 -1.771,-0.913 1.771,0.901 v 0.012"
+           id="polygon576" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1240.129,978.027 -0.281,0.596 0.282,-0.6 v 0.004"
+           id="polygon577" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1124.733,740.31 -1.045,-0.019 1.049,0.017 v 0.002"
+           id="polygon579" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1130.588,696.381 0.044,0.953 -0.047,-0.978 v 0.025"
+           id="polygon581" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 761.622,1221.41 -0.324,-0.106 0.318,0.104 h 0.006"
+           id="polygon582" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 839.281,690.402 0.08,-0.005 -2.789,0.984 2.709,-0.979"
+           id="polygon584" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1105.866,713.422 -0.849,-1.232 0.851,1.231 v 10e-4"
+           id="polygon587" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 618.314,695.994 -1.025,0.958 1.03,-0.968 -0.005,0.01"
+           id="polygon588" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 760.941,1221.189 -1.708,-0.745 1.698,0.741 h 0.01"
+           id="polygon590" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 764.755,1221.916 1.551,0.647 -1.553,-0.648 0.002,10e-4"
+           id="polygon591" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 796.402,1230.242 h -0.007 l -1.499,-0.535 1.506,0.537"
+           id="polygon595" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 837.527,725.402 -2.984,1.887 2.983,-1.918 0.001,0.031"
+           id="polygon597" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 696.413,820.24 -0.023,0.011 -2.377,0.546 2.4,-0.557"
+           id="polygon598" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 768.41,1223.277 1.056,0.332 -1.031,-0.322 -0.025,-0.01"
+           id="polygon604" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 742.707,792.644 -2.261,0.645 2.258,-0.663 0.003,0.018"
+           id="polygon605" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 749.721,809.598 1.443,-2.117 -1.441,2.131 -0.002,-0.014"
+           id="polygon607" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1005.756,634.481 -0.861,-2.202 0.866,2.203 v -10e-4"
+           id="polygon608" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 776.534,1224.754 v 0 l -0.695,0.057 0.695,-0.057"
+           id="polygon611" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 768.691,1223.951 -1.601,-0.72 1.604,0.721 -0.003,-10e-4"
+           id="polygon613" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 933.442,643.225 -1.014,-1.228 1.014,1.224 v 0.004"
+           id="polygon615" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 988.114,665.552 -1.505,1.012 1.505,-1.019 v 0.007"
+           id="polygon616" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 585.683,908.99 -0.417,3.119 0.41,-3.121 0.007,0.002"
+           id="polygon618" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 793.043,728.212 -0.063,1.242 0.058,-1.241 0.005,-10e-4"
+           id="polygon621" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 985.275,638.775 0.094,-1.822 -0.089,1.826 -0.005,-0.004"
+           id="polygon623" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 972.629,697.253 -2.045,-0.675 2.04,0.67 0.005,0.005"
+           id="polygon624" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1132.292,731.725 v 0.008 l -0.633,1.482 0.633,-1.49"
+           id="polygon625" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1129.622,684.983 -0.736,0.267 0.729,-0.301 0.01,0.034"
+           id="polygon626" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 777.125,1225.308 2.003,0.647 -2.012,-0.648 0.009,10e-4"
+           id="polygon627" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 850.272,553.876 h 0.003 l -0.935,0.062 0.932,-0.062"
+           id="polygon628" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 979.919,662.835 0.068,-2.381 -0.068,2.385 v -0.004"
+           id="polygon630" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1020.531,732.372 -1.08,-0.971 1.08,0.966 v 0.005"
+           id="polygon631" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 767.324,1223.246 0.95,0.318 -0.952,-0.319 h 0.002"
+           id="polygon632" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 954.184,568.22 -1.222,-0.54 1.22,0.535 0.002,0.005"
+           id="polygon633" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 670.536,847.165 -1.222,1.13 1.217,-1.148 0.005,0.018"
+           id="polygon635" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 996.129,577.796 -3.313,-0.184 3.311,0.18 0.002,0.004"
+           id="polygon637" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 798.69,724.764 -0.688,-1.156 0.693,1.16 -0.005,-0.004"
+           id="polygon639" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 983.442,639.328 -0.437,-1.165 0.443,1.162 -0.006,0.003"
+           id="polygon641" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 880.685,900.453 0.736,-2.604 -0.732,2.609 -0.004,-0.005"
+           id="polygon642" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1132.895,734.547 -0.717,-1.74 0.717,1.736 v 0.004"
+           id="polygon645" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 954.472,566.704 -1.028,-0.44 1.028,0.438 v 0.002"
+           id="polygon649" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 868.621,922.144 -1.378,-2.078 1.378,2.068 v 0.01"
+           id="polygon652" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 749.283,751.573 0.004,-0.004 1.641,-0.452 -1.645,0.456"
+           id="polygon654" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 650.449,813.958 -2.441,2.604 2.441,-2.608 v 0.004"
+           id="polygon655" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1041.841,837.054 1.813,-2.556 -1.811,2.559 v -0.003"
+           id="polygon659" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 871.037,553.116 -1.452,0.087 1.452,-0.087 v 0"
+           id="polygon660" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 987.462,592.159 -1.565,-0.738 1.564,0.735 10e-4,0.003"
+           id="polygon663" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 767.824,1223.041 -0.997,-0.336 0.989,0.331 h 0.008"
+           id="polygon671" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 762.166,1221.701 0.026,0.023 -0.034,-0.026 h 0.008"
+           id="polygon673" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1127.623,680.666 -0.513,0.626 0.508,-0.631 0.01,0.005"
+           id="polygon675" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 978.177,682.727 -1.234,-0.906 1.234,0.901 v 0.005"
+           id="polygon678" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1000.005,726.779 -4.092,-2.261 4.093,2.252 -10e-4,0.009"
+           id="polygon679" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 944.821,704.131 -1.01,1.667 1.01,-1.679 v 0.012"
+           id="polygon681" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 738.996,804.098 -0.941,1.516 0.936,-1.544 0.005,0.028"
+           id="polygon684" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1127.051,739.074 -1.621,0.316 1.621,-0.323 v 0.007"
+           id="polygon697" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 766.581,1222.475 1.256,0.557 -1.252,-0.555 h -0.004"
+           id="polygon698" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 747.29,814.317 0.69,-1.886 -0.682,1.882 -0.008,0.004"
+           id="polygon700" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 989.727,592.897 -1.525,-0.422 1.523,0.416 0.002,0.006"
+           id="polygon702" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 742.075,786.91 -1.739,1.481 1.737,-1.5 0.002,0.019"
+           id="polygon705" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 993.424,580.595 -1.5,-0.352 1.537,0.36 -0.037,-0.008"
+           id="polygon706" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1153.966,700.87 -0.401,0.671 0.398,-0.681 v 0.01"
+           id="polygon710" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 943.393,706.044 -1.82,-3.812 1.82,3.795 v 0.017"
+           id="polygon713" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 764.487,1222.62 h 0.002 l 1.014,0.402 -1.016,-0.403"
+           id="polygon714" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 774.677,1224.499 -0.018,-0.01 -0.101,-0.281 0.119,0.288"
+           id="polygon715" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 958.058,680.588 -1.456,-0.497 1.456,0.493 v 0.004"
+           id="polygon716" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 954.206,717.756 1.423,1.452 -1.428,-1.457 0.005,0.005"
+           id="polygon720" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 880.791,717.078 -2.738,1.556 2.738,-1.564 v 0.008"
+           id="polygon721" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1000.498,739.204 -2.041,-2.668 2.046,2.665 v 0.003"
+           id="polygon724" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 925.452,736.303 -0.993,-1.347 1.006,1.359 -0.013,-0.012"
+           id="polygon727" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1045.183,729.816 v 0.004 l -1.504,-0.804 1.504,0.8"
+           id="polygon734" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 754.022,806.431 -0.007,-0.005 -0.943,-1.572 0.95,1.577"
+           id="polygon735" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 763.888,1222.407 0.399,0.189 -0.401,-0.189 h 0.002"
+           id="polygon740" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 996.568,630.793 -1.101,0.872 1.101,-0.875 v 0.003"
+           id="polygon742" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1234.703,978.84 0.529,-1.818 -0.531,1.825 v -0.007"
+           id="polygon744" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 956.289,565.513 0.701,0.554 -0.704,-0.555 0.003,0.001"
+           id="polygon746" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 905.001,761.219 -3.291,-0.652 3.291,0.634 v 0.018"
+           id="polygon748" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 799.835,1231.455 2.294,0.886 -2.3,-0.885 0.006,-10e-4"
+           id="polygon749" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 740.925,783.354 -0.21,-3.007 0.215,2.994 -0.005,0.013"
+           id="polygon750" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 822.273,726.191 3.113,-1.002 -3.118,1.007 0.005,-0.005"
+           id="polygon751" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1125.231,699.644 -1.252,-0.32 1.249,0.292 v 0.028"
+           id="polygon758" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 992.014,625.012 0.7,1.838 -0.7,-1.835 v -0.003"
+           id="polygon759" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1003.656,640.288 -1.46,-1.204 1.459,1.19 10e-4,0.014"
+           id="polygon762" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 792.025,655.397 -1.338,0.615 1.339,-0.636 -10e-4,0.021"
+           id="polygon772" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1103.358,715.782 -1.111,0.517 1.111,-0.529 v 0.012"
+           id="polygon775" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 862.918,904.255 h 0.007 l -2.203,0.289 2.196,-0.289"
+           id="polygon778" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1008.154,687.915 2.04,1.242 -2.045,-1.243 v 10e-4"
+           id="polygon781" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 643.555,823.722 -1.173,0.414 1.171,-0.418 0.002,0.004"
+           id="polygon783" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1151.326,694.525 -0.734,-1.212 0.731,1.199 v 0.013"
+           id="polygon784" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1035.488,658.401 -0.457,-1.24 0.462,1.242 v -0.002"
+           id="polygon785" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 803.152,980.313 -1.49,-1.688 1.495,1.688 h -0.005"
+           id="polygon787" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1244.535,958.52 0.129,-1.262 -0.128,1.258 -10e-4,0.004"
+           id="polygon789" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1005.297,630.453 0.614,-1.198 -0.609,1.196 v 0.002"
+           id="polygon790" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1127.198,677.416 0.094,1.197 -0.096,-1.203 v 0.006"
+           id="polygon793" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1140.387,664.024 -0.209,0.368 0.203,-0.379 0.01,0.011"
+           id="polygon794" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 922.955,734.532 -1.229,-0.791 1.229,0.782 v 0.009"
+           id="polygon799" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1035.41,660.941 -1.302,-1.043 1.3,1.015 v 0.028"
+           id="polygon801" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1140.315,666.801 -0.704,0.023 0.702,-0.029 v 0.006"
+           id="polygon803" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1093.52,1060.711 -1.381,-0.855 1.399,0.838 -0.018,0.017"
+           id="polygon805" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1035.379,676.453 -2.39,-0.396 2.389,0.366 10e-4,0.03"
+           id="polygon808" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1015.581,637.12 v -0.004 l 2.059,-0.74 -2.054,0.744"
+           id="polygon813" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1150.102,690.666 -1.434,-2.849 1.433,2.846 10e-4,0.003"
+           id="polygon816" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1002.055,705.091 -1.491,-0.971 1.495,0.972 v -10e-4"
+           id="polygon817" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 753.043,934.446 -1.273,-1.134 1.271,1.129 0.002,0.005"
+           id="polygon820" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 781.019,733.326 -1.549,1.076 1.548,-1.09 10e-4,0.014"
+           id="polygon828" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 908.12,557.729 -1.009,-0.438 1.012,0.434 -0.003,0.004"
+           id="polygon829" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1017.68,643.013 1.472,0.495 -1.472,-0.493 v -0.002"
+           id="polygon831" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 833.95,721.216 -0.712,1.662 0.707,-1.661 0.005,-10e-4"
+           id="polygon832" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 964.74,678.915 -1.372,0.82 1.372,-0.828 v 0.008"
+           id="polygon833" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 817.785,1237.578 h 0.005 l -2.181,-0.728 2.176,0.725"
+           id="polygon835" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 958.419,682.589 -3.218,-1.046 3.21,1.04 0.008,0.006"
+           id="polygon836" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 779.95,1226.157 1.554,0.445 -1.549,-0.44 -0.005,-0.01"
+           id="polygon840" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 773.265,1224.543 2.685,0.927 -2.689,-0.928 0.004,10e-4"
+           id="polygon841" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 782.626,1226.618 1.464,0.615 -1.46,-0.613 h -0.004"
+           id="polygon844" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1001.228,726.359 -1.931,-1.098 1.933,1.072 v 0.026"
+           id="polygon845" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1041.739,713.609 -1.189,-4.227 1.19,4.218 -10e-4,0.009"
+           id="polygon855" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 929.959,682.958 -1.516,-0.189 1.516,0.181 v 0.008"
+           id="polygon858" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 740.527,777.784 v 0.005 l 0.032,2.293 -0.032,-2.298"
+           id="polygon861" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 828.227,830.911 -0.537,-1.841 0.535,1.826 0.002,0.015"
+           id="polygon862" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 742.203,784.009 -1.515,1.193 1.505,-1.199 0.01,0.006"
+           id="polygon868" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1114.066,748.181 -1.426,0.089 1.427,-0.102 -10e-4,0.013"
+           id="polygon871" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 953.434,717.2 -3.366,-4.776 3.367,4.768 -10e-4,0.008"
+           id="polygon874" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 908.518,716.382 -2.226,0.013 2.227,-0.026 -10e-4,0.013"
+           id="polygon879" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 825.688,1241.563 1.606,0.345 -1.608,-0.345 h 0.002"
+           id="polygon885" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1239.873,981.452 0.024,-0.473 -0.022,0.465 v 0.008"
+           id="polygon887" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1133.389,1128.916 0.449,-0.953 -0.445,0.951 v 0"
+           id="polygon889" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 940.712,696.313 -1.862,0.903 1.862,-0.916 v 0.013"
+           id="polygon890" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 821.808,738.1 -3.421,1.888 3.421,-1.893 v 0.005"
+           id="polygon892" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 825.43,733.588 -2.097,0.557 2.096,-0.566 10e-4,0.009"
+           id="polygon894" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 559.689,901.656 -0.194,1.296 0.184,-1.348 0.01,0.052"
+           id="polygon897" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1006.86,686.759 -0.989,0.61 0.988,-0.629 10e-4,0.019"
+           id="polygon900" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1151.376,709.312 -0.253,-1.083 0.258,1.082 -0.01,10e-4"
+           id="polygon901" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 833.306,693.309 1.532,-0.062 -1.537,0.066 0.005,-0.004"
+           id="polygon904" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1131.804,730.835 -1.507,-0.625 1.507,0.598 v 0.027"
+           id="polygon906" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 766.008,1222.657 -0.016,-0.01 0.874,0.235 -0.858,-0.228"
+           id="polygon907" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 741.504,779.101 1.752,0.406 -1.753,-0.403 10e-4,-0.003"
+           id="polygon908" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 965.267,562.938 -0.588,0.146 0.588,-0.146 v 0"
+           id="polygon912" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 842.219,684.83 -1.473,0.651 1.473,-0.663 v 0.012"
+           id="polygon918" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1004.881,626.879 -0.019,0.009 -0.979,0.39 0.998,-0.399"
+           id="polygon919" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 953.996,566.229 -1.387,-0.718 1.386,0.715 10e-4,0.003"
+           id="polygon921" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 812.622,707.057 -0.559,1.765 0.558,-1.786 10e-4,0.021"
+           id="polygon927" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 576.247,915.756 0.053,1.839 -0.055,-1.847 0.002,0.008"
+           id="polygon934" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1108.757,669.845 0.701,-0.203 -0.706,0.205 0.01,-0.002"
+           id="polygon935" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1015.811,630.463 -1.144,0.309 1.143,-0.321 v 0.012"
+           id="polygon941" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 961.359,718.064 1.276,-0.784 -1.277,0.801 0.001,-0.017"
+           id="polygon943" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 720.937,675.316 -1.658,0.955 1.659,-0.962 -10e-4,0.007"
+           id="polygon944" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1028.882,669.857 -1.515,-0.265 1.515,0.262 v 0.003"
+           id="polygon947" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 969.978,570.237 -4.024,-0.898 4.021,0.891 0.003,0.007"
+           id="polygon952" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1139.057,663.216 -0.133,0.459 0.129,-0.47 v 0.011"
+           id="polygon953" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 797.028,1230.538 1.179,0.454 -1.19,-0.454 h 0.011"
+           id="polygon955" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 998.41,644.281 -1.434,-0.093 1.433,0.086 10e-4,0.007"
+           id="polygon958" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 791.565,1229.063 h 0.01 l -0.7,0.099 0.69,-0.103"
+           id="polygon962" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1036.655,804.483 -0.646,-1.301 0.646,1.296 v 0.005"
+           id="polygon963" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1003.224,632.809 -1.453,0.088 1.451,-0.109 v 0.021"
+           id="polygon967" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 962.394,684.321 -1.487,-0.31 1.487,0.294 v 0.016"
+           id="polygon968" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 791.178,723.573 -1.333,0.722 1.333,-0.726 v 0.004"
+           id="polygon970" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1008.086,739.238 -1.718,-1.004 1.718,1 v 0.004"
+           id="polygon974" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 958.282,569.731 -1.192,-0.48 1.191,0.478 0.001,0.002"
+           id="polygon977" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 619.19,695.014 0.019,0.279 -0.031,-0.268 0.012,-0.011"
+           id="polygon981" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 827.969,827.063 -0.163,1.845 0.162,-1.854 0.001,0.009"
+           id="polygon982" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 743.924,772.825 -1.111,-0.401 1.11,0.397 10e-4,0.004"
+           id="polygon985" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1126.981,665.034 -0.184,0.645 0.18,-0.657 v 0.012"
+           id="polygon989" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 816.992,738.819 -1.639,0.438 1.634,-0.437 0.005,-0.001"
+           id="polygon994" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 796.625,1230.234 h 0.007 l 2.485,0.848 -2.492,-0.85"
+           id="polygon997" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1092.481,670.569 -0.837,0.504 0.834,-0.521 v 0.017"
+           id="polygon998" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 972.014,720.74 1.433,-0.559 -1.417,0.557 -0.016,0.002"
+           id="polygon1001" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1123.115,702.416 -0.427,0.658 0.426,-0.673 10e-4,0.015"
+           id="polygon1005" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 857.534,702.511 -1.314,0.552 1.319,-0.556 -0.005,0.004"
+           id="polygon1012" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1032.656,733.399 -1.137,-1.311 1.138,1.293 -10e-4,0.018"
+           id="polygon1013" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1023.75,602.534 -1.301,-0.763 1.297,0.751 v 0.012"
+           id="polygon1017" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 950.038,712.496 -1.671,0.172 1.672,-0.188 -10e-4,0.016"
+           id="polygon1029" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1138.031,724.9 -1.018,0.201 1.017,-0.212 10e-4,0.011"
+           id="polygon1030" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1144.674,662.33 -0.953,-1.459 0.944,1.442 0.01,0.017"
+           id="polygon1032" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1102.575,674.016 -0.26,-1.64 0.268,1.643 -0.01,-0.003"
+           id="polygon1039" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1011.24,659.97 v 10e-4 l 2.817,0.878 -2.822,-0.879"
+           id="polygon1043" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1115.398,715.32 -2.408,0.36 2.41,-0.36 v 0"
+           id="polygon1045" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 950.482,573.068 -1.54,-0.172 1.537,0.163 0.003,0.009"
+           id="polygon1046" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 709.461,703.377 0.466,-1.302 -0.453,1.294 -0.013,0.008"
+           id="polygon1048" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 880.005,716.851 -1.867,0.381 1.867,-0.394 v 0.013"
+           id="polygon1054" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 771.125,1223.443 1.037,0.593 -1.048,-0.595 h 0.011"
+           id="polygon1064" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1022.436,667.211 -0.038,1.093 0.036,-1.14 v 0.047"
+           id="polygon1081" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 778.543,1225.564 1.448,0.552 -1.456,-0.553 0.008,10e-4"
+           id="polygon1083" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 796.377,728.434 -1.275,0.741 1.274,-0.753 10e-4,0.012"
+           id="polygon1097" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1043.416,831.446 -0.086,1.636 0.078,-1.638 0.01,0.002"
+           id="polygon1098" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1017.135,637.856 0.431,0.993 -0.436,-0.993 v 0"
+           id="polygon1105" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 768.158,1222.793 2.08,0.792 -2.082,-0.792 h 0.002"
+           id="polygon1108" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1201.521,748.463 -0.604,-0.298 0.604,0.291 v 0.007"
+           id="polygon1109" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1105.665,711.608 0.013,0.006 1.788,1.018 -1.801,-1.024"
+           id="polygon1114" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 944.366,732.174 0.005,0.005 -0.107,1.896 0.102,-1.901"
+           id="polygon1116" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 976.016,686.287 -1.401,-0.151 1.402,0.127 -0.001,0.024"
+           id="polygon1147" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1090.154,667.508 -1.336,-0.314 1.335,0.312 10e-4,0.002"
+           id="polygon1149" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 910.384,716.857 -1.563,-0.522 1.563,0.509 v 0.013"
+           id="polygon1152" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1043.446,831.356 0.062,-1.375 -0.061,1.37 -10e-4,0.005"
+           id="polygon1167" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1240.502,968.457 -0.182,-0.022 0.183,0.019 -10e-4,0.003"
+           id="polygon1171" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 839.463,724.817 -1.431,1.268 1.431,-1.281 v 0.013"
+           id="polygon1186" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 685.235,813.403 -1.43,-1.1 1.432,1.068 -0.002,0.032"
+           id="polygon1188" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 573.376,942.355 0.072,1.385 -0.074,-1.386 0.002,10e-4"
+           id="polygon1189" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1247.323,900.722 -0.182,0.073 0.182,-0.077 v 0.004"
+           id="polygon1196" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 805.159,1233.359 3.894,1.163 -3.896,-1.163 h 0.002"
+           id="polygon1206" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 774.96,1224.532 0.668,0.522 -0.671,-0.524 h 0.003"
+           id="polygon1209" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 1108.448,720.966 -1.622,-0.875 1.622,0.859 v 0.016"
+           id="polygon1421" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 863.529,698.109 0.466,1.127 -0.479,-1.116 0.013,-0.011"
+           id="polygon1649" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 844.965,1235.294 -3.25,-0.729 3.301,0.73 -0.051,-10e-4"
+           id="polygon1833" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 882.033,1243.437 2.708,-0.04 -2.604,0.106 -0.104,-0.066"
+           id="polygon1857" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 836.684,1227.618 0.279,-0.383 -0.263,0.422 -0.016,-0.039"
+           id="polygon1858" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 856.21,1237.044 -1.603,-0.35 1.631,0.348 h -0.028"
+           id="polygon1862" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 807.966,1184.32 1.634,0.452 -1.638,-0.431 0.004,-0.021"
+           id="polygon1863" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 846.257,1062.711 0.25,-1.271 -0.271,1.392 0.021,-0.121"
+           id="polygon1864" />
+        <path
+           style="fill:#000080"
+           inkscape:connector-curvature="0"
+           d="m 855.764,1234.773 0.054,0.035 -1.105,-0.468 1.051,0.433"
+           id="polygon1865" />
+      </g>
+      <g
+         id="layer1-1">
+        <path
+           style="fill:#00ed00"
+           inkscape:connector-curvature="0"
+           d="m 819.353,587.924 9.754,-2.216 4.568,-2.369 5.829,-1.361 -0.81,-1.084 -3.542,-0.135 0.54,-0.895 5.403,-0.798 2.43,0.539 0.972,-1.083 9.278,-2.222 1.374,-1.538 7.689,2.227 6.042,-0.75 6.165,-1.634 8.078,1.012 -2.094,0.781 3.513,0.579 2.289,-0.238 2.849,-1.952 0.096,1.586 -1.13,-0.818 -1.497,1.164 4.954,-0.472 -4.772,0.565 11.07,0.716 -0.778,-0.676 4.011,-0.776 -2.005,0.053 1.688,-0.768 -1.542,-1.157 3.868,0.348 0.589,-1.032 3.425,1.292 4.36,-0.229 1.615,1.347 4.376,-2.42 3.822,3.601 -2.444,0.005 1.683,0.942 -1.959,0.077 0.515,1.406 4.288,0.756 2.287,1.774 4.246,-1.644 4.898,1.334 1.836,1.161 -1.422,0.467 4.677,1.742 4.677,0.003 -1.043,1.935 1.615,-0.338 0.1,1.113 2.406,0.725 1.468,-0.469 -2.048,-0.706 8.498,1.793 2.701,-0.232 -5.111,0.615 -13.943,-0.228 -0.015,1.939 -0.83,-1.234 -1.271,0.534 1.099,3.336 6.325,1.563 -2.532,0.386 3.277,2.032 -3.378,-0.481 1.188,1.812 5.223,0.175 2.574,-1.066 2.383,1.366 0.646,-1.376 0.291,1.008 5.122,1.284 -1.649,0.186 2.995,1.892 1.42,-0.028 -1.473,-0.832 10.582,4.3 2.488,-0.585 -0.146,1.163 3.509,-2.13 7.776,5.939 5.358,-0.959 1.035,-3.318 9.28,-0.919 -0.812,1.536 -4.286,-0.12 2.861,0.731 -7.007,-0.763 1.868,1.883 -0.532,3.432 1.775,0.979 1.504,-0.671 1.434,2.213 2.784,-3.038 0.846,2.742 -7.696,1.695 3.239,-0.313 5.766,2.208 3.21,-1.516 7.993,0.848 -2.492,-2.766 0.164,-2.134 2.694,-0.676 3.255,0.935 -0.051,-1.693 0.378,2.209 -5.585,0.564 2.854,2.469 5.395,0.084 10.251,4.314 0.423,4.17 -3.744,-3.979 -9.596,-3.156 -1.828,1.285 -10.365,-0.694 -2.43,1.113 -7.37,-1.217 -0.266,1.347 1.147,2.412 8.129,1.491 3.597,2.108 8.517,0.691 -0.708,-1.683 2.396,-1.247 5.086,1.804 -3.766,3.082 -0.031,-0.839 -1.698,6.531 1.943,1.169 3.841,-0.634 1.02,1.834 2.188,0.666 -3.405,0.348 3.134,2.936 0.433,2.762 2.369,1.301 v 2.308 l -3.537,-1.482 -1.161,-1.603 0.218,1 3.926,3.203 -1.537,-0.271 3.804,6.402 1.792,-0.135 0.051,1.907 3.829,1.744 0.219,2.53 -3.616,0.386 -1.852,-3.42 -1.819,-0.41 -3.745,3.58 2.505,-0.493 12.89,5.221 -3.654,1.685 2.424,3.595 2.406,2.967 5.538,1.223 -2.575,2.572 0.998,1.324 -1.229,-1.313 -2.512,1.613 2.171,1.737 3.155,-1.301 2.375,2.473 -5.583,2.267 -4.975,-1.667 -2.212,-2.373 -3.346,1.776 -0.368,-1.592 -5.209,0.61 10.02,-8.053 -4.667,-6.004 -6.378,-0.078 -8.257,3.482 -1.274,2.199 1.941,1.855 -2.543,-2.039 -0.91,1.745 -1.832,-0.842 0.789,-1.267 -1.883,0.733 1.539,2.138 -2.421,0.322 0.619,1.678 -3.467,-0.336 1.743,-1.734 -1.195,-1.984 -4.063,1.145 1.62,2.685 -2.383,-2.43 -1.526,0.592 3.118,2.656 0.067,1.049 -3.085,-2.05 3.49,4.575 -3.594,-3.415 -1.682,1.121 4.188,4.599 -3.565,1.128 3.517,1.302 -2.273,0.124 2.312,4.122 -3.111,-2.899 2.118,2.712 -1.891,-1.476 0.087,1.575 2.684,0.72 -2.789,0.771 3.311,3.42 -0.717,2.089 2.205,-1.412 -1.797,2.108 2.932,1.821 -2.771,-1.071 0.027,1.652 1.482,-0.124 -1.187,1.349 2.754,-0.124 -0.658,3.169 2.339,-0.808 -2.068,3.056 1.41,-0.011 1.377,3.708 1.032,-2.05 -1.064,2.917 1.868,0.319 -1.223,0.294 2.158,3.725 0.986,-1.608 -0.737,3.993 1.063,-1.491 -0.079,2.168 1.807,0.38 -0.467,1.43 -1.704,-0.909 1.587,6.052 1.925,-0.897 -0.676,-3.623 2.123,3.418 -1.413,2.121 -1.47,-1.055 -1.166,2.499 2.647,2.261 -2.215,0.318 2.508,0.566 -4.062,0.767 3.239,-0.367 -3.164,2.998 3.741,0.969 -1.952,-0.411 0.666,1.251 -1.685,0.281 1.391,0.243 -2.938,0.979 1.3,1.279 3.429,-2.106 -3.351,2.151 0.754,1.663 2.23,-0.567 -1.667,1.331 1.632,-0.681 0.095,1.827 2.282,-2.181 -0.388,-1.344 2.176,0.409 -0.817,-1.899 1.276,1.009 0.286,2.533 -2.187,-0.785 -2.799,2.869 1.8,-0.006 -1.104,1.169 1.706,0.813 0.359,-1.626 0.04,2.558 1.493,0.765 -0.293,-1.669 1.445,2.683 0.998,-5.11 -0.343,7.274 1.926,0.665 0.906,-2.786 0.276,3.269 1.766,-0.956 0.024,1.54 -2.287,0.117 1.994,2.171 5.218,0.647 2.054,-2.4 -1.306,-6.766 2.11,-1.071 -2.786,-4.334 7.249,6.331 0.638,-1.187 1.796,2.532 -1.002,-2.434 2.177,3.229 7.063,3.021 0.117,2.13 4.482,3.616 2.842,-2.5 -2.243,-4.431 2.64,-1.67 -4.187,-7.59 -5.025,-3.915 0.936,-0.915 -2.051,0.598 1.675,-2.851 -1.531,-1.947 2.14,1.139 -0.813,-3.338 -1.675,0.468 0.161,-3.051 -5.615,-1.681 -1.657,1.002 -9.752,-10.25 1.735,0.279 -1.254,-7.872 -1.901,-3.845 -4.803,-2.715 1.32,-0.222 -2.745,-2.035 1.836,-0.148 -1.559,-1.681 2.482,-2.583 5.124,1.479 5.594,14.85 7.125,3.945 3.655,4.084 3.381,-0.343 0.051,-1.601 2.373,2.524 2.647,-13.703 1.895,1.446 3.832,-1.736 -1.655,4.711 1.682,1.747 -4.028,3.046 -0.803,5.66 4.448,3.025 1.316,-1.469 4.778,4.611 0.183,2.561 -5.193,-1.27 -0.508,2.48 3.554,5.651 7.391,6.088 -1.271,1.426 -2.422,-4.38 1.961,3.735 -0.381,1.943 1.123,1.291 0.748,-1.2 0.113,4.028 -0.893,-2.816 -0.688,3.412 -3.645,-0.5 -3.003,9.734 1.414,2.217 -6.668,-0.954 -2.825,6.115 -1.111,-2.481 -1.963,2.084 -3.582,-1.171 -3.043,-4.422 0.193,-5.809 -2.852,0.139 -2.935,-5.631 -1.974,6.192 8.24,11.848 0.3,-1.19 2.42,1.213 -0.34,1.65 5.819,1.527 -4.085,0.282 1.549,2.842 -2.607,-0.75 -1.63,2.133 2.137,1.213 -4.502,1.784 -0.271,2.516 3.027,1.603 -0.595,2.387 -3.617,-2.438 1.47,6.31 2.562,0.193 -2.713,2.98 2.85,-0.46 -5.938,6.956 2.4,3.478 -2.366,7.288 -7.146,0.971 4.962,4.968 -3.848,2.871 -2.327,-1.499 -4.532,4.663 2.736,0.467 -1.662,0.542 2.139,2.291 7.343,-1.545 4.679,4.581 2.829,-0.239 1.269,3.635 0.837,0.481 3.96,12.573 -19.729,8.761 -3.086,-0.783 -4.484,6.611 4.216,3.011 3.899,13.056 -0.207,8.783 1.846,-2.098 0.01,3.811 2.445,-0.925 -0.88,0.496 2.053,8.069 8.253,-5.088 7.745,5.168 3.318,-6.241 8.956,-4.374 0.844,-5.566 2.498,-2.076 -0.941,-4.458 1.728,-3.695 -2.707,-1.233 -1.288,-3.489 0.79,-9.371 5.229,-9.042 -3.479,-4.578 -0.048,-3.191 1.612,-2.946 8.082,-1.377 3.381,-12.702 5.586,-0.673 7.643,5.994 20.187,1.105 5.224,4.53 1.057,5.701 1.454,-0.63 -1.372,-5.847 0.877,-2.616 -4.233,-1.814 -1.165,-4.354 2.906,-1.704 2.855,1.178 -0.745,-2.131 -10.836,-0.146 -1.025,-2.691 -3.971,2.608 -8.117,-4.81 -5.47,-0.491 -4.692,-5.364 2.199,-5.095 4.514,4.275 -0.205,-4.082 9.755,5.585 2.661,-1.707 4.047,0.687 -2.37,0.944 5.991,-1.785 4.32,1.188 4.098,7.515 8.342,3.373 0.606,-1.474 -0.146,2.123 2.459,1.336 5.363,-4.935 0.024,1.966 -4.377,2.807 0.598,2.495 4.765,3.396 0.289,-2.19 2.87,2.089 -1.004,-2.446 2.46,0.208 -4.753,-4.077 2.181,-1.592 -2.626,-0.689 0.583,-2.249 2.422,0.467 -1.633,-2.587 -5.698,0.958 0.61,-2.195 -1.44,-1.301 1.482,-0.304 -6.094,-4.012 0.127,-1.715 4.594,0.551 -1.914,-1.378 2.07,-0.866 -3.492,-0.996 1.865,-4.958 4.483,-2.854 1.034,4.493 -0.982,-7.932 2.422,-4.136 -7.445,-2.852 -0.62,1.227 -2.1,-8.28 -5.39,-7.123 1.293,0.827 0.265,-2.323 -3.931,-4.206 1.076,0.656 -0.667,-2.271 0.713,2.408 -0.925,-4.015 -1.761,-0.435 1.746,0.408 -1.574,-2.684 0.212,-4.538 2.283,0.466 -1.603,2.033 1.277,-0.751 0.404,1.323 2.753,-4.232 1.459,1.064 0.363,4.995 0.685,-2.131 3.793,3.068 1.514,-0.812 -1.182,-11.147 -0.915,3.453 -4.282,-1.647 4.36,1.726 -0.868,0.994 -2.904,-0.876 -1.813,-4.328 1.712,2.298 -1.49,-4.719 0.35,-11.057 2.093,4.007 -0.948,2.211 3.653,0.167 -1.224,-0.004 3.104,5.372 -0.108,3.24 14.264,-3.862 3.864,2.454 1.617,2.894 0.899,5.396 -1.491,5.278 -3.293,4.312 -4.934,0.431 -1.781,4.992 0.611,9.942 -3.654,5.164 1.723,1.615 1.414,-1.535 -1.273,3.024 1.069,1.244 -4.101,5.98 0.651,3.893 1.441,2.263 1.307,-2.868 2.82,4.847 1.56,-0.333 -0.463,2.03 -1.776,-0.979 1.083,2.449 2.947,-1.564 0.627,2.193 2.617,0.068 0.239,2.409 1.667,-3.529 -0.386,4.52 1.209,-4.083 4.686,-0.167 0.979,-2.458 -1.871,-3.67 0.874,-1.56 5.309,-1.174 0.98,-4.416 -1.117,-4.595 1.838,-1.023 -0.114,-3.755 3.852,6.779 3.906,3.74 7.961,19.893 -2.355,8.206 -1.749,-1.663 -1.683,2.505 -1.186,9.853 -5.89,3.536 -3.999,5.061 -1.788,-1.5 -4.277,4.084 -1.903,-1.735 -4.225,2.589 -1.846,8.425 3.573,6.798 -1.305,6.015 -4.854,-0.03 -7.294,3.519 -4.193,-3.593 -6.834,2.208 -3.217,3.176 -9.17,0.291 -1.66,-1.574 0.888,-8.271 -4.72,-3.109 -0.918,-6.39 -0.809,3.449 -3.945,-1.694 -4.514,7.03 -5.581,2.114 -2.476,4.813 -5.773,1.658 -9.088,8.344 -2.538,5.838 -3.321,2.541 -2.532,5.684 -3.526,1.524 -1.303,-1.588 -6.386,4.563 -4.634,-2.606 -1.643,1.551 -0.243,11.643 -8.097,12.79 -0.617,7.56 2.917,7.32 -1.394,5.331 -4.664,8.002 -6.17,4.219 -1.931,8.634 -3.454,3.917 -0.491,9.353 -4.202,6.566 0.902,-1.279 -4.517,14.269 0.182,5.628 0.745,-2.112 4.551,4.246 -1.143,5.268 3.949,8.356 -1.408,12.113 -4.596,6.636 6.066,3.167 0.336,2.784 4.971,-2.278 -4.082,2.647 -2.097,-0.581 0.232,4.841 2.949,-1.035 -2.932,1.938 4.198,-0.844 -1.716,1.85 2.775,-0.22 -0.425,1.531 5.396,-2.974 -2.99,1.979 2.661,0.01 -2.4,2.426 1.632,1.313 1.161,-1.352 -0.271,1.516 1.993,-1.456 1.728,4.16 5.159,0.594 -0.875,1.83 2.341,0.167 1.04,3.924 1.805,-0.745 -2.403,1.52 4.766,1.873 -0.207,2.066 7.11,0.645 13.833,4.998 6.508,-0.355 6.738,-6.046 10.429,-6.012 10.052,-2.305 15.036,-15.253 10.865,-8.83 -1.739,2.252 4.523,-2.562 2.998,1.157 1.206,-1.854 -1.116,2.037 2.02,-0.797 -1.544,1.271 0.867,0.36 1.296,-1.629 -1.204,2.744 2.951,2.432 3.024,-2.183 -0.019,-1.389 0.689,0.824 -0.477,-1.251 1.047,0.79 0.161,-1.98 1.198,0.676 3.805,-3.172 -0.319,-1.791 1.458,1.245 1.009,-2.1 1.814,2.781 1.983,-2.287 0.509,1.08 -1.147,0.86 1.909,2.236 -2.167,10.968 1.405,-0.593 -0.088,3.048 -1.408,0.775 2.689,-0.431 -1.915,2.026 -0.602,-0.994 -0.897,5.666 -1.724,1.06 3.454,5.29 7.568,2.846 1.105,4.32 1.731,-0.313 -1.547,1.808 2.713,6.288 -1.957,4.219 1.467,5.371 -1.945,5.687 -5.304,8.222 -5.803,11.838 -2.792,7.919 1.559,8.35 -6.358,11.245 -3.685,7.013 -1.985,2.07 -2.116,2.162 -2.541,2.546 1.689,-1.687 1.363,-1.38 9.078,-9.585 5.345,-5.998 7.068,-8.38 12.646,-16.45 7.146,-10.271 4.434,-6.79 6.635,-10.854 -0.713,1.209 0.058,-0.098 9.572,-17.275 3.885,-7.737 1.597,-3.323 1.654,-3.544 0.039,-0.085 4.035,-9.114 2.535,-6.112 6.399,-17.13 3.467,-10.626 1.988,-6.675 0.494,-1.737 1.418,-5.192 1.03,-3.989 -0.255,0.644 1.169,-6.125 0.616,-2.904 -0.288,1.049 1.021,-5.067 -0.229,-1.423 1.268,-7.94 1.829,-12.788 0.924,-5.294 -0.134,-0.709 0.508,-1.969 1.98,-21.236 1.074,-17.623 -0.126,-17.237 -3.468,-34.127 -0.943,-4.397 -0.204,-2.572 0.075,1.622 -1.697,-7.5 -0.139,1.199 0.816,8.241 -0.145,8.483 0.262,6.039 -0.468,1.588 -0.066,7.025 -2.343,-0.345 -0.359,2.823 0.048,-5.416 -0.661,-2.089 -4.754,-1.956 -1.436,2.148 -1.225,-1.374 0.484,2.546 -6.349,-9.656 -2.924,0.343 -5.157,-9.895 0.582,-0.043 -2.721,-3.159 -3.649,0.192 -2.592,-3.956 0.5,-0.987 -2.381,-0.552 -10.944,-10.29 -4.641,-2.085 -2.996,-4.005 5.147,3.964 3.817,0.504 -4.014,-10.821 3.486,8.027 1.022,-1.968 10.219,6.274 2.271,3.113 2.633,-0.888 3.985,3.905 2.994,5.897 4.432,0.48 7.243,6.774 2.438,7.387 4.358,8.632 0.839,-6.365 -0.521,-5.116 -0.116,-14.774 -0.836,-5.161 -1.771,-15.182 -1.47,-4.788 -1.956,-11.994 -1.703,-5.083 -0.738,-3.869 -1.876,-5.212 -1.264,-4.922 -2.521,-5.254 -1.063,-2.831 0.153,-0.346 -5.136,-12.131 -2.094,-1.528 0.221,3.928 -0.993,-0.254 -2.731,-3.395 -2.086,-3.766 7.037,17.661 0.3,5.049 0.83,2.947 -0.831,1.275 -4.237,-7.791 -0.112,1.781 3.339,6.119 -3.303,-2.648 -1.759,-3.29 -2.749,0.57 -5.204,-4.713 -0.143,1.27 -0.425,-2.372 -1.634,-1.376 0.323,-2.896 -1.148,-1.675 1.225,-0.568 -0.536,-2.56 6.601,4.69 0.603,-2.458 2.252,-0.671 0.126,-2.904 -2.959,-9.383 3.408,3.417 -2.057,-12.47 -7.87,-18.509 1.645,2.268 -0.891,-1.957 1.762,2.622 -1.613,-3.158 1.101,1.828 -1.718,-3.068 1.545,2.701 0.135,-0.075 -2.687,-4.765 1.483,2.551 2.858,5.137 -0.092,-0.236 -3.609,-6.36 -2.926,-4.939 -1.093,-1.799 1.481,2.445 0.65,1.085 -0.817,-1.364 1.518,2.545 0.55,0.934 2.6,4.511 6.636,12.281 5.964,12.158 3.278,7.235 0.076,0.173 -1.398,-3.145 -1.585,-3.466 -2.018,-4.275 0.045,0.093 -2.271,-4.645 -1.093,-2.174 -2.77,-5.348 -4.718,-8.628 -3.635,-6.277 -1.854,-3.09 -1.444,-2.36 -2.095,-3.347 -2.803,-4.354 -1.23,-1.867 -7.277,-10.543 -5.002,-6.795 -4.662,-6.039 -3.864,-4.806 -1.411,-1.713 -3.227,-3.835 -2.094,-2.43 1.404,1.624 -2.511,-2.89 0.471,0.537 -1.477,-1.677 0.548,0.62 -1.782,-2.006 0.15,0.168 -2.041,-2.262 1.066,1.177 -3.334,-3.645 1.645,1.785 -1.004,-1.092 -1.522,-1.639 -1.958,-2.079 4.782,5.137 -2.021,-2.197 1.634,1.772 -1.162,-1.263 1.091,1.185 1.364,1.498 0.537,0.595 -2.032,-2.235 4.587,5.101 5.891,6.858 -1.819,-2.157 1.863,2.209 -1.383,-1.643 0.394,0.465 -1.593,-1.875 0.485,0.568 -2.239,-2.601 -1.954,-2.229 -0.761,-0.857 0.244,0.274 -2.106,-2.349 -2.24,-2.453 2.213,2.423 -1.088,-1.197 5.504,6.171 3.578,4.174 -1.587,-1.867 2.743,3.246 3.377,4.107 -0.118,-0.145 4.105,5.165 2.052,2.658 -1.521,-1.975 7.49,10.021 -1.29,-1.779 2.979,4.148 5.949,8.685 3.105,4.767 1.196,1.884 -1.788,-2.805 0.374,0.583 -3.102,-4.751 -5.252,-7.678 -1.977,-2.779 -1.963,-2.705 1.041,1.427 -5.597,-7.504 1.305,1.711 -3.296,-4.284 -7.752,-9.565 -3.58,-4.194 -2.861,-3.258 3.179,3.624 -2.163,-2.478 0.055,0.062 3.528,4.069 -1.879,-2.182 2.179,2.533 -1.202,-1.404 0.074,0.086 4.701,5.581 -0.732,-0.885 -3.853,-4.56 -1.498,-1.732 0.305,0.351 -1.596,-1.825 0.465,0.529 -0.86,-0.978 -0.398,-0.45 -0.173,-0.195 -0.53,-0.595 -0.999,-1.115 -0.261,-0.289 -6.938,-7.47 -5.167,-5.291 -0.597,-0.597 -8.996,-8.66 -2.193,-2.02 -0.131,-0.119 -4.435,-3.977 -4.473,-3.876 -3.124,-2.63 -1.814,-1.499 -0.302,-0.248 -0.915,-0.746 -1.692,-1.368 -3.155,-2.503 -1.883,-1.465 -1.635,-1.257 0.596,0.456 -2.542,-1.932 0.265,0.199 2.974,2.268 2.276,1.771 -0.893,-0.697 -5.052,-3.863 0.756,0.569 -4.202,-3.123 -1.281,-0.932 -1.211,-0.874 -1.281,-0.915 -0.674,-0.479 -2.873,-2.012 1.452,1.012 -1.681,-1.169 0.16,0.11 -3.581,-2.446 1.523,1.033 -1.009,-0.686 -2.649,-1.775 1.06,0.705 -2.587,-1.713 0.498,0.327 -3.351,-2.178 -1.957,-1.248 -0.261,-0.165 -2.488,-1.558 -1.821,-1.122 0.549,0.337 -3.766,-2.28 -0.317,-0.19 -2.184,-1.29 -1.452,-0.846 -0.817,-0.472 -1.459,-0.835 -0.562,-0.319 -2.197,-1.235 0.5,0.279 -3.089,-1.708 -2.436,-1.318 0.63,0.338 -0.695,-0.374 -1.065,-0.568 -0.476,-0.252 -7.664,-3.938 -0.415,-0.207 -3.168,-1.554 -1.499,-0.722 -2.033,-0.964 -0.354,-0.166 -1.572,-0.733 -1.851,-0.851 1.895,0.871 -3.692,-1.684 -0.036,-0.017 3.401,1.55 -7.919,-3.54 -1.573,-0.676 1.368,0.587 -3.65,-1.551 -1.485,-0.617 -6.289,-2.524 1.396,0.548 -1.446,-0.568 -7.5,-2.827 -0.526,-0.191 -1.426,-0.513 -2.382,-0.841 -5.283,-1.797 -1.014,-0.334 -2.846,-0.92 4.002,1.301 7.761,2.676 -3.36,-1.184 3.022,1.063 -2.889,-1.017 -4.617,-1.566 -12.911,-4.005 -3.887,-1.1 1.023,0.285 7.731,2.261 -2.283,-0.688 5.384,1.649 -12.912,-3.797 -4.636,-1.233 4.858,1.294 -0.294,-0.08 2.074,0.573 3.027,0.861 -1.498,-0.43 1.513,0.434 -1.313,-0.377 -1,-0.283 -1.047,-0.294 3.997,1.14 -0.47,-0.137 2.395,0.704 1.078,0.323 -1.595,-0.477 2.742,0.824 -1.004,-0.304 6.751,2.111 1.576,0.515 0.94,0.311 0.983,0.328 -4.087,-1.343 1.504,0.488 -2.682,-0.865 0.942,0.301 -1.959,-0.623 -0.249,-0.078 -2.709,-0.838 -0.173,-0.053 -6.121,-1.803 -5.204,-1.438 -5.89,-1.524 -0.055,-0.014 -2.858,-0.7 -11.167,-2.492 -4.633,-0.922 -5.078,-0.937 -1.738,-0.303 -0.873,-0.148 -5.217,-0.841 0.15,0.023 -8.792,-1.24 -20.233,-1.996 -17.772,-0.78 -8.152,-0.028 -4.102,0.266 3.482,0.239 -2.113,-0.027 -0.775,0.111 6.121,0.366 3.883,0.031 0.295,-0.126 4.651,-0.079 -1.686,0.285 3.544,-0.133 -0.419,0.385 3.872,0.121 1.679,0.262 -10.753,0.522 -13.685,2.355 -9.958,0.68 -1.256,-0.205 -1.235,0.414 -7.653,0.429 -1.092,0.669 -9.322,0.581 3.606,-0.604 -1.013,-0.147 -11.372,2.075 1.067,0.172 2.502,-0.462 0.239,0.438 -4.721,2.919 -9.445,2.656 0.379,-1.13 -0.616,-0.29 -1.611,0.527 -0.207,-0.575 -3.873,2.52 -2.517,0.68 2.007,0.805 -3.105,1.157 -2.268,0.32 2.535,-1.079 -2.203,-1.613 4.265,-1.729 6.227,-4.381 4.267,-1.049 1.107,-1.228 -0.662,-1.019 -9.761,-0.127 -4.697,1.413 1.532,-0.009 -5.512,1.283 2.013,0.156 -6.096,1.927 2.73,0.409 -3.814,1.113 4.406,-0.05 -1.155,0.74 4.783,-1.002 -0.974,2.766 -2.144,0.758 -1.676,0.05 -2.373,1.724 -1.559,-0.476 -0.566,1.072 -5.442,2.185 -4.585,0.584 0.714,0.541 -3.711,3.864 -5.858,4.313 -5.396,2.134 0.486,0.78 8.799,-0.41 -0.937,-0.185 3.482,-0.323 2.043,-1.694 0.607,0.307 2.258,-0.978 -8.833,4.509 0.262,1.83 3.088,0.533 -1.571,0.998 -3.32,-0.686 -3.377,2.195 -4.936,0.756 -5.021,1.933 0.565,0.525 -1.808,0.065 -0.981,1.204 3.173,-1.066 -0.73,1.461 1.744,0.23 2.457,-1 -4.281,2.254 2.18,-0.322 -2.369,0.977 0.799,1.301 6.592,-1.971 3.884,-2.105 1.385,-1.139 -4.794,0.164 8.265,-0.378 13,-3.345 0.024,-0.009 m -43.586,639.285 1.355,0.512 -0.11,-0.041 4.8,1.762 0.923,0.33 -1.976,-0.71 0.272,0.099 -2.094,-0.765 4.208,1.521 1.051,0.37 5.605,1.912 3.123,1.021 -2.56,-0.833 -2.222,-0.742 2.234,0.745 -2.061,-0.687 3.01,0.998 -1.802,-0.594 1.823,0.601 1.435,0.466 0.09,0.028 5.032,1.576 -1.179,-0.362 -4.339,-1.37 -5.023,-1.679 0.999,0.245 4.881,1.478 -1.577,-0.878 2.932,0.572 -3.303,-1.135 2.156,0.566 1.849,0.722 1.646,0.331 -1.64,-0.771 -2.298,-0.452 -3.029,-1.113 -2.123,-1.5 5.859,2.026 5.564,1.339 -2.116,-1.922 1.468,0.463 -2.359,-1.205 5.764,1.706 11.071,2.087 3.855,0.319 2.74,-0.933 -0.869,-0.893 -3.446,-1.174 0.156,-0.906 -7.493,-2.867 -0.838,-2.323 0.967,1.581 3.351,1.569 8.601,2.383 9.494,1.25 6.406,-1.658 0.714,-2.198 5.141,-2.043 -1.298,-0.91 4.077,1.438 -6.702,2.396 5.931,-1.151 4.68,-3.202 4.586,-1.18 0.99,-3.082 -2.216,-2.219 2.223,-1.607 -2.216,-0.714 2.92,0.521 3.227,-1.734 6.352,-1.558 5.354,0.156 5.408,-2.106 4.817,0.587 2.61,-1.013 0.221,0.853 5.826,0.207 0.257,-1.296 5.49,-1.412 -0.512,-1.454 7.188,-5.66 0.646,-3.878 3.275,-2.229 1.853,-16.918 0.93,-0.938 1.291,1.567 2.413,-1.331 19.036,-17.485 0.963,-4.987 -2.72,-6.901 -2.144,-1.478 -9.309,-0.217 -8.04,-5.356 -9.433,-3.771 -13.653,-0.074 -7.082,-2.598 -8.476,4.201 0.398,-3.261 2.361,-1.17 -3.814,0.303 3.064,-1.634 -2.139,-3.015 -2.464,1.856 -0.541,-2.469 -1.183,0.817 0.643,-0.971 -1.697,0.534 -1.782,-1.89 -0.968,1.126 -0.304,-1.936 -0.913,0.973 -5.727,-2.831 -0.459,1.04 -4.156,-1.146 -2.654,3.449 2.585,0.642 -2.29,0.504 -1.25,-1.549 -4.993,3.98 1.202,-2.846 -6.97,0.266 9.28,-1.048 3.07,-5.276 -11.766,-2.179 -2.759,3.942 -0.21,-2.191 -2.476,1.745 -0.247,-2.258 -2.462,1.9 2.322,-3.936 8.496,-5.004 -1.443,-0.219 1.251,-2.257 -4.995,-2.465 -3.061,-10.896 -1.461,-1.068 -0.682,1.735 -3.685,-4.927 -10.996,-6.378 -17.41,-2.897 -6.709,-6.771 -2.119,2.158 1.43,-4.588 -3.076,-3.91 -6.525,-5.075 -3.688,-0.613 0.407,-4.375 -4.214,-3.528 -3.952,-0.573 -2.823,-3.736 5.833,-0.452 -13.256,-3.202 3.312,1.887 h -7.926 l -6.106,-5.063 -10.207,-2.477 -1.029,-4.15 -6.262,-3.805 -1.603,-4.601 -1.473,2.576 2.276,0.509 -0.084,1.429 -1.725,-1.408 -7.945,1.191 2.293,6.754 -0.455,2 -3.412,0.051 -1.754,-4.794 3.332,-3.509 -1.437,-5.246 4.681,-0.882 -2.556,-3.295 -8.889,2.856 -4.307,-2.117 -0.891,1.479 -2.724,-1.82 -2.244,0.673 -2.596,2.426 -0.016,3.775 -6.914,1.552 0.466,3.656 -4.634,-8.715 -4.909,-4.937 -3.012,-1.867 -7.212,0.46 -3.431,-4.018 0.317,1.519 -2.008,-1.463 -5.497,-16.041 5.778,-13.965 0.18,-5.337 -6.057,-8.191 -12.99,-6.973 -2.814,-3.325 4.169,-3.541 2.412,-6.997 -1.145,-0.97 2.031,-1.561 -0.138,4.113 3.703,-6.256 -1.154,-1.318 6.329,-6.306 -4.702,-5.157 -8.945,-2.888 -4.345,7.638 -4.458,2.404 -2.449,-3.56 -8.119,-2.993 -1.533,-5.735 -2.204,-2.045 -0.023,-23.132 0.677,-3.049 4.06,-9.801 1.763,-3.586 1.549,0.344 -1.247,1.749 3.23,-3.709 2.181,-7.511 -1.004,-1.155 1.214,0.86 2.628,-3.686 2.993,0.886 -0.096,-2.188 1.894,2.306 -1.137,0.167 4.71,0.125 1.987,-2.979 1.216,2.271 -1.414,0.176 3.66,0.925 0.7,-1.681 -0.644,1.625 4.435,4.967 2.331,-0.249 1.478,6.522 2,-0.291 0.644,1.979 0.708,-2.488 1.261,1.6 -0.052,3.903 2.041,-0.324 -1.596,-3.867 2.368,-0.513 -3.23,-4.766 8.046,5.312 1.549,-2.149 -0.129,2.712 -1.248,0.184 4.444,0.434 -1.168,1.03 3.907,1.615 -1.383,-0.214 3.24,2.703 -0.573,4.065 5.338,0.159 1.548,2.415 1.939,8.245 -2.871,4.964 1.931,0.639 -2.058,1.909 0.286,3.857 1.561,0.504 -0.842,6.483 2.307,3.555 -1.033,2.31 2.335,0.963 -0.418,1.147 5.435,-8.992 2.18,-27.886 5.775,-3.518 -0.015,-1.902 0.303,1.793 10.463,-4.546 12.132,-1.452 -2.351,-1.888 2.592,-0.499 -1.645,-2.26 3.032,2.493 2.34,-0.893 0.242,-2.204 -1.426,1.499 0.627,-1.99 -2.828,-0.944 2.877,-1.078 1.165,2.064 0.743,-3.966 -0.323,6.114 0.598,-7.333 -3.178,-3.642 1.912,1.929 -0.581,-3.227 0.555,2.182 1.496,-1.399 -1.502,-3.548 1.354,3.164 1.114,-1.362 -3.208,-4.589 1.118,-1.59 2.082,5.195 1.596,-7.443 3.513,-0.214 -3.487,2.966 0.901,6.279 -3.071,4.28 6.323,-5.686 1.066,-8.324 0.842,5.645 4.788,-3.361 0.895,-4.537 3.882,-1.863 8.848,1.545 1.274,-2.517 0.048,2.42 5.28,0.74 0.403,-2.422 -1.775,1.506 -1.445,-4.877 5.931,-6.535 1.888,0.531 0.693,-2.005 1.886,1.709 2.991,-3.693 -0.732,2.051 2.789,-0.814 0.198,1.714 5.245,-1.369 -0.111,-2.67 2.475,1.881 9.74,-2.271 -3.354,2.512 6.191,1.59 -3.488,1.287 -0.943,-2.398 -7.864,2.957 -1.541,3.987 2.148,2.906 6.63,-5.133 2.382,1.538 0.451,-1.744 10.157,-0.23 1.613,-0.427 -2.881,-4.25 -5.689,-0.417 -4.45,-5.122 1.081,-4.51 -2.352,-0.681 3.697,-3.559 -3.605,0.205 0.01,-1.965 -3.383,-1.567 5.749,1.649 4.201,-1.333 0.268,-4.309 -5.47,-2.277 -8.388,0.891 -14.818,6.398 6.774,-3.667 0.813,-2.872 11.561,-2.774 5.241,-4.354 23.496,6.498 5.992,-4.823 6.528,0.351 5.489,-3.027 -1.525,-2.484 2.225,0.439 -3.049,-1.53 2.748,0.573 -1.205,-1.672 2.065,-2.678 -1.758,-3.081 -3.601,1.505 1.595,-2.813 -3.129,-2.452 -10.475,3.696 9.761,-3.784 -4.41,0.188 8.49,-1.49 -2.622,-1.557 1.104,-0.874 -3.597,-0.144 0.351,-1.916 -1.55,0.784 1.136,-1.393 -3.268,2.271 2.411,-1.97 -1.965,-0.142 1.075,-1.141 -3.609,1.275 2.606,-4.204 -1.525,1.029 0.709,-1.436 -3.421,-1.784 1.854,-1.116 -2.224,-0.581 1.511,0.044 -1.66,-1.585 1.921,0.084 -2.349,-1.937 2.434,1.473 1.863,-2.46 -2.834,-3.104 2.221,-0.29 -1.79,-2.276 1.169,-1.171 -3.107,0.398 3.399,-2.185 -3.477,0.194 3.055,-1.648 -0.108,-2.177 -2.703,-0.543 2.367,-0.417 -2.011,-5.604 1.405,-0.934 -1.044,-1.074 -3.312,2.822 0.648,2.412 -2.32,-0.016 0.713,1.598 -2.706,0.561 -0.917,3.079 0.178,-3.538 -5.682,3.347 0.438,-3.405 -3.35,2.48 2.88,-3.869 -5.276,-1.876 1.857,-1.091 0.172,1.64 2.165,-2.438 -1.423,-0.508 1.804,-3.38 -2.84,-1.564 3.38,1.107 2.91,-5.146 -1.724,1.038 -3.418,-3.527 1.464,-2.336 -1.889,-0.485 -0.756,-6.062 -3.107,1.039 -5.134,-5.468 -2.799,0.754 -0.769,4.371 -4.189,2.863 1.872,0.561 -1.816,4.371 -7.862,5.173 1.957,5.364 -3.793,9.128 -6.372,4.258 -7.843,0.343 0.54,3.47 -4.139,11.1 -3.292,1.521 -1.223,3.418 0.143,-3.302 -2.927,2.112 -2.123,-2.11 1.513,-2.162 -0.954,-9.25 7.362,-11.245 -6.965,-4.888 -4.813,-19.038 -5.769,-1.491 2.554,-1.335 4.259,-7.463 -1.704,-1.911 -1.723,1.592 1.474,-4.04 6.661,-5.931 7.869,-2.924 0.292,-1.497 5.746,-0.046 0.201,-1.928 1.494,1.685 2.919,-0.584 0.377,-3.752 -1.968,-0.315 1.381,-0.641 -2.032,-3.102 1.539,-1.029 1.878,7.567 4.177,-2.199 3.189,2.487 6.177,-2.889 -3.382,-8.282 2.035,1.079 1.329,5.898 5.951,-1.939 -0.003,-2.699 3.533,5.063 0.632,-4.9 2.189,1.339 -1.229,3.154 8.024,-2.761 1.238,-5.827 3.103,0.457 -0.416,-1.829 2.379,-0.729 -1.777,-3.277 1.741,-0.05 -3.903,-3.51 -3.325,5.631 -1.385,-0.957 -7.137,5.058 -2.527,-0.126 6.496,-8.391 -0.19,-2.497 -5.912,3.297 3.526,-5.993 1.909,0.755 -2.306,-3.622 3.184,-1.573 0.813,1.126 4.802,-9.818 -7.918,2.026 0.436,1.294 -4.571,2.643 1.223,4.995 -1.426,-0.814 -3.097,1.765 2.235,-0.094 -1.514,2.099 -5.026,-0.386 -3.949,3.648 -0.113,-2.581 4.648,-2.47 -2.381,0.155 1.861,-0.813 -0.263,-1.826 -2.16,-1.289 -1.595,2.523 1.217,0.949 -2.177,1.477 1.273,-3.739 -2.404,1.117 -3.941,-4.223 1.288,-3.242 -1.615,-2.108 3,-4.11 -5.813,-1.355 0.532,2 3.856,1.058 -6.314,-0.471 -2.441,3.396 -1.674,1.002 0.101,-1.451 -2.667,2.786 2.507,-4.207 1.658,0.111 2.112,-5.13 -3.209,-1.55 -1.398,-4.986 2.027,-1.251 1.962,1.339 1.941,-2.771 -1.07,-2.892 3.378,-8.726 -3.371,-2.395 4.901,-1.912 -5.25,0.455 6.945,-5.758 -2.461,1.529 -4.888,-3.27 5.431,0.127 -4.967,-3.173 -0.476,-1.482 2.676,-1.029 -2.565,-1.396 -3.365,1.739 11.077,-12.417 6.139,-10.183 2.105,-1.748 1.307,0.371 1.145,-2.278 2.636,-1.027 -1.19,-1.094 1.77,0.531 1.969,-1.009 -1.483,-1.6 1.417,-2.098 -2.239,-0.347 1.767,-0.238 0.353,-2.131 -3.93,-2.81 2.352,-2.679 -1.645,-0.964 -6.842,2.954 -3.05,0.476 -3.026,2.622 -2.583,0.196 -1.921,1.718 1.641,-1.846 3.567,-1.138 -5.768,1.806 3.303,-3.587 3.298,-0.769 1.369,-4.946 -5.059,2.577 0.99,-1.214 -3.754,0.924 -5.387,4.233 1.139,0.028 -2.012,0.512 0.97,1.431 -1.901,1.393 -0.4,-1.029 -3.685,1.3 -1.148,-0.521 1.864,-1.752 -0.995,-1.366 2.662,-1.684 -4.809,-2.246 -2.73,0.955 -1.097,1.193 -0.39,-0.472 -3.707,2.772 1.036,-1.649 -3.766,0.878 -1.807,3.022 -5.813,1.746 -1.066,-0.757 -0.962,2.819 -5.39,3.104 2.909,0.007 -2.964,1.062 -0.003,2.06 -1.95,-0.688 -4.393,1.115 -0.615,-4.355 -2.437,0.66 3.293,-3.046 -1.692,-1.921 0.175,0.521 -1.099,0.865 1.635,-0.5 -2.108,1.48 1.5,0.232 -1.761,0.908 -0.313,2.213 -1.653,0.718 3.881,5.271 -0.308,2.28 2.187,1.019 1.917,-1.866 1.708,-0.325 5.66,4.372 -0.696,2.369 -0.835,-1.266 -2.86,2.385 2.59,-2.813 -0.51,-1.49 -4.222,0.202 -0.9,1.69 -2.194,-0.782 0.155,3.173 1.561,-0.352 -1.443,0.669 1.981,-0.323 -1.861,2.07 2,0.292 2.493,-1.849 1.569,1.209 -2.156,0.267 1.354,0.244 -1.564,0.596 0.426,1.614 -0.801,-0.48 -1.002,1.367 -0.209,-0.926 0.053,0.979 -1.83,0.642 -0.838,1.992 -2.699,1.816 -1.327,5.241 -2.957,2.883 1.475,0.91 -1.613,1.672 -1.076,-0.363 2.342,-1.174 -2.184,0.117 -8.299,8.943 0.671,0.963 3.905,-3.44 -1.939,2.275 1.63,-0.547 -3.657,1.963 -0.979,2.003 6.53,-3.144 -5.826,3.446 -1.15,1.729 1.649,0.143 -2.393,0.357 -1.211,2.363 -0.399,-0.73 -1.541,2.095 1.268,-2.121 -1.951,2.1 -0.795,-0.684 -5.137,6.776 -3.197,0.102 2.48,1.245 -1.769,1.607 -4.938,2.222 2.774,0.158 3.125,-1.182 -4.405,1.785 -0.475,1.406 -1.616,-0.896 -1.747,1.985 1.72,-1.984 -1.414,0.673 -0.712,2.526 -1.346,-0.529 -2.833,3.465 3.123,-0.308 -2.225,1.083 -0.211,1.674 0.184,-2.178 -3.834,5.064 -2.228,-0.069 1.178,0.247 -1.569,1.317 2.418,0.68 -4.235,0.394 -1.677,1.617 1.122,0.386 -1.808,-0.214 0.267,1.676 -1.025,-1.2 0.369,2.673 -1.033,-1.59 -0.032,3.507 -0.563,-0.66 -0.636,1.383 1.609,0.744 -1.931,-0.73 -0.83,2.146 1.481,-0.377 -1.318,0.564 0.053,1.259 2.458,-0.885 -2.935,1.314 1.122,1.251 -2.492,0.455 -1.046,2.253 2.125,-0.357 -1.99,2.35 -1.078,-0.478 1.188,1.413 -3.104,2.322 -0.874,2.63 -5.458,5.13 -2.427,-0.234 2.288,-0.556 1.87,-1.808 -2.918,0.616 3.755,-1.721 0.196,-5.942 -6.313,6.459 0.357,0.825 -3.22,1.708 0.186,1.867 -0.336,-1.548 -14.688,10.719 -5.461,6.664 -4.156,2.776 -5.567,7.915 -3.107,5.822 0.72,2.084 -2.047,3.167 0.97,-2.838 -2.214,2.688 -6.065,14.026 -1.981,2.43 0.134,8.958 -1.417,6.905 -8.764,21.274 -1.398,11.387 -1.898,1.836 -0.203,2.215 -1.315,-3.972 -0.693,9.451 1.438,0.261 -0.86,7.392 -3.068,6.232 0.338,12.267 -0.905,4.308 1.756,0.383 1.265,-5.412 -0.904,-4.318 3.999,-12.856 1.16,-10.015 1.664,-3.685 1.922,-12.913 5.131,-9.759 0.57,9.021 -5.069,13.395 -1.042,8.354 0.894,2.3 -1.581,2.673 0.095,9.518 -2.109,1.902 1.22,7.446 -0.904,2.213 0.417,15.347 -1.147,9.611 -2.213,2.257 0.33,1.911 -1.401,-0.646 -0.309,2.459 1.874,15.281 3.554,6.935 1.312,6.381 11.271,22.729 8.161,4.45 7.976,20.353 9.989,12.351 -0.87,-1.265 5.379,2.94 -0.1,2.826 -1.58,-1.017 6.581,15.146 -1.318,0.079 1.124,1.401 -0.732,4.408 2.121,3.326 1.254,-0.718 -1.454,-3.381 2.074,3.002 4.183,7.733 -0.152,3.18 1.248,1.053 -0.229,-2.085 1.717,4.887 0.948,-1.019 4.217,3.072 0.825,3.176 2.202,0.143 0.386,3.991 2.088,0.971 2.209,-0.266 -1.836,-4.813 6.906,-0.673 2.739,5.148 1.761,0.48 -1.897,1.713 4.654,9.52 -1.962,11.085 2.385,2.604 -0.596,1.12 -3.277,3.201 -3.851,-0.858 0.06,3.311 -2.41,-0.613 0.446,2.977 -5.495,-1.541 0.647,3.207 -2.571,1.23 1.057,1.863 -2.926,0.156 0.208,5.891 3.091,3.516 1.639,-1.438 0.827,2.136 -1.2,2.786 -5.547,0.822 2.331,7.134 -1.245,0.636 5.74,6.305 5.397,8.672 8.238,15.768 8.595,11.568 -0.504,1.5 2.97,3.886 4.403,4.479 19.735,14.308 6.939,6.171 2.507,5.526 1.876,4.663 -0.35,5.206 3.25,5.655 0.098,7.394 2.663,2.856 -0.882,0.839 5.603,6.795 0.147,3.982 -1.709,-0.534 6.375,4.28 0.437,1.015 3.066,1.541 -0.656,-0.216 2.494,0.952 1.68,0.741 0.72,0.212 -1.175,-0.275 2.608,1.166 0.225,0.201 -1.818,-0.814 2.027,0.932 -1.478,-0.639 1.098,0.677 2.229,0.987 -1.274,-0.495 3.545,1.503 -1.945,-0.798 3.172,1.321 -2.498,-1.037 0.438,0.184 1.272,0.529 0.094,0.039 -1.662,-0.692 -2.015,-0.853 1.579,0.669 -1.267,-0.536 0.215,0.092 -0.745,-0.317 -1.575,-0.678 -1.152,-0.502 2.247,0.974 -0.36,-0.154 -2.021,-0.879 1.593,0.694 -1.261,-0.549 1.771,0.768 0.825,0.354 2.189,0.927 1.934,0.804 -1.668,-0.692 2.257,0.936 -2.554,-1.06 3.433,1.419 2.519,1.014 -1.801,-0.723 1.683,0.676 -5.029,-2.05 3.589,1.472 -1.67,-0.679 1.457,0.593 -0.299,-0.121 1.039,0.419 2.142,0.853 -2.502,-0.998 2.488,0.992 -3.084,-1.232 2.816,1.126 0.285,0.113 1.12,0.438 1.17,0.455 -2.918,-1.143 2.225,0.873 -0.451,-0.176 2.23,0.861 -0.379,-0.145 1.136,0.433 -1.065,-0.406 2.845,1.076 -3.148,-1.192 1.442,0.551 -0.403,-0.153 2.56,0.963 -1.048,-0.392 0.163,0.062 -0.478,-0.18 -0.23,-0.087 -2.606,-0.996 0.643,0.248 2.621,0.995 -1.34,-0.506 h -0.005 m 109.893,-447.266 1.921,-1.96 2.856,1.73 -3.098,-2.886 4.038,0.197 -1.885,-1.586 2.515,-1.306 -2.707,-0.486 2.909,0.323 -1.734,-1.433 2.515,-0.84 -1.941,-0.638 2.485,-0.537 -1.839,-0.413 2.251,-1.289 -2.396,-2.977 2.367,0.831 -2.743,-2.156 3.853,-0.309 -0.839,-2.427 2.182,1.13 -1.635,-2.332 2.134,0.993 -1.236,-1.087 2.338,-0.497 -2.041,-1.585 2.689,0.993 -0.184,-2.356 -2.602,-0.835 3.25,-0.48 -1.996,-4.412 2.347,0.857 0.74,-3.208 4.379,-0.322 0.645,-4.426 1.778,0.551 -1.499,2.471 1.545,0.634 -0.233,-1.95 0.711,1.319 3.405,-1.583 -0.873,-1.749 2.73,0.534 2.894,-7.64 2.524,-1.586 -1.748,-3.684 2.593,2.821 3.438,-0.664 -0.106,-1.605 1.485,1.009 6.124,-3.302 6.643,-9.024 -6.806,-0.46 -3.634,3.09 -2.622,-0.472 3.72,-2.487 -5.435,0.814 1.792,-3.938 2.472,0.802 2.161,-2.144 -6.094,-0.528 1.901,-1.11 -2.262,-1.232 7.839,2.244 3.849,4.091 1.023,-2.426 0.826,2.017 1.696,-0.655 -2.555,-2.361 0.292,-2.446 -1.464,0.456 0.724,-1.622 -2.068,1.007 0.619,-1.708 -4.556,-1.804 -1.141,1.833 0.051,-1.492 -1.92,0.352 2.974,-1.002 -1.671,-1.384 -2.04,1.787 -1.87,-1.367 3.808,-1.792 -4.604,0.411 2.201,-0.904 -2.006,-1.058 2.61,0.956 1.816,-1.706 -2.438,-1.903 2.745,1.681 0.123,-1.443 3.472,0.349 -3.18,0.288 3.539,1.567 2.872,-1.84 -0.56,-1.898 -2.677,-0.487 0.609,2.094 -1.812,-1.808 -0.387,-2.79 4.527,0.926 0.526,-1.443 -3.527,-0.047 -0.134,-2.08 -2.941,-10e-4 2.772,-0.674 -3.505,-1.106 5.041,1.065 -0.866,-2.896 -4.034,-0.361 2.518,-1.573 -2.924,0.394 -2.11,-2.069 5.642,-1.877 -1.286,-2.327 -3.788,-0.156 1.98,-1.446 -2.646,-0.82 -0.696,1.858 -0.679,-2.173 0.72,-9.443 -2.285,1.731 -0.915,-1.516 3.419,-2.875 -4.947,0.981 5.189,-2.944 -0.684,-4.064 -3.535,0.155 -0.187,2.464 -2.586,-0.137 -1.493,5.349 -0.944,-7.125 -3.116,3.669 0.624,-2.829 -6.7,1.547 0.988,-1.784 5.758,-0.617 2.21,-2.564 -3.982,0.046 -0.053,-1.802 -7.48,2.767 1.331,-2.096 5.52,-1.366 -8.482,-0.15 -0.58,3.519 -3.256,-2.454 -1.383,1.472 3.524,1.065 0.196,1.618 -4.301,-2.05 2.319,2.591 -1.92,-0.212 -0.027,2.291 -4.628,-3.911 0.089,4.21 -2.416,-2.093 -1.46,1.532 0.815,-3.256 -4.464,0.533 1.097,3.532 -1.148,-2.742 -1.839,-0.109 -1.732,3.407 -0.987,-1.285 -0.789,2.084 0.054,-1.862 -5.015,2.33 -0.388,1.388 3.241,0.513 -4.763,3.832 -3.33,-0.708 -6.816,2.035 1.94,4.619 4.04,0.652 -0.906,1.572 -3.461,-1.288 2.847,1.849 -6.115,-1.916 3.036,3.181 -2.871,0.438 0.431,1.95 2.199,1.712 0.073,-1.81 1.613,1.751 3.569,-0.873 2.854,1.88 3.948,9.185 -2.59,1.866 2.256,-0.491 -1.332,6.149 1.63,3.283 -2.465,-0.225 1.538,0.7 -1.671,2.057 2.024,-1.329 -3.536,2.34 3.301,1.855 1.879,-4.55 -0.33,3.357 2.978,0.276 -2.853,1.292 3.186,0.115 -2.619,1.327 2.13,-0.438 -1.594,0.797 2.396,0.815 -2.002,-0.296 2.007,3.959 -4.199,-2.9 -3.47,0.077 3.708,3.813 4.315,0.541 -2.799,4.208 2.493,0.438 -1.145,1.405 -1.319,-1.461 0.286,3.447 -3.316,-1.203 -3.098,1.391 6.101,-0.214 -1.761,1.505 2.204,1.723 -6.397,-2.327 2.525,1.651 -2.448,-0.78 -1.81,2.765 5.31,-1.968 -1.69,0.752 4.608,0.3 -8.597,1.257 5.315,1.146 -5.827,0.166 3.437,2.257 -3.208,0.613 2.392,1.032 -2.797,-0.395 0.989,1.189 -1.74,0.988 7.493,-3.723 1.313,0.869 -8.423,3.356 4.224,0.362 -3.908,1.234 1.296,2.289 3.599,-1.954 1.75,1.007 -5.646,1.29 1.512,0.193 -1.2,2.728 2.617,-0.752 -2.641,1.39 -0.145,2.775 4.076,-2.555 -0.372,-2.751 2.584,5.232 -2.947,-1.891 1.587,1.19 -4.314,0.964 4.301,0.773 -4.055,0.034 1.715,0.843 -1.977,1.181 2.769,0.432 -2.198,0.989 2.844,0.647 -2.591,-0.053 2.734,0.98 -1.272,2.378 2.091,-1.341 -2.243,2.949 2.694,1.563 -1.498,1.568 2.577,-0.351 -2.101,1.305 2.026,-0.816 -1.246,1.513 1.617,0.535 -1.993,0.366 2.893,0.315 -2.491,0.571 3.333,0.705 0.393,2.987 7.435,-1.708 -3.265,2.41 2.625,-1.333 -1.988,2.367 2.409,-0.987 -0.154,2.112 1.875,-1.712 -1.909,3.229 2.314,-2.225 -0.925,3.088 m -57.795,-21.505 -2.859,-11.892 2.095,3.078 0.477,-2.265 4.685,8.347 1.673,-6.514 0.677,3.56 1.435,-3.947 -1.792,-2.481 1.809,-0.207 -0.541,-2.642 -2.048,0.775 0.222,-2.502 -0.923,1.617 1.043,-5.292 -2.674,0.516 1.413,-3.374 2.569,1.193 -0.164,-3.707 2.496,1.044 0.434,3.026 1.793,-1.08 -1.945,1.994 4.367,-1.094 -4.018,2.4 2.57,5.833 2.354,-5.497 1.191,2.393 0.609,-3.154 1.977,1.373 -1.448,-2.314 3.039,0.887 -0.862,-1.925 2.145,0.249 -0.839,-2.42 -2.417,1.638 0.438,-1.676 -2.496,0.25 2.692,-2.29 -2.482,1.795 1.439,-1.528 -3.167,0.404 2.25,-0.844 -1.56,-1.044 1.747,0.661 -0.146,-2.74 -1.871,0.415 1.866,-1.382 -2.231,1.58 -0.022,-2.235 -1.406,1.748 1.272,-2.135 -1.555,1.047 1.018,-1.75 -1.373,0.678 0.472,-2.169 -1.893,-0.271 2.883,-0.081 -4.387,-3.655 3.085,1.256 0.159,-2.082 -2.033,0.307 2.447,-0.58 -1.445,-1.293 3.972,2.438 -0.25,-1.795 -5.109,-2.23 5.813,1.019 0.568,-1.278 -0.731,-2.24 -5.351,2.147 4.11,-1.936 -3.21,-0.144 4.789,-1.145 -1.309,-2.021 -3.021,0.844 2.516,-1.547 -5.436,2.958 2.22,-2.202 -1.784,0.042 4.269,-2.09 -4.69,0.758 4.394,-2.123 -1.116,-2.721 -4.071,1.92 2.761,-3.169 -4.281,1.72 2.279,-1.879 -1.098,-0.642 3.054,-0.896 -4.062,-0.633 4.044,-1.94 -2.624,-2.883 -2.565,0.701 1.194,2.456 -2.417,-1.816 -0.051,3 -0.251,-4.853 -4.007,1.745 4.266,-3.061 2.02,-5.122 -5.86,-1.104 0.253,2.412 -2.236,-1.59 0.856,2.45 -1.59,-2.067 -1.669,4.945 -0.372,-1.977 -2.085,0.294 0.507,2.922 -3.27,2.664 0.79,-1.333 -6.551,-3.762 -1.618,3.072 0.166,1.961 3.276,0.248 -1.346,2.687 5.601,4.357 -0.243,-3.045 0.975,4.458 0.356,-2.565 3.717,3.682 0.469,-2.846 2.185,-0.967 -1.215,5.419 1.895,-0.571 -1.528,1.419 1.796,0.67 -0.41,2.509 -3.691,1.63 3.204,-0.565 0.602,3.394 1.517,-0.233 -1.389,7.915 -3.201,1.692 1.612,1.326 -1.925,-1.1 -4.542,1.492 -0.185,4.394 -5.563,-1.125 -2.432,-2.68 -4.871,4.342 7.454,3.792 1.307,-2.694 0.414,3.882 1.696,-1.45 -1.006,4.674 2.578,2.593 -2.571,-0.074 0.229,2.017 10.84,11.063 -0.005,-0.011 m 46.872,-103.146 -4.802,-0.024 -1.359,2.916 -1.069,-3.244 -2.178,0.31 0.023,1.982 -0.974,-2.178 -4.333,-0.189 1.196,1.152 -1.746,0.443 2.498,0.99 -3.724,0.48 4.479,1.292 -4.734,-0.855 -0.055,1.866 5.909,0.342 -3.78,-0.041 -1.558,0.691 3.315,0.183 0.966,0.711 -2.129,0.404 2.077,0.523 6.049,-1.424 -3.701,1.381 1.912,0.974 -7.275,-0.72 -1.017,4.021 0.248,-4.004 -1.758,-1.456 -2.844,6.008 -1.27,-0.577 2.888,1.503 -2.395,-0.102 -0.328,1.512 -0.887,-2.758 -2.25,-0.313 -3.228,1.825 2.565,0.02 -0.896,1.248 2.834,-1.328 -4.691,3.865 4.621,-0.675 -5.26,1.712 -1.009,-4.333 -1.507,3.427 -5.519,0.178 0.225,1.361 1.815,-1.223 -1.15,2.131 1.361,-1.015 -0.424,1.62 1.366,-1.059 -0.191,2.26 2.52,-0.834 0.154,1.641 1.214,-1.469 -0.312,2.13 1.236,-1.971 -0.969,3.754 4.214,0.274 2.389,-1.965 -3.275,-2.865 1.866,-2.062 1.831,3.232 3.007,-2.357 2.298,1.207 -0.129,-1.525 2.286,0.419 -0.922,-1.553 2.244,0.677 -2.356,-3.857 3.997,2.106 -2.192,-2.852 4.984,1.374 0.283,-1.903 1.996,1.714 2.063,-1.164 -1.303,-1.188 1.911,0.902 0.524,-1.753 0.573,1.2 7.053,-2.948 -5.371,-0.147 4.005,-0.828 -1.559,-1.514 2.486,1.275 3.666,-0.801 1.783,-1.286 -0.697,-2.463 -4.047,-0.239 2.395,-0.755 -6.086,-3.411 -0.066,-0.008 m 167.491,145.922 2.936,-4.169 -0.662,-1.304 -3.606,1.494 1.568,-1.733 -0.473,-5.947 -2.754,-1.624 -3.44,2.155 -0.063,0.118 -2.05,-3.445 -0.962,-0.222 -1.695,0.588 1.961,-1.51 -1.344,-1.732 -4.575,-0.747 -6.681,-5.656 -5.282,1.209 2.956,-2.422 -2.461,0.435 1.688,-2.061 -1.396,-6.316 -6.481,3.954 0.14,-7.712 -5.049,2.458 2.225,4.288 -2.092,0.691 3.329,3.41 -1.222,3.031 3.428,-1.42 1.801,8.466 -0.17,-3.535 0.546,-2.587 1.794,1.188 -1.39,0.375 2.392,6.104 1.476,0.816 -0.683,-1.264 4.786,-2.997 -0.257,3.299 2.728,1.695 0.473,-1.432 1.179,4.101 1.803,0.41 -4.038,2.882 -0.521,3.023 1.769,-1.667 1.418,1.813 -2.287,5.665 7.25,-0.126 1.99,-3.791 -0.349,4.375 -3.648,1.661 -1.664,8.259 6.195,-3.873 -0.789,-2.784 10.242,-5.88 0.011,-0.007 m -204.82,50.769 5.462,-4.5 0.686,2.812 -2.308,3.43 3.042,-1.96 -0.896,3.409 1.875,0.383 3.086,-5.061 -0.407,-1.809 -2.227,1.279 2.086,-3.522 -3.229,3.52 -1.167,-2.251 1.528,-0.976 -1.197,-1.285 4.123,-1.287 -4.882,0.231 3.701,-4.917 -3.876,-0.453 0.438,-1.851 -4.158,2.527 1.521,-2.82 -3.892,-0.002 3.213,-2.707 -2.832,-0.259 0.486,-1.326 -3.5,3.106 6.315,-8.329 -0.947,-1.824 2.177,0.339 -1.157,-1.788 -6.805,4.381 -2.863,7.099 -2.099,-0.051 0.68,2.848 -1.708,-1.44 -4.271,3.181 3.886,0.559 -5.291,2.672 0.454,2.166 3.637,-0.602 5.373,2.717 4.758,-1.803 -1.969,2.724 5.92,-0.229 -5.995,3.37 3.223,0.301 0.006,-0.002 m -57.71,-179.463 -2.702,1.977 4.455,4.888 6.039,0.791 -1.819,3.767 3.857,3.857 2.038,-2.354 -2.969,0.284 2.737,-2.407 0.082,1.689 3.123,0.053 -0.857,1.482 2.584,-1.803 1.05,-6.794 8.809,-6.332 1.456,-2.915 -1.685,-1.2 -8.133,4.963 6.004,-6.196 -0.57,-0.86 -2.325,2.498 0.219,-1.434 -1.811,0.411 -0.64,-1.154 2.987,-0.21 0.594,-2.443 -3.226,-0.916 4.527,-1.85 -6.631,-2.537 -4.403,0.844 -0.054,1.891 -1.756,0.024 2.221,3.554 -4.244,-2.88 -2.06,1.766 2.392,4.658 -0.607,3.965 -4.97,-6.804 -3.113,2.696 -0.597,5.029 -0.002,0.002 m 180.694,78.376 3.992,-3.785 1.408,-4.44 -1.575,-0.223 1.612,-0.761 -6.332,-4.117 0.814,-1.848 -1.418,1.718 -2.65,-1.451 0.164,2.604 -4.068,0.547 1.603,2.641 -2.825,-2.437 -0.486,2.867 -3.092,-1.402 0.123,5.296 -2.088,-4.4 -4.978,-1.373 2.652,2.856 -3.062,-1.463 1.339,2.683 -2.223,-0.31 1.204,1.32 -1.791,0.505 6.98,-1.098 -1.783,1.905 2.236,0.455 -5.322,1.837 7.541,1.355 -2.429,3.884 3.981,-1.647 6.939,1.574 3.534,-3.292 v 0 m 54.155,56.066 4.322,-4.301 -5.057,-9.501 1.554,-3.774 -4.156,-3.075 -2.817,2.636 0.524,-1.719 -1.755,-0.212 0.418,2.551 -1.755,-1.002 -1.085,3.834 2.223,-0.553 -0.074,2.865 -4.977,1.707 2.842,1.766 -1.017,2.903 4.603,-0.45 -1.757,4.872 3.73,-2.042 -4.32,4.335 2.15,-0.289 -1.351,2.521 2.677,-1.247 -1.337,2.25 2.027,-1.521 -0.347,1.976 4.73,-4.521 v -0.009 m -186.128,-130.199 0.083,3.425 3.19,-0.278 -1.084,2.347 5.071,2.757 1.557,-1.381 0.342,2.974 4.57,-0.097 -0.758,-1.194 2.624,-1.297 -0.979,-2.703 -7.255,-1.628 -0.858,-2.813 -1.307,0.816 1.619,-2.834 -2.066,-0.261 2.069,-0.126 -0.38,-1.752 2.111,1.844 -1.104,-2.392 1.369,-0.336 -3.495,-0.961 2.421,-1.874 -2.121,-2.481 -2.608,3.475 2.586,1.307 -5.563,5.433 -0.034,0.03 m -16.175,-21.211 3.362,0.426 -2.35,1.054 2.624,2.229 -4.868,-1.926 -0.57,2.704 5.51,1.849 1.577,2.671 4.682,-1.678 0.477,-1.575 -2.441,0.871 0.079,-1.395 5.151,-3.558 -3.267,0.017 -4.068,3.524 -1.018,-2.251 4.115,-5.582 -1.69,-0.419 -0.22,1.4 -2.289,-1.382 0.67,1.822 -2.702,-1.63 1.48,1.845 -3.53,-1.615 -0.725,2.593 0.011,0.006 m 33.583,6.377 -0.239,2.936 -1.425,-0.517 -0.591,1.481 1.79,1.792 1.73,-1.883 -1.237,2.266 4.369,-2.541 -1.135,1.541 4.925,-0.747 0.848,-1.675 -1.696,-0.587 3.749,-3.085 -1.973,0.753 2.892,-6.688 -3.886,0.692 -0.445,1.781 -2.49,-1.022 -0.525,2.343 -0.537,-1.778 -1.314,0.808 0.861,1.649 -2.953,1.052 3.173,2.898 -3.88,-1.472 -0.011,0.003 m 119.01,5.537 3.2,0.134 -7.811,-7.024 -0.188,-2.61 -6.401,-0.386 0.966,1.126 -4.351,-1.229 5.928,3.296 -5.524,-1.61 2.122,2.024 -2.659,-0.024 -0.474,-1.754 -0.529,2.799 8.023,3.015 -1.465,-3.541 1.986,1.171 -0.507,-1.534 1.986,0.327 -0.843,3.672 1.906,0.873 1.175,-2.749 -0.271,2.416 1.969,-0.332 -1.973,1.314 3.735,0.626 v 0 m 30.638,-34.101 -3.154,-0.354 0.493,-0.887 -5.767,-2.668 -7.901,-6.773 -4.276,-0.08 5.111,3.314 1.425,3.319 7.607,5.542 2.837,-0.564 2.91,2.303 1.064,-1.156 -0.643,1.318 2.309,1.818 0.543,-2.217 2.017,2.271 0.157,-2.844 -2.811,-0.092 0.371,-1.247 -1.238,0.886 0.397,-1.295 -2.402,0.069 0.951,-0.659 v -0.004 m -284.221,348.573 4.442,-0.024 -6.859,-5.718 0.642,-2.371 -5.238,-3.575 -10.577,-15.368 -5.306,-4.813 -12.728,-4.395 -2.185,3.209 -2.928,-1.006 3.761,2.148 6.518,-1.12 3.686,2.32 0.614,1.539 -2.298,-0.724 1.144,2.063 12.417,10.124 1.504,6.192 3.957,2.537 0.172,1.97 -3.49,1.42 12.752,5.592 v 0 m 16.555,18.333 2.806,-1.449 10.003,4.956 1.995,-1.638 -6.135,-4.979 2.607,-0.361 -2.987,-0.969 -0.688,-2.607 -13.74,-7.007 -3.353,0.177 3.393,2.812 -1.044,2.061 1.744,3.713 -8.857,-4.579 -1.55,0.799 2.444,3.466 9.132,2.549 2.478,4.699 1.749,-1.639 h 0.003 m 146.269,-449.31 3.471,-0.24 -2.689,0.183 -2.845,0.217 1.406,-0.11 9.647,-0.601 3.966,-0.169 -3.662,0.155 -3.989,0.212 8.437,-0.266 2.566,0.849 1.594,-0.103 -2.049,-0.199 3.629,-0.218 0.372,-0.328 -2.571,-0.167 -17.272,0.784 -0.011,10e-4 m -66.003,132.783 5.383,-3.02 -0.654,-2.775 5.087,-1.022 -2.972,-3.958 -1.846,1.79 -0.557,-1.45 0.128,2.718 -2.491,0.987 -0.218,-3.054 -2.45,0.775 -3.631,8.046 1.406,0.861 2.28,-1.663 -1.193,0.896 1.705,0.877 0.023,-0.008 m -10.755,52.367 2.985,-0.623 -0.364,-2.525 -2.659,-0.539 2.415,-2.472 -1.526,-7.299 -1.76,0.725 1.542,-3.902 -8.301,7.432 -3.87,1.058 3.322,1.255 -1.461,3.352 8.39,-2.27 -0.946,3.034 2.209,2.773 0.024,0.001 m 217.865,-94.39 -0.596,-4.63 -6.293,1.745 -3.912,-0.616 -3.592,-2.228 -0.316,1.826 0.819,1.942 1.478,-0.177 1.133,1.654 0.303,-1.425 4.888,3.717 2.157,-0.108 -0.655,-2.095 4.567,0.405 0.019,-0.01 m -289.143,-16.689 0.116,0.612 -1.532,0.024 0.893,1.901 1.417,-0.862 -1.244,1.337 1.924,-0.491 2.029,-2.076 -1.506,0.042 1.623,-0.958 -3.107,1.123 2.62,-2.062 -0.979,-0.202 -2.25,1.609 -0.004,0.003 m 230.21,26.319 -3.133,0.375 0.513,1.656 -2.28,-0.857 2.593,1.691 -4.136,0.106 1.889,1.045 -0.944,1.082 2.688,0.594 1.123,-2.048 0.974,1.947 3.336,-1.553 -2.612,-4.038 h -0.011 m -134.78,18.808 1.848,1.664 2.459,-0.607 5.496,-5.045 -1.903,0.458 -0.807,-1.872 -2.479,2.762 1.567,-3.335 -2.621,2.68 -2.339,-1.118 2.675,2.567 -2.598,0.05 -1.335,1.764 0.037,0.032 m -28.104,-13.475 10.701,2.339 3.139,-3.987 -1.974,-1.058 2.6,-3.507 -1.85,-3.077 -3.328,2.05 -10.745,0.483 0.116,1.345 -4.698,3.863 3.05,2.242 2.973,-0.702 0.016,0.009 m -122.337,52.105 1.458,1.32 -2.553,1.076 -0.469,5.654 7.836,-11.828 1.5,-8.851 -1.574,2.007 0.867,1.063 -2.389,0.281 0.29,1.968 -4.963,7.31 h -0.003 m 28.385,-33.872 -1.584,1.708 2.857,-1.421 0.588,-1.91 0.473,1.051 4.744,-5.428 -3.808,2.267 -0.026,1.011 -1.64,0.151 -1.608,2.568 0.004,0.003 m -10.506,6.554 1.061,0.232 0.674,-1.94 4.595,-0.951 -2.916,-0.316 2.182,-0.475 0.974,-2.531 -5.503,4.063 -4.642,6.185 3.555,-4.255 0.02,-0.012 m 214.293,-99.042 -8.911,0.204 2.091,2.128 -1.746,-1.753 -2.902,1.316 6.25,1.587 1.148,-1.562 2.639,1.628 2.805,-1.581 -1.374,-1.963 v -0.004 m -85.748,271.714 -1.249,-2.446 -2.927,3.155 -1.516,-0.276 3.879,-2.707 1.163,-4.391 -6.063,4.771 0.251,3.157 6.456,-1.24 0.006,-0.023 m 8.376,-204.834 -1.352,-1.628 -8.804,-0.705 1.978,1.155 -1.697,1.619 6.085,-0.014 -2.795,1.688 6.391,-0.5 0.202,-1.618 -0.008,0.003 m -5.257,47.812 1.406,-3.815 2.805,-3.068 6.139,-2.971 -1.579,-1.8 -5.94,0.458 -8.682,5.878 2.872,3.785 2.975,1.53 0.004,0.003 m 237.453,62.845 -0.721,-4.084 -2.952,-1.844 1.439,2.606 -1.945,-0.99 -1.039,2.658 7.065,3.627 -1.844,-1.976 v 0.003 M 946.5,605.9 l -3.223,-2.156 -3.538,1.822 0.032,1.166 1.791,0.039 -1.313,0.649 6.254,1.174 10e-4,-2.691 -0.004,-0.003 m -109.359,56.223 3.958,-3.608 -0.003,-4.698 -2.715,1.667 0.543,1.321 -3.128,0.432 1.61,0.836 -0.267,4.059 0.002,-0.009 m -124.226,1.114 2.609,-2.869 -1.428,2.222 1.334,-0.338 1.389,-3.293 -4.463,2.854 1.96,-0.82 -1.397,2.238 -0.004,0.006 m 98.408,21.717 3.855,-0.153 0.663,-1.999 2.223,2.166 7.454,-2.67 -4.853,-4.686 -9.369,7.332 0.027,0.01 m 156.106,-25.694 -4.02,-0.859 -0.453,1.823 3.546,1.896 0.081,-1.695 2.115,0.904 -1.267,-2.074 -0.002,0.005 m -193.558,115.357 2.5,0.261 -0.763,1.001 2.635,-2.312 -1.787,1.44 1.737,-3.092 -4.332,2.704 0.01,-0.002 m 100.713,-48.962 -1.864,-3.793 -3.02,-0.552 -0.88,3.196 2.993,0.606 -1.48,1.5 4.24,-0.948 0.011,-0.009 m 284.724,99.196 2.897,-4.089 -0.671,-2.002 -0.361,2.462 -6.357,3.93 1.23,1.932 3.259,-2.235 v 0.002 m -531.492,221.218 1.051,-0.288 -2.247,-6.075 -0.89,0.102 2.01,4.425 h -1.659 l 1.733,1.836 h 0.002 m 129.935,173.648 1.355,0.542 -3.304,-1.772 -1.927,-0.829 0.54,0.375 1.439,0.84 1.891,0.842 h 0.006 m -54.219,-545.027 -1.928,0.413 -0.266,0.944 1.243,-0.422 -1.863,0.726 0.493,0.77 2.321,-2.431 m 242.95,-72.952 -6.899,-1.433 -0.818,2.213 2.61,-0.147 -2.207,1.305 7.331,-1.938 h -0.017 m -2.542,7.229 -3.622,-1.266 -2.413,0.511 -0.823,2.381 7.304,-0.042 -0.449,-1.583 0.003,-10e-4 m -235.026,334.149 0.746,1.264 1.834,-3.568 -1.842,-3.252 1.347,3.102 -2.085,2.436 v 0.018 m 394.662,-95.863 2.801,-4.297 -3.083,-6.876 -4.026,-2.449 -2.235,4.024 6.551,9.611 -0.01,-0.013 m -298.155,3.877 4.362,-1.72 -7.665,-2.193 0.905,-3.468 -2.286,2.148 4.677,5.212 0.007,0.021 m -105.919,137.751 3.888,1.421 -2.766,-4.28 -6.709,-2.991 2.179,4.117 3.407,1.73 10e-4,0.003 m 34.154,-384.917 0.427,0.914 1.516,-1.361 -1.813,0.706 1.105,-1.701 -1.233,1.437 -0.002,0.005 m 441.962,198.088 0.26,-5.107 -1.277,-0.787 -0.568,-4.06 -1.274,9.731 2.858,0.229 10e-4,-0.006 m -399.096,257.528 0.624,-3.637 -4.145,-0.334 1.015,2.484 -2.743,0.614 5.249,0.859 v 0.014 m -71.278,-105.626 -1.231,-0.702 1.079,-1.267 -1.373,0.337 0.688,2.465 0.846,-0.829 -0.009,-0.004 m 128.799,-260.053 0.131,1.7 5.126,1.796 0.505,-3.942 -3.796,-3.222 -1.961,3.665 -0.005,0.003 m 192.916,-42.312 -2.107,-2.503 -2.316,0.814 2.325,2.126 2.099,-0.43 v -0.007 m -212.841,182.475 1.029,-1.226 -2.571,-2.844 -6.173,-3.127 7.708,7.2 0.007,-0.003 m 334.924,-32.475 0.558,-1.006 -1.74,-0.968 -0.546,1.991 1.727,-0.018 10e-4,10e-4 m -436.163,149.753 -0.562,2.191 0.923,-2.835 -2.115,-3.718 1.759,4.358 -0.005,0.004 m 64.568,-355.263 -0.181,1.203 7.376,-3.981 -1.727,-0.101 -5.476,2.879 h 0.008 m -67.624,70.572 -2.93,2.009 0.046,1.031 2.312,-0.84 0.59,-2.223 -0.018,0.023 m 44.241,342.94 2.335,-1.664 -8.607,-2.594 0.013,2.52 6.255,1.74 h 0.004 m 297.65,-248.823 1.516,1.967 1.964,-1.021 -2.436,-2.4 -1.04,1.446 v 0.008 m 97.009,50.797 -2.727,-2.434 -3.092,0.475 -0.419,2.095 6.232,-0.128 0.01,-0.008 m -147.592,-38.739 0.743,1.195 0.762,-1.688 -1.086,-3.271 -0.415,3.762 v 0.002 m 4.846,-74.227 -0.498,-3.922 0.222,2.03 -1.964,-1.305 2.231,3.195 0.01,0.002 m -302.339,252.534 1.647,-1.496 -1.203,-3.89 -2.034,2.833 1.586,2.552 0.004,0.001 m 225.428,-241.624 3.837,0.949 -2.955,-3.06 -2.393,0.403 1.502,1.709 0.009,-10e-4 m -241.139,-20.395 0.713,0.122 -1.964,1.851 4.235,-3.823 -2.983,1.847 v 0.003 m -10.067,265.903 2.128,0.595 -0.198,-2.096 -1.193,-1.052 -0.765,2.536 0.028,0.017 m 317.074,-334.985 -1.919,-0.284 0.953,1.298 2.138,0.089 -1.166,-1.093 -0.006,-0.01 m -187.736,51.34 3.575,-1.205 -0.851,-2.402 -1.586,0.206 -1.166,3.384 0.028,0.017 m 81.535,-88.123 -3.197,-0.382 -2.648,1.329 7.277,0.492 -1.431,-1.436 -10e-4,-0.003 m 5.977,-4.842 -0.83,0.66 2.619,1.013 3.864,-1.277 -5.645,-0.396 h -0.008 m 189.96,279.008 0.583,-3.158 -1.564,-0.794 -2.008,3.783 2.989,0.172 v -0.003 m 13.246,-24.39 -0.347,-4.583 -3.188,-4.38 -0.584,5.313 4.119,3.65 v 0 m -305.838,-141.513 0.677,4.674 3.702,0.066 1.607,-7.029 -5.993,2.285 0.007,0.004 m -80.111,-25.868 3.871,-2.051 1.51,-2.158 -7.271,3.807 1.889,0.406 10e-4,-0.004 m 417.901,177.588 -3.003,-9.633 -8.141,9.196 1.845,1.919 9.294,-1.478 0.01,-0.004 M 757.801,602.26 l 2.805,-0.944 1.4,-1.982 -4.293,2.14 0.085,0.787 0.003,-10e-4 m -25.748,6.292 -1.478,1.591 2.806,-1.613 0.213,-1.677 -1.538,1.696 -0.003,0.003 m 92.515,111.858 -1.995,-2.588 -4.004,4.44 3.416,0.932 2.546,-2.761 0.037,-0.023 m -33.461,16.082 -3.389,0.644 -0.762,1.829 6.703,-1.382 -2.545,-1.092 -0.007,10e-4 m -14.939,290.692 2.512,-0.784 -1.43,-1.89 -1.968,0.633 0.885,2.045 h 10e-4 m 55.021,-373.253 -1.25,-2.481 -2.302,0.82 0.289,2.135 3.25,-0.482 0.013,0.008 m 114.651,-45.175 -1.608,0.026 1.387,1.674 1.521,-0.793 -1.295,-0.9 -0.005,-0.007 m -106.733,55.518 3.29,-0.831 -0.04,-3.44 -3.744,2.576 0.467,1.682 0.027,0.013 m 403.03,304.999 0.072,-0.934 -0.399,2.438 0.16,0.182 0.166,-1.683 10e-4,-0.003 m -222.637,-334.3 -1.398,-0.808 -2.206,1.73 2.435,0.528 1.169,-1.45 m 40.401,88.74 -0.338,1.088 1.714,0.104 0.216,-1.601 -1.592,0.409 m -301.639,-119.402 1.576,-0.824 -0.024,-1.065 -1.408,0.68 -0.144,1.209 m 249.538,174.625 -0.017,2.058 1.506,-1.445 -1.484,-0.614 v 0.001 m -175.793,-128.105 2.669,2.394 0.958,-1.709 -3.63,-0.698 0.003,0.013 m 97.772,55.222 -3.271,-1.166 -1.595,1.508 4.86,-0.341 0.006,-10e-4 m 281.12,52.359 -0.798,-1.901 1.636,5.098 -0.835,-3.182 v -0.015 m 21.105,107.123 0.485,-1.408 -1.003,0.229 0.514,1.194 v -0.015 m -127.604,-61.565 -1.283,-0.247 2.637,0.855 -1.352,-0.608 v 0 m -496.342,25.208 -0.257,1.909 1.188,-2.176 -0.928,0.264 -0.003,0.003 m 397.758,-53.915 -2.686,-0.991 3.381,2.373 -0.692,-1.381 v -10e-4 m 53.696,-33.004 2.694,4.236 -3.662,-6.396 0.967,2.153 10e-4,0.007 m -54.807,-44.73 -1.843,-1.849 0.556,2.183 1.281,-0.335 0.01,10e-4 m -50.587,-32.115 2.405,0.331 -4.521,-1.306 2.111,0.973 0.005,0.002 m 184.936,156.336 1.408,-0.888 -1.815,-1.115 0.402,1.962 0.01,0.041 m -374.238,401.088 -1.02,-0.447 -1.098,-0.449 2.115,0.895 h 0.003 m -45.697,-252.81 0.004,0.01 0.968,-1.341 -2.704,2.28 1.732,-0.949 m 13.876,-335.816 1.684,0.019 -2.326,-0.715 0.635,0.699 0.007,-0.003 m 226.672,3.629 -2.185,-2.955 -2.419,-0.188 4.604,3.146 v -0.003 m -260.991,36.214 -0.842,1.138 2.691,-2.256 -1.841,1.107 -0.008,0.011 m 365.362,54.775 -0.527,-4.515 -2.26,2.576 2.765,1.94 0.022,-10e-4 M 729.103,626.29 l 0.6,1.282 1.391,-1.784 -1.982,0.498 -0.009,0.004 m 98.532,-36.968 -3.799,3.547 4.611,-1.459 -0.812,-2.089 v 10e-4 m 194.64,367.244 2.082,-4.163 -3.583,2.362 1.493,1.795 0.01,0.006 m -18.083,-265.771 -1.326,0.065 1.801,2.791 -0.474,-2.853 v -0.003 m -164.969,431.045 2.097,-1.696 -4.486,0.104 2.379,1.592 h 0.01 m -10.028,-359.639 1.349,-1.14 -1.993,-0.522 0.64,1.661 0.004,10e-4 m 11.562,-182.143 0.003,0.765 2.708,-0.643 -2.708,-0.124 -0.003,0.002 m -89.146,286.52 5.512,1.653 2.343,-1.422 -7.851,-0.234 -0.004,0.003 m 72.733,-193.519 1.312,3.739 3.576,-4.069 -4.874,0.331 -0.014,-10e-4 m -116.28,-5.657 1.524,-1.247 -4.785,2.482 3.263,-1.239 -0.002,0.004 m 0.8,-2.403 -3.122,2.104 7.367,-4.819 -4.246,2.709 10e-4,0.006 m 101.92,-100.225 2.708,-0.588 -4.263,0.815 1.549,-0.226 0.006,-10e-4 m 430.317,262.668 -0.544,-3.118 0.525,4.797 0.02,-1.673 -10e-4,-0.006 m -205.912,124.031 -0.125,-3.354 -2.12,4.933 2.241,-1.578 v -0.001 M 804.34,709.075 l -0.685,1.449 2.251,-2.546 -1.552,1.075 -0.014,0.022 m -4.176,12.907 1.317,1.144 -0.601,-3.365 -0.719,2.206 0.003,0.015 m -41.213,64.45 2.707,3.732 0.448,-3.304 -3.156,-0.431 10e-4,0.003 m -79.842,110.463 h -0.002 l -1.142,-0.602 2.969,1.614 -1.825,-1.012 m 483.275,-86.051 -0.98,-3.049 0.021,2.984 0.96,0.071 -10e-4,-0.006 m -346.819,-159.142 2.458,-0.47 -3.533,-0.657 1.075,1.124 v 0.003 m 22.92,-96.138 0.317,0.013 2.179,-0.507 -2.471,0.49 -0.025,0.004 m 322.873,477.795 1.083,-0.052 0.815,-3.302 -1.899,3.346 10e-4,0.01 m -228.576,-338.047 2.02,-0.67 -1.896,-1.652 -0.125,2.321 0.001,10e-4 m 24.909,-64.254 1.973,-0.451 -1.563,-1.019 -0.42,1.478 0.01,-0.008 m -282.904,454.79 0.955,-0.657 -1.493,-0.809 0.53,1.469 h 0.008 m 46.543,-106.069 1.029,-1.631 -3.655,0.4 2.622,1.233 0.004,-0.002 m 38.745,70.784 -2.073,-0.479 3.482,0.856 -1.378,-0.393 -0.031,0.016 m 184.239,-462.301 -0.514,-1.012 -1.781,0.351 2.28,0.657 0.015,0.004 m 92.376,357.825 -0.268,-1.405 -1.432,2.826 1.701,-1.416 -10e-4,-0.005 M 802.547,741.05 l 1.804,-1.124 -1.893,-1.015 0.085,2.135 0.004,0.004 m 192.182,298.177 1.632,-0.287 -1.93,-1.547 0.31,1.821 -0.012,0.013 m -101.337,-376.609 1.853,2.731 0.146,-2.065 -1.958,-0.698 -0.041,0.032 m -173.758,329.092 -1.439,-0.795 2.142,2.236 -0.695,-1.438 -0.008,-0.003 m 242.937,-331.861 -1.734,-1.619 -0.209,1.417 1.934,0.202 h 0.009 m -141.08,49.034 1.732,-0.56 -2.586,-0.727 0.854,1.31 v -0.023 m -28.055,36.622 2.54,-0.605 0.728,-2.288 -3.262,2.875 -0.006,0.018 m -59.277,290.036 h 0.002 l 1.279,1.421 -1.969,-2.63 0.688,1.206 m 294.626,-80.828 -1.734,-0.538 -0.409,1.711 2.14,-1.167 v -0.006 m -121.753,-403.374 1.215,0.213 1.489,-0.189 -2.707,-0.025 0.003,10e-4 m -104.393,35.284 -0.141,0.082 -1.147,0.873 2.722,-1.721 -1.434,0.766 m 28.204,72.444 1.417,-1.668 -2.84,2.66 1.436,-0.98 -0.013,-0.012 m 126.648,-29.925 -3.112,-1.303 0.836,1.457 2.3,-0.138 -0.024,-0.016 m -194.596,-47.809 -1.775,0.794 3.318,-1.449 -1.528,0.647 -0.015,0.008 m 77.001,84.734 -2.426,-1.153 1.305,2.441 1.116,-1.273 0.005,-0.015 m -12.858,55.392 -1.835,-0.839 1.807,2.286 0.037,-1.433 -0.009,-0.014 m 326.672,332.394 0.253,0.859 1.005,-1.981 -1.258,1.118 v 0 m -224.373,-353.85 3.121,-0.324 -2.048,-0.885 -1.07,1.205 -0.003,0.004 m -87.166,-30.613 -0.922,-0.907 -0.966,1.882 1.891,-0.958 -0.003,-0.017 m 222.594,90.686 -1.29,-1.276 -0.13,1.847 1.42,-0.571 m -237.725,-196.528 -2.384,1.42 2.829,-0.87 -0.445,-0.55 m 97.671,157.23 4.72,-1.668 -1.458,-2.096 -3.262,3.764 m 3.608,-13.476 4.043,0.2 -1.584,-1.218 -2.459,1.018 m -173.408,-121.34 -0.644,0.547 1.811,-0.982 -1.167,0.435 m 307.104,153.772 -2.669,-5.405 0.158,3.257 2.511,2.148 m -369.543,-55.63 -2.082,2.355 3.454,-3.606 -1.372,1.251 m 6.817,276.918 1.006,1.234 -1.002,-1.249 -0.004,0.015 m 304.033,-265.603 -0.715,-1.997 0.708,1.989 0.01,0.008 m -212.6,-6.134 -1.186,1.363 1.194,-1.363 h -0.008 m 218.086,95.026 0.458,-1.802 -0.473,1.775 0.015,0.027 m -401.025,38.97 -0.744,3.793 0.75,-3.795 -0.006,0.002 m 359.738,84.413 3.435,-0.029 -3.435,0.024 v 0.005 m 144.591,-101.064 1.217,-1.161 -1.223,1.153 0.01,0.008 m -400.623,152.782 1.313,1.654 -1.309,-1.657 -0.004,0.003 m 42.549,-372.963 -1.162,0.952 1.169,-0.954 -0.007,0.002 m 234.454,163.683 1.568,1.12 -1.564,-1.121 -0.004,10e-4 m 15.755,-73.748 -1.262,0.453 1.26,-0.45 v -0.003 m -49.05,-49.145 -3.322,-1.112 3.318,1.116 0.004,-0.004 M 601.282,823.835 v 0 l 0.953,-0.814 -0.953,0.814 m 355.74,-185.118 -0.207,-2.483 0.206,2.486 0.001,-0.003 m -120.428,480.443 0.086,1.357 -0.086,-1.376 v 0.019 m -9.331,-351.586 1.081,1.107 -1.077,-1.117 -0.004,0.01 m 8.223,-16.717 0.371,2.086 -0.369,-2.09 -0.002,0.004 m 167.838,-63.941 -0.641,1.395 0.644,-1.394 v -10e-4 m -274.257,-73.079 -1.44,0.86 1.444,-0.861 -0.004,10e-4 m 102.711,142.729 1.628,0.335 -1.623,-0.348 -0.005,0.013 m 254.673,95.467 -0.01,0.005 1.246,-0.432 -1.238,0.427 m -401.807,-158.347 -0.004,-0.001 -1.029,0.252 1.033,-0.251 m 133.928,71.855 0.111,-1.752 -0.115,1.75 0.004,0.002 m 187.117,-67.194 v 0.002 l -0.121,1.679 0.123,-1.681 m -336.58,332.825 v 0.01 l 0.451,1.508 -0.451,-1.517 m 136.621,-290.524 0.104,-1.678 -0.111,1.682 0.007,-0.004 m 202.631,22.147 1.156,1.188 -1.164,-1.202 0.01,0.014 m -179.635,29.075 1.502,0.688 -1.499,-0.69 -0.003,0.002 m 66.111,-31.193 2.107,1.462 -2.107,-1.466 v 0.004 m -116.673,279.622 0.554,-1.856 -0.581,1.844 0.027,0.012 m 336.586,-233.414 0.01,-0.01 -0.945,0.85 0.935,-0.84 m 109.879,-31.38 -1.159,-2.848 1.145,2.82 0.014,0.028 M 954.832,602.43 l -1.427,-0.06 1.431,0.063 -0.004,-0.003 m 99.933,117.327 -0.292,-2.032 0.265,2.009 0.027,0.023 m -99.857,-87.603 0.002,0.012 0.762,-1.717 -0.764,1.705 m -2.869,-1.351 1.254,0.904 -1.254,-0.907 v 0.003 m -71.97,144.269 1.596,-0.777 -1.595,0.772 -0.001,0.005 m 127.709,-23.331 0.393,1.252 -0.385,-1.256 -0.01,0.004 m -154.013,469.999 0.735,-0.812 -0.735,0.812 v 0 m -196.959,-248.585 -0.006,-0.004 -1.145,-0.044 1.151,0.048 m -27.058,72.72 1.484,0.905 -1.481,-0.907 h -0.003 m 364.685,-432.328 -0.002,-0.003 -1.716,-1.375 1.718,1.378 m -18.506,-3.239 -1.765,0.195 1.761,-0.187 0.004,-0.008 m -301.101,98.655 -0.976,2.146 0.983,-2.152 -0.007,0.006 m 459.398,107.781 -2.116,-1.087 2.108,1.084 0.01,0.003 m -474.08,133.379 1.313,-0.1 -1.309,0.097 -0.004,0.003 m 478.151,-130.733 -0.537,-1.88 0.534,1.876 v 0.004 m -91.561,-94.641 1.265,0.438 -1.267,-0.445 v 0.007 m -56.696,26.87 -1.975,-1.119 1.975,1.119 v 0 m 19.435,30.455 v -0.003 l 0.396,-1.199 -0.398,1.202 m -188.908,-69.971 3.063,-0.845 -3.056,0.833 -0.007,0.012 m 208.946,-90.212 -1.467,-0.831 1.455,0.839 0.012,-0.008 m -377.72,342.48 1.021,-1.022 -1.017,1.005 -0.004,0.017 m -2.146,-82.35 -0.007,0.004 1.239,-0.123 -1.232,0.119 m 84.483,-246.869 -0.225,0.941 0.232,-0.938 -0.007,-0.003 m -23.799,27.671 1.764,-0.736 -1.768,0.734 0.004,0.002 m 30.34,216.819 1.473,-1.504 -1.477,1.5 0.004,0.004 m 35.802,150.253 0.997,1.882 -0.994,-1.913 -0.003,0.031 m -58.489,-62.734 1.465,1.316 -1.462,-1.331 -0.003,0.015 m 55.914,-376.078 0.01,-0.007 -2.278,1.122 2.268,-1.115 m 216.682,162.659 1.486,0.885 -1.486,-0.885 v 0 m -59.48,-63.268 0.003,10e-4 -2.446,-3.168 2.443,3.167 m 58.893,340.476 2.391,-0.095 -2.392,0.081 0.001,0.014 m 64.336,-266.935 -1.557,-0.426 1.553,0.429 v -0.003 m -283.06,16.541 2.16,0.426 -2.148,-0.429 -0.012,0.003 m -66.848,-107.672 -0.004,0.006 1.78,-1.557 -1.776,1.551 m 510.154,107.419 -0.622,-0.431 0.629,0.441 -0.01,-0.01 m -599.998,3.503 -0.067,-1.381 0.065,1.369 0.002,0.012 m 390.345,-101.919 -0.93,-1.58 0.925,1.585 v -0.005 m 96.343,121.108 1.6,1.752 -1.598,-1.754 v 0.002 m -88.695,-92.057 -0.499,-1.221 0.484,1.208 0.015,0.013 m 127.132,93.942 1.058,-0.627 -1.063,0.625 0.01,0.002 m 11.041,6.053 -1.288,-0.029 1.302,0.048 -0.014,-0.019 m -219.253,-113.929 -1.207,-1.309 1.206,1.312 10e-4,-0.003 M 641.4,882.424 l 2.132,-0.42 -2.13,0.416 -0.002,0.004 m 116.945,337.632 1.226,0.54 -1.228,-0.54 h 0.002 m -33.479,-593.335 0.289,0.576 -0.289,-0.578 v 0.002 m 415.899,195.86 1.413,-0.224 -1.416,0.22 v 0.004 m -441.443,-145.8 h -10e-4 l 1.436,-0.675 -1.435,0.675 m 79.257,359.158 0.017,0.01 -0.994,-1.987 0.977,1.981 m -147.668,-137.788 1.357,-1.92 -1.351,1.903 -0.006,0.017 m 328.283,-188.062 0.823,-2.243 -0.845,2.251 0.022,-0.008 m -179.776,344.212 -0.047,-0.011 -1.583,0.143 1.63,-0.132 m 58.607,64.366 -0.525,1.115 0.55,-1.112 h -0.025 m -122.478,-153.635 -0.982,-4.645 0.981,4.642 10e-4,0.003 m 516.443,-112.018 -0.564,-0.071 0.565,0.078 -10e-4,-0.007 m -634.813,-1.097 -0.044,2.094 0.046,-2.091 -0.002,-0.003 m 554.248,-45.592 -1.535,-2.124 1.524,2.12 0.011,0.004 m -343.98,-240.589 -2.76,0.633 2.766,-0.632 -0.006,-10e-4 m 193.177,209.604 1.231,-0.771 -1.233,0.766 v 0.005 m -242.037,92.188 2.161,0.391 -2.165,-0.392 0.004,10e-4 m 80.476,-158.069 1.683,-0.514 -1.683,0.514 v 0 m -141.193,249.922 1.75,1.586 -1.749,-1.591 -10e-4,0.005 m 317.964,-233.262 0.728,-1.276 -0.734,1.269 0.01,0.007 m -172.778,395.86 -2.818,0.144 2.823,-0.143 -0.005,-10e-4 m 237.472,-259.913 -0.946,1.411 0.949,-1.413 v 0.002 m -50.525,-240.118 -0.01,-0.007 0.272,0.975 -0.267,-0.968 m -300.81,4.115 0.914,-0.901 -0.914,0.901 v 0 m 289.235,164.76 0.239,-2.477 -0.247,2.463 0.01,0.014 m -3.509,162.947 1.189,1.672 -1.184,-1.681 v 0.009 m 192.382,-122.596 0.692,-0.438 -0.703,0.419 0.011,0.019 m 11.4,-53.889 -0.166,-1.316 0.16,1.306 0.01,0.01 m -492.3,-161.719 0.797,0.211 -0.79,-0.213 -0.007,0.002 m -51.784,87.35 -1.107,1.531 1.108,-1.527 -10e-4,-0.004 m 70.738,-110.487 10e-4,-0.002 -2.722,1.839 2.721,-1.837 m -10.362,299.347 -2.077,2.947 2.095,-2.938 -0.018,-0.009 m 249.808,137.97 1.941,-0.982 -1.942,0.973 10e-4,0.01 m -174.672,-282.29 0.009,0.003 -1.336,-0.842 1.327,0.839 m 23.093,373.871 2.342,0.316 -2.34,-0.317 -0.002,10e-4 m 409.806,-157.786 -0.196,1.95 0.198,-1.962 v 0.012 m -571.488,-249.23 -0.975,1.083 0.982,-1.089 -0.007,0.006 m 200.796,423.687 0.234,-1.202 -0.239,1.205 h 0.005 m -99.368,-89.389 1.045,-0.974 -1.045,0.968 v 0.01 m -112.751,-160.658 0.878,1.014 -0.873,-1.015 -0.005,10e-4 m 357.073,-162.652 v 0.002 l -0.743,1.668 0.746,-1.67 m -316.028,-50.142 -1.267,0.94 1.271,-0.942 -0.004,0.002 m 127.181,-23.948 1.942,-1.005 -1.944,0.988 0.002,0.017 m 301.649,197.506 1.138,0.146 -1.143,-0.154 v 0.008 m -254.657,363.026 1.604,0.049 -1.605,-0.064 10e-4,0.015 m 84.365,-577.911 -1.468,-0.364 1.469,0.371 -10e-4,-0.007 m -118.202,203.002 1.536,-0.281 -1.534,0.267 -0.002,0.014 m -42.067,-116.936 -1.49,2.246 1.494,-2.241 -0.004,-0.005 m -94.158,-47.043 1.573,-1.585 -1.585,1.592 0.012,-0.007 m 452.763,137.143 v 0.004 l 0.242,-1.605 -0.244,1.601 m -3.242,-4.436 -0.012,0.01 -0.898,1.113 0.91,-1.123 m -285.356,407.782 1.267,-0.227 -1.268,0.225 h 10e-4 m 1.693,-482.956 -0.004,0.004 2.052,-0.339 -2.048,0.335 m 284.518,81.886 v 0.002 l -0.186,1.19 0.188,-1.192 M 962.81,653.278 l 0.342,-1.362 -0.36,1.393 0.018,-0.031 m -227.026,-52.497 -0.214,1.666 0.217,-1.666 h -0.003 m 162.53,-20.559 1.188,0.63 -1.186,-0.631 -0.002,10e-4 m 263.76,235.031 -0.429,-1.614 0.423,1.606 0.01,0.008 m -272.827,-35.163 -1.763,-0.99 1.762,1.014 10e-4,-0.024 m -128.228,441.133 1.418,0.609 -1.432,-0.615 0.014,0.01 m 69.715,-98.579 1.783,-1.187 -1.783,1.121 v 0.066 m -123.203,-184.879 -3.67,-0.526 3.677,0.53 -0.007,-0.004 m 313.72,-143.044 1.541,-0.922 -1.546,0.914 v 0.008 m 38.085,-35.852 -0.525,1.219 0.525,-1.219 v 0 m -60.53,273.959 1.083,-1.385 -1.091,1.38 h 0.008 m -151.727,-298.566 1.208,-0.815 -1.213,0.818 0.005,-0.003 m -90.704,275.319 1.653,0.312 -1.651,-0.325 -0.002,0.013 m -118.558,-124.353 2.464,-2.264 -2.462,2.26 -0.002,0.004 m 68.916,-215.141 -0.838,1.119 0.842,-1.117 -0.004,-0.002 m 199.421,-86.113 0.06,1.211 -0.038,-1.219 -0.022,0.008 m 247.467,225.34 0.118,-1.865 -0.121,1.876 v -0.011 M 910.53,551.464 l -0.755,0.081 0.761,-0.081 h -0.006 m -282.046,491.74 1.261,1.231 -1.261,-1.255 v 0.024 m 409.36,-238.826 1.483,-0.934 -1.485,0.93 v 0.004 m -32.555,-122.262 -0.974,0.561 0.978,-0.561 v 0 m -177.84,-20.291 -1.574,1.411 1.574,-1.381 v -0.03 m 303.02,92.862 0.01,-0.002 -1.422,0.455 1.416,-0.453 m -173.664,149.647 -1.557,-0.368 1.57,0.382 -0.013,-0.014 m 36.605,-287.601 -0.783,-0.836 0.774,0.836 h 0.009 m -33.766,286.779 1.604,-0.023 -1.62,-0.087 0.016,0.11 m -211.906,-312.76 -1.479,1.485 1.498,-1.494 -0.019,0.009 m -39.15,78.494 -1.155,1.464 1.193,-1.481 -0.038,0.017 m -48.286,274.197 1.249,0.211 -1.253,-0.229 0.004,0.018 m 53.812,10.523 1.334,3.973 -1.328,-3.995 -0.006,0.022 m -25.922,-263.693 -1.057,1.027 1.085,-1.044 -0.028,0.017 m 379.74,69.208 v 0.003 l -0.339,1.438 0.343,-1.441 m -281.439,286.359 -0.96,-1.463 0.956,1.466 h 0.004 m 56.011,-491.083 -0.886,0.162 0.886,-0.162 v 0 m -18.259,108.752 2.112,0.485 -2.119,-0.49 0.007,0.005 m -131.572,19.525 -0.542,1.074 0.554,-1.081 -0.012,0.007 m 44.55,353.363 0.843,1.563 -0.841,-1.575 -0.002,0.012 m -96.608,-153.644 0.977,-0.532 -1.021,0.551 0.044,-0.019 m 94.002,-249.845 1.26,0.041 -1.239,-0.045 -0.021,0.004 m 92.897,38.901 -1.545,-0.268 1.528,0.268 h 0.017 M 686.83,689.758 v 0.002 l 1.71,-1.689 -1.71,1.687 m 41.611,206.661 1.646,-0.984 -1.639,0.965 -0.007,0.019 m 232.885,-261.073 -0.359,0.808 0.36,-0.8 -10e-4,-0.008 m -209.469,-47.208 -0.172,-0.43 0.168,0.433 0.004,-0.003 m 121.437,547.969 2.16,-0.18 -2.16,0.176 v 0 m 141.628,-207.393 1.64,0.083 -1.636,-0.084 v 0.001 m 226.008,48.625 0.596,-2.619 -0.594,2.611 v 0.008 m -627.114,-188.166 -0.246,1.702 0.251,-1.709 -0.005,0.007 m 292.589,-208.779 1.14,0.639 -1.142,-0.641 0.002,0.002 m -29.741,145.558 -0.048,-2.048 0.043,2.052 0.005,-0.004 m -78.655,-33.906 -0.457,1.306 0.473,-1.289 -0.016,-0.017 m 346.381,105.012 -0.538,1.049 0.54,-1.048 v -10e-4 m -139.529,-97.136 0.246,1.384 -0.244,-1.386 v 0.002 m -304.02,264.357 -0.273,-2.092 0.265,2.124 0.008,-0.032 m 349.63,-136.057 1.242,-0.088 -1.244,0.083 v 0.005 m 81.992,-75.429 v -10e-4 l -0.786,0.933 0.791,-0.932 m -349.869,-179.877 -1.01,0.526 1.012,-0.526 h -0.002 m -120.92,318.23 0.487,1.192 -0.482,-1.195 -0.005,0.003 m 184.821,-234.298 1.759,-1.637 -1.758,1.63 -10e-4,0.007 m -86.918,356.148 1.856,0.107 -1.855,-0.117 -10e-4,0.01 m 197.783,-365.117 0.003,0.004 -0.325,-1.32 0.322,1.316 m -323.979,402.1 1.529,0.219 -1.529,-0.222 v 0 m 608.449,-214.715 -0.034,-1.12 0.033,1.117 10e-4,0.003 M 671.812,714.13 l -0.507,1.177 0.509,-1.179 -0.002,0.002 m 392.638,40.264 -1.688,-0.954 1.676,0.955 0.012,-10e-4 m -61.741,-72.156 0.321,-2.421 -0.328,2.421 h 0.01 m -175.723,34.998 -0.799,1.819 0.809,-1.796 -0.01,-0.023 m 170.988,311.174 0.717,1.106 -0.718,-1.111 10e-4,0.01 m -323.607,58.726 0.889,-0.139 -0.889,0.131 v 0.01 M 652.498,960.811 h 0.002 l 0.945,-1.135 -0.947,1.135 m 116.181,-381.905 0.674,-0.453 -0.708,0.465 0.034,-0.012 m -65.481,356.878 -0.003,-0.002 0.805,1.442 -0.802,-1.44 m 96.025,-252.351 -0.002,0.002 -0.77,1.205 0.772,-1.207 m 13.975,17.63 -0.847,-1.319 0.84,1.324 0.007,-0.005 m 5.206,-25.687 -1.938,-1.275 1.9,1.278 0.038,-0.003 m -192.931,365.669 1.059,1.471 -1.059,-1.51 v 0.039 m 83.127,-103.967 1.183,0.844 -1.18,-0.846 -0.003,0.002 m 245.461,-307.988 -0.005,-0.015 -1.003,-0.993 1.008,1.008 m -276.083,72.16 0.212,1.117 -0.209,-1.119 -0.003,0.002 m -77.718,159.994 0.313,-1.594 -0.318,1.587 0.005,0.007 m 237.991,-305.577 -0.937,0.211 0.942,-0.211 h -0.005 m -27.222,288.945 2.926,-1.521 -2.913,1.509 -0.013,0.012 m 94.111,-96.011 1.823,-0.651 -1.811,0.637 -0.012,0.014 m -39.905,381.569 0.49,-1.088 -0.49,1.077 v 0.011 m -23.025,-280.993 -0.002,-0.006 -0.991,0.982 0.993,-0.976 m -89.207,18.766 1.39,0.182 -1.386,-0.191 -0.004,0.009 m -148.382,-12.585 0.296,1.171 -0.29,-1.184 -0.006,0.013 m 181.503,-283.387 -2.618,0.94 2.615,-0.938 0.003,-0.002 m 316.016,232.702 1.255,0.611 -1.257,-0.623 v 0.012 m -268.92,318.878 0.962,-0.868 -0.975,0.86 0.013,0.01 m 179.028,-340.225 1.357,0.455 -1.391,-0.517 0.034,0.062 m 39.473,45.931 1.062,0.801 -1.062,-0.807 v 0.006 m 0.011,-105.402 -2.519,-1.121 2.516,1.12 v 10e-4 m -176.873,-7.934 0.386,1.208 -0.381,-1.212 -0.005,0.004 m -104.67,301.88 1.186,1.146 -1.184,-1.155 -0.002,0.01 m 76.097,-335.186 0.004,0.01 0.935,-0.945 -0.939,0.935 m -56.32,-90.166 -0.751,0.758 0.753,-0.747 -0.002,-0.011 m -67.274,393.91 -1.614,-1.059 1.61,1.076 0.004,-0.017 m 463.689,-168.859 0.271,-1.047 -0.272,1.05 10e-4,-0.003 m -23.2,292.66 -0.012,0.644 0.035,-0.709 -0.023,0.065 m -37.274,-241.901 -0.492,1.314 0.498,-1.309 -0.01,-0.005 m -242.281,-89.294 0.852,-1.125 -0.85,1.106 -0.002,0.019 m 170.736,-15.853 1.226,0.009 -1.225,-0.016 -10e-4,0.007 m -324.017,-122.906 -0.028,-0.018 -0.702,-0.435 0.73,0.453 m 197.659,42.42 -0.271,-1.213 0.269,1.217 0.002,-0.004 m 169.112,141.244 0.718,-1.176 -0.736,1.146 0.018,0.03 m -263.898,298.375 -0.833,1.038 0.84,-1.031 -0.007,-0.01 m -15.565,-372.682 1.267,2.068 -1.269,-2.072 0.002,0.004 m 1.202,-83.166 1.94,-1.317 -1.957,1.284 0.017,0.033 m 14.701,454.494 1.35,0.06 -1.346,-0.065 -0.004,0.01 m -58.748,-347.775 -0.005,0.008 2.35,-1.133 -2.345,1.125 m 50.481,-63.134 -2.286,0.413 2.293,-0.381 -0.007,-0.032 m 9.934,-48.946 -0.542,-1.288 0.53,1.313 0.012,-0.025 m -140.935,20.528 -0.017,0.001 -0.247,1.127 0.264,-1.128 m 129.435,-28.645 -1.079,-0.436 1.083,0.439 -0.004,-0.003 m -142.166,317.297 1.396,1.079 -1.39,-1.102 -0.006,0.023 m 224.219,-395.73 -1.887,-0.049 1.885,0.07 0.002,-0.021 m 145.417,183.195 0.998,0.965 -0.992,-0.964 -0.01,-10e-4 m 92.671,41.611 -0.192,1.845 0.198,-1.837 -0.01,-0.008 m -88.074,-37.528 0.622,1.67 -0.615,-1.669 -0.01,-10e-4 m -183.204,-51.551 -1.542,0.831 1.543,-0.828 -10e-4,-0.003 m -10.765,-29.364 -1.248,-0.746 1.245,0.761 0.003,-0.015 m 92.581,224.846 2.475,0.168 -2.477,-0.178 0.002,0.01 M 824.91,665.583 l -1.866,-0.668 1.835,0.668 h 0.031 m -41.166,19.798 0.41,0.915 -0.388,-0.93 -0.022,0.015 m 205.779,-73.66 0.955,-0.69 -0.975,0.684 0.02,0.006 m 58.557,167.815 0.782,-1.128 -0.802,1.099 0.02,0.029 m 103.743,44.802 -0.887,-1.022 0.882,1.029 0.01,-0.007 m -314.549,-151.213 1.693,-1.283 -1.709,1.227 0.016,0.056 m -113.503,299.038 0.009,0.019 1.191,0.976 -1.2,-0.995 m 173.976,-219.551 1.773,2.701 -1.773,-2.71 v 0.009 m -73.468,-87.904 -0.646,-0.807 0.636,0.8 0.01,0.007 m -45.454,109.524 -1.516,0.836 1.506,-0.813 0.01,-0.023 m 20.684,-167.516 0.385,0.551 -0.365,-0.549 -0.02,-0.002 M 960,631.861 l -1.75,-0.781 1.75,0.784 v -0.003 m -87.17,101.522 1.763,0.099 -1.751,-0.101 -0.012,0.002 m -173.59,-53.38 -1.146,0.035 1.143,-0.029 0.003,-0.006 m 126.727,32.139 -0.84,1.503 0.847,-1.49 -0.007,-0.013 m 196.959,34.176 v -0.004 l -0.953,-1.118 0.955,1.122 m -323.944,186.694 -0.426,1.23 0.43,-1.232 -0.004,0.002 m 130.931,-260.684 1.099,-0.845 -1.121,0.822 0.022,0.023 m 59.92,-7.068 -1.134,-1.668 1.095,1.686 0.039,-0.018 m -17.241,51.719 0.961,-0.906 -0.963,0.903 0.002,0.003 m 136.725,38.684 -2.054,-3.254 2.045,3.241 0.01,0.013 M 900,660.756 l -1.146,-1.074 1.146,1.074 v 0 m -0.907,0.607 -0.899,-0.903 0.848,0.894 0.051,0.009"
+           id="polygon0" />
+      </g>
+      <g
+         id="layer2-9">
+        <radialGradient
+           gradientUnits="userSpaceOnUse"
+           gradientTransform="matrix(0.0194,0,0,-0.0205,772.9011,743.9232)"
+           r="16567.537"
+           cy="-7131.8633"
+           cx="7553.0029"
+           id="radialGradient8499">
+          <stop
+             id="stop8495"
+             style="stop-color:#0101FF"
+             offset="0" />
+          <stop
+             id="stop8497"
+             style="stop-color:#000080"
+             offset="1" />
+        </radialGradient>
+        <path
+           style="fill:url(#polygon8_1_)"
+           inkscape:connector-curvature="0"
+           d="m 816.922,1128.468 -2.089,0.699 -5.204,-0.451 -2.362,4.688 0.97,-5.429 2.884,0.622 -5.426,-1.635 3.239,0.474 -3.058,-1.649 -6.19,1.688 -5.01,-1.841 -6.294,2.965 -6.267,-2.248 -11.858,0.622 -3.277,-2.11 -6.255,1.726 -0.569,-1.853 1.598,0.088 -7.674,-5.048 -0.526,0.8 -2.801,-4.449 -3.987,-2.45 -7.489,-2.149 -4.075,2.791 -5.911,-2.265 -1.703,1.517 1.218,1.064 -2.811,0.313 -2.108,-3.021 -6.138,-2.91 -1.946,-3.2 -6.128,-1.319 1.733,-0.028 -1.185,-0.936 2.405,1.475 3.112,0.641 2.031,3.274 6.162,2.694 2.52,3.262 2.175,-0.292 -1.289,-1.043 1.813,-1.662 6.354,1.978 3.777,-2.467 10.746,2.95 6.032,6.645 7.135,4.453 3.775,-0.669 2.707,1.815 5.35,-0.098 0.69,-1.761 5.245,1.398 -3.826,-1.624 -6.06,-8.591 -11.351,-7.879 -15.051,-4.549 2.716,0.103 11.982,3.801 11.855,8.408 9.226,10.047 9.08,2.047 4.876,-2.362 5.275,1.784 3.654,-2.137 6.841,1.397 2.06,0.954 -0.222,1.303 1.885,0.172 9.143,-2.311 -6.124,1.778 m -101.765,-297.499 -4.463,4.921 -3.234,-0.215 3.309,-9.46 6.579,-6.841 -2.142,-1.029 6.784,-4.172 0.031,2.345 4.798,-0.432 4.49,3.809 0.2,-3.138 -1.968,-1.74 1.124,-1.407 -7.829,-3.232 -0.031,-2.944 -2.321,-0.624 1.117,-2.722 -7.132,-0.304 -1.221,-1.218 1.493,-1.642 -3.937,-1.635 13.742,-2.491 0.637,1.367 2.39,-1.944 -1.669,1.985 1.558,-0.201 1.199,-2.075 4.214,4.58 -0.994,5.152 2.803,2.061 -3.659,8.309 9.943,9.658 0.666,7.809 -2.488,1.511 -2.447,-2.215 -0.56,-5.02 -0.442,4.248 -5.17,6.012 -3.14,0.502 1.632,-6.14 -4.538,-0.688 3.723,-2.039 2.62,-5.148 -3.418,-5.673 -4.716,4.209 1.29,-2.397 -3.735,1.295 -5.089,8.974 0.001,0.039 m 243.432,-268.732 6.997,0.843 2.506,1.658 4.415,1.678 10.577,1.257 -10.588,-1.241 -4.588,-1.726 -2.76,-1.652 -9.97,-1.143 -8.12,-1.725 -16.184,-0.911 -2.219,1.706 6.809,2.68 3.711,-0.222 3.805,1.056 13.046,1.814 -13.047,-1.796 -3.78,-1.001 -2.91,0.154 3.329,1.975 -0.442,4.404 -10.363,4.353 -4,0.163 -0.265,1.33 0.133,-1.347 3.96,-0.19 9.489,-4.065 1.122,-4.408 -7.984,-3.768 -12.756,-1.885 0.023,-0.455 -6.067,-0.94 2.252,-2.71 1.685,0.181 -1.432,-0.09 -0.818,0.863 -1.573,1.743 6.04,0.928 -0.031,0.446 10.024,1.139 -0.558,-1.737 4.832,-0.762 14.195,1.332 7.987,1.695 2.069,0.173 -0.678,-0.61 2.104,0.813 h 0.023 m 212.155,169.835 -3.231,-3.417 -0.862,-3.395 -1.164,1.438 -8.193,-1.766 -5.172,-4.227 1.495,2.112 -5.022,-2.058 -4.6,-5.62 -0.193,-4.153 -3.267,-3.859 -2.399,-6.763 0.427,-4.116 1.335,0.152 4.927,4.688 0.835,-0.753 0.088,4.906 2.303,2.974 1.436,-0.585 -0.531,3.032 1.219,1.183 0.749,-1.11 4.352,2.259 1.611,-2.755 2.626,3.04 4.06,2.141 -3.703,-3.332 -0.882,-2.64 4.096,0.414 2.036,4.439 -1.638,0.873 3.271,3.452 2.006,0.793 -1.033,-0.542 v -1.854 l 1.722,1.084 -0.421,0.924 1.868,1.968 -0.797,-1.843 1.568,0.255 7.807,7.233 1.42,7.647 -3.521,4.659 -4.888,-3.596 -1.767,-3.276 0.024,-0.006 m -122.113,-99.839 4.864,2.299 5.618,-4.231 -5.788,-10.162 -1.659,-5.761 3.069,-1.365 -1.17,-3.012 1.546,-3.659 1.492,-0.665 4.443,1.452 -4.372,-1.385 -1.595,1.906 -0.229,5.45 -2.602,1.177 1.047,4.731 6.54,10.472 1.439,-0.708 4.101,0.87 2.976,2.417 7.022,3.051 -7.048,-3.003 -2.971,-2.427 -3.981,-0.802 -7.898,5.762 -5.525,-2.335 -5.616,-0.322 -5.979,-1.739 -3.368,-1.754 -2.633,-3.74 2.378,1.546 0.453,2.209 3.016,1.541 6.045,1.844 6.367,0.344 0.018,-0.001 m -105.051,-79.509 -10.35,-1.143 4.597,0.469 -4.875,-0.496 -15.951,-1.142 -2.821,-0.126 0.873,0.037 -2.125,-0.085 -1.005,-0.019 -12.577,-0.023 -0.881,0.113 2.684,0.166 -3.577,0.047 3.296,-0.059 -2.703,-0.165 1.697,-0.151 -1.221,0.073 0.5,-0.069 h -2.039 l 6.584,-0.04 6.738,0.065 -0.413,-0.032 1.253,0.042 7.08,0.293 11.521,0.795 6.547,0.623 7.145,0.821 0.023,0.006 m 77.907,46.088 3.371,0.453 1.291,-2.486 -1.277,2.558 -11.363,-0.647 -2.149,0.803 0.838,1.66 -12.836,1.318 1.054,2.449 -1.993,-1.57 0.727,-1.036 12.932,-1.315 -0.868,-1.569 1.885,-0.627 -2.342,-1.349 -0.236,-1.327 2.903,-0.865 -1.083,-2.208 1.286,2.262 -2.927,0.815 0.544,1.563 1.883,0.939 8.348,0.187 0.012,-0.008 m 210.433,381.676 0.983,-10.801 1.169,-3.964 0.596,-0.284 0.67,-3.338 0.227,0.984 0.852,-2.294 0.481,2.006 0.757,-3.154 0.159,0.642 -1.288,4.138 -0.275,4.859 -1.373,5.196 1.031,-1.479 -0.784,3.074 -0.866,1.276 0.072,1.72 -0.523,1.624 0.281,-2.6 -1.066,1.093 -0.948,4.273 -0.151,-2.979 v 0.008 m -129.547,-296.871 1.535,1.843 1.842,0.223 -0.775,-2.592 2.816,3.314 0.713,-1.617 0.805,3.042 -0.612,-1.255 -4.044,-0.264 -4.682,-4.759 -1.646,-0.358 1.139,0.1 -1.552,-1.104 1.089,-0.469 -1.124,-3.724 -1.527,-1.148 1.31,0.603 -0.649,-1.42 4.093,8.549 1.231,0.998 0.038,0.038 m -348.437,-16.224 3.85,0.704 0.797,-1.462 1.161,2.188 0.371,-3.215 -2.39,-2.031 2.172,-1.175 5.767,6.238 -0.575,1.719 -3.388,-1.056 0.585,3.052 2.363,0.565 -5.297,2.208 -0.542,-3.162 -2.483,1.566 -3.529,-1.463 4.561,-0.714 -4.183,-1.031 0.745,-2.922 0.015,-0.009 m 265.271,-89.137 -2.28,-1.08 1.043,-0.265 3.955,-0.171 -0.024,0.298 0.652,0.083 0.092,-0.635 2.718,0.695 -1.611,-0.095 1.249,0.698 -1.236,-0.607 -5.97,0.146 2.79,1.331 2.709,-0.081 -0.238,0.418 -1.146,-0.349 0.771,1.059 -3.466,-1.447 -0.01,0.002 m -283.704,115.788 0.3,-6.184 0.477,3.564 3.297,-1.023 1.241,1.327 3.846,-5.242 -2.117,7.132 7.064,1.48 1.129,3.455 -3.225,-3.657 -1.652,0.41 2.795,1.096 0.626,1.288 -1.681,-1.429 0.957,1.516 -2.037,-1.492 -9.377,-0.277 -1.678,-1.956 0.035,-0.008 m 408.174,-14.484 3.613,4.015 1.378,0.311 1.993,4.22 -1.491,-0.458 0.979,3.393 -4.55,-2.829 -4.529,-4.172 -0.465,-2.158 -2.109,-1.207 0.604,-0.647 -2.955,-2.615 0.354,-1.63 -1.658,-2.35 3.449,3.871 1.975,1.17 1.662,-1.16 1.75,2.244 v 0.002 m -327.174,119.544 0.679,4.569 2.202,1.11 -3.698,-0.06 -1.37,-2.101 -2.877,1.398 0.521,2.184 -1.425,-0.616 1.299,-2.399 -2.244,-5.062 -0.801,2.086 1.282,-4.825 1.746,7.379 1.938,0.013 -0.161,-3.792 0.209,3.143 2.331,0.664 0.369,-3.691 m 307.643,243.435 -0.256,-1.704 -3.89,0.12 3.288,-0.619 0.498,-3.622 -0.731,-0.874 -1.184,0.563 1.156,-0.882 -3.12,1.833 2.635,-2.572 -3.364,0.028 -1.179,-2.332 -3.6,1.906 3.256,-2.028 -0.834,-1.845 6.412,3.833 0.117,-6.47 0.796,14.665 m -67.732,-336.407 -3.208,-0.877 1.819,-0.722 -0.855,-2.577 -4.925,0.519 -1.713,-2.263 -4.353,-1.087 8.246,0.726 -2.966,0.41 2.521,1.784 1.976,-1.996 -2.343,-1.487 1.497,-0.575 2.913,2.465 0.857,4.125 1.282,-0.533 -0.711,2.059 -0.037,0.029 m -316.864,363.383 2.169,-4.114 4.373,-1.359 4.386,-0.01 3.922,2.496 14.527,-0.725 0.396,-1.444 -0.616,-4.706 1.082,5.761 2.552,1.12 -13.785,-0.01 -4.309,0.166 -3.963,-2.465 -4.088,-0.01 -6.619,5.331 -0.027,-0.034 m 305.046,-367.095 3.545,2.345 -2.072,-2.235 1.729,0.112 -1.922,-0.583 1.516,-0.701 2.447,5.593 3.186,2.669 0.345,-1.917 2.098,2.267 -3.709,-0.322 -3.302,-4.462 -2.816,-2.019 -1.404,0.42 0.343,-1.185 0.016,0.018 m 171.524,290.916 -6.208,0.809 -9.034,13.669 -2.812,6.055 0.188,3.926 -7.477,17.135 -0.386,4.405 -0.036,-3.687 5.483,-13.354 1.425,-15.287 -1.14,14.895 2.106,-9.132 5.328,-10.428 6.604,-8.625 5.947,-0.394 0.012,0.013 m -495.398,-236.797 -0.293,-2.827 2.888,-1.801 1.199,2.801 2.74,-3.402 -0.847,1.996 -8.727,15.985 -4.079,2.946 4.668,-5.711 -1.813,-0.295 2.365,-3.657 -1.844,-0.251 2.04,-5.847 1.327,0.102 0.376,-0.039 m 28.809,-89.563 2.299,-1.836 3.797,-7.296 3.545,-1.208 5.827,-5.229 -0.506,-2.849 2.82,-2.922 5.858,-1.459 -6.747,2.516 -1.421,5.403 -5.299,4.415 -3.74,1.243 -4.051,7.612 -2.372,1.612 -0.01,-0.002 m 65.964,548.695 -15.764,-3.07 -1.77,3.832 1.188,2.604 -4.043,1.447 2.524,2.685 -2.952,-2.924 4.016,-1.068 -1.166,-3.23 0.701,-0.363 1.206,-3.054 2.567,0.017 13.479,3.117 0.014,0.01 m 262.337,-558.625 -3.475,-1.54 5.522,1.479 1.48,1.72 1.711,0.175 0.084,-1.365 0.346,1.059 2.304,0.478 -3.799,-0.155 -0.26,1.371 -1.438,-2.188 -0.796,0.87 -1.674,-1.898 v -0.006 m -121.187,-63.329 2.009,0.051 1.005,1.303 1.756,-1.203 -1.177,0.883 1.303,1.286 -2.501,-0.677 -1.431,1.298 0.337,-1.777 -4.193,-1.476 -1.214,0.632 -1.059,-1.494 5.158,1.169 0.007,0.005 m -188.065,18.826 -6.755,-2.43 -4.274,0.257 1.038,-2.854 2.78,-1.037 2.666,-2.133 3.911,-1.024 -3.578,0.96 -3.589,2.754 -2.107,0.52 0.257,2.654 2.28,-0.39 7.379,2.711 -0.008,0.012 m 231.504,-43.25 -1.292,-0.543 5.077,0.33 4.799,1.259 -0.97,-0.518 10.85,3.526 2.931,0.746 4.338,1.708 2.589,1.372 -5.272,-2.192 -6.363,-2.049 -8.184,-2.234 -8.504,-1.404 h 10e-4 m 53.869,119.291 3.059,-0.807 7.019,2.709 1.277,2.097 -1.603,1.411 v -1.964 l -4.582,0.346 -4.015,-1.634 3.292,0.275 -3.182,-1.303 3.308,0.648 -0.642,-1.545 -3.933,-0.233 m -325.522,154.33 5.467,2.589 -0.982,-1.092 6.513,0.532 -2.146,2.173 -11.754,0.999 -5.223,-4.671 5.177,-3.759 0.197,2.269 -2.294,-0.532 -0.54,1.69 5.583,-0.203 0.002,0.005 m 366.258,-226.398 0.849,1.896 -6.146,-3.889 -0.074,1.06 -1.803,-1.491 1.668,1.028 -0.575,-1.267 3.925,2.602 0.229,-0.384 1.528,1.175 -1.166,-1.787 1.56,1.053 0.01,0.004 m 29.06,121.854 -0.043,-1.768 5.305,4.577 -1.284,3.273 2.038,3.113 -0.435,3.571 0.264,-3.24 -2.62,-3.719 1.184,-2.732 -2.784,-3.111 -11.313,2.95 9.688,-2.914 m -79.074,-93.582 -4.917,-0.05 5.248,4.407 0.402,3.571 -12.021,-3.705 -3.483,-3.847 3.55,3.811 11.807,3.568 -0.396,-3.462 -5.234,-4.428 5.013,0.124 0.031,0.011 m 145.696,61.714 4.199,6.792 2.278,3.479 2.458,3.01 4.885,7.959 -0.028,-0.21 0.682,1.34 -5.517,-9.043 -2.487,-3.053 -2.282,-3.494 -4.129,-6.679 -0.059,-0.101 m -64.532,6.015 1.775,-0.079 2.152,2.294 4.121,5.225 0.241,2.968 -2.126,-1.804 0.901,-1.039 -2.958,-2.679 0.583,-0.804 -2.129,-3.218 -2.522,-0.865 h -0.038 m 62.499,56.638 0.683,-0.808 2.975,3.181 1.966,-1.421 0.753,-3.087 1.651,1.287 -1.619,-1.207 -0.134,2.922 -2.586,1.571 -3.029,-3.206 -0.642,0.755 -0.018,0.013 m -319.818,437.614 -2.343,-1.028 -1.325,0.471 1.25,-0.729 -2.162,-1.632 4.405,0.012 -0.255,0.578 2.295,1.208 -3.695,-1.595 -1.788,0.335 3.641,2.389 -0.023,-0.01 m 357.409,-206.394 0.941,-5.379 0.22,8.932 -0.756,2.837 1.293,0.051 -0.199,5.715 -1.193,1.531 0.307,-4.27 -1.215,-1.911 1.126,-9.378 -0.524,1.872 m 5.584,6.189 0.401,-1.382 0.266,0.456 -0.939,4.965 -1.57,5.104 -1.859,6.507 -0.614,1.222 1.575,-5.924 1.275,-3.857 1.452,-7.053 0.013,-0.038 m -111.456,-364.358 -3.223,-3.009 -4.562,-7.05 -2.705,-2.606 3.168,2.672 4.069,6.345 4.993,4.48 4.216,2.418 -2.104,-0.006 -3.857,-3.248 0.01,0.004 m -366.122,199.982 -2.906,1.208 -0.748,3.314 -3.495,0.522 -9.759,-5.203 3.749,-1.723 6.864,3.262 1.681,-0.968 -2.529,-1.202 7.137,0.789 0.006,10e-4 m 309.779,-169.954 -6.854,2.779 -3.844,-0.597 -2.58,-2.049 -2.148,1.394 2.062,-1.475 2.707,2.061 3.773,0.538 6.85,-2.65 0.034,-0.001 m 67.072,41.018 -8.382,-9.454 -4.33,-2.835 -2.287,-4.677 2.062,3.93 3.011,2.401 2.675,0.386 0.462,2.328 6.791,7.916 v 0.005 m -39.688,-23.055 3.479,-0.981 -1.095,-5.011 1.312,-2.358 3.502,-0.717 -3.318,0.979 -1.417,2.149 1.043,5.097 -3.485,0.84 -0.021,0.002 M 854.59,573.504 l 5.076,-0.72 3,-2.889 5.168,-1.189 -4.851,1.2 0.618,0.467 -2.598,1.173 -1.098,1.337 -5.204,0.653 -0.111,-0.032 m 222.148,120.694 2.812,-0.527 2.104,2.839 -4.364,0.547 1.52,-1.469 -3.743,-0.987 0.476,-1.925 0.216,1.797 0.978,-0.281 10e-4,0.006 m -384.634,74.08 -0.742,2.613 1.297,0.087 -1.368,1.615 1.967,2.855 -2.76,-2.941 1.234,-3.239 -1.571,-2.429 1.94,1.437 0.003,0.002 m 55.527,-43.836 3.835,-2.503 2.946,0.738 -3.856,0.899 -0.249,1.549 -0.342,-1.454 -2.497,2.876 0.149,-2.112 0.014,0.007 m -31.033,54.208 -1.516,4.505 -1.468,-2.04 1.245,2.434 -3.994,-1.265 4.282,-2.129 -1.319,-1.138 2.777,-0.385 -0.007,0.018 m 58.799,57.822 -21.381,5.852 8.614,-2.542 -8.182,-3.786 -2.593,-6.212 2.656,6.141 8.106,3.632 12.799,-3.168 -0.019,0.083 m -41.646,323.475 5.513,4.732 -1.155,0.739 -1.276,-2.061 -1.142,0.19 -4.161,-2.953 0.269,-1.671 1.901,0.976 0.051,0.048 m -7.292,-426.847 2.975,-2.033 -1.857,1.627 2.25,-0.177 2.475,-3.433 4.993,-0.695 -5.612,4.426 -5.239,0.3 0.015,-0.015 m 453.438,231.57 -3.43,6.452 -4.286,-4.603 1.289,-1.901 1.562,2.66 1.062,-1.947 0.444,1.648 3.352,-2.319 0.01,0.01 m -486.94,-274.983 1.06,2.262 -1.052,4.486 -1.222,-1.056 2.012,-3.543 -2.309,-0.536 1.896,0.117 -0.385,-1.73 m 29.739,58.164 -1.923,2.012 1.833,0.174 -2.855,0.271 -0.875,4.26 -1.082,-4.837 1.771,0.662 3.131,-2.542 m 331.847,275.194 -9.376,-5.476 -9.398,3.277 -1.348,1.879 1.228,-1.915 9.554,-3.308 4.879,1.271 4.461,4.272 m -337.12,-270.982 0.384,2.631 -5.733,5.689 4.566,-6.027 -1.463,-2.29 1.082,-1.269 1.166,1.236 -0.002,0.03 m 488.178,99.46 2.802,4.458 -1.206,4.658 0.739,9.12 -1.346,-7.669 1.175,-3.823 -2.163,-6.736 -10e-4,-0.008 m -161.102,-93.308 -1.008,-3.261 2.215,-1.135 -1.088,1.842 1.897,1.452 -1.697,-0.746 -0.279,1.894 -0.04,-0.046 m -173.995,441.086 -1.886,-0.221 1.169,-1.458 -1.82,0.257 1.333,-1.33 2.597,2.189 -1.373,0.574 -0.02,-0.011 m -142.098,-541.238 -4.908,2.973 -1.102,-0.726 3.805,-1.172 -0.251,-1.567 0.462,1.341 2.011,-0.877 -0.017,0.028 m 102.607,473.234 -1.413,-2.621 5.572,0.768 -1.845,1.634 0.929,1.397 -2.63,-3.441 -0.624,2.226 0.011,0.037 m 221.681,-535.278 -6.309,-2.915 0.337,-0.241 4.211,2.289 1.231,-0.326 2.88,0.801 -2.319,0.407 -0.031,-0.015 m -423.36,193.085 -1.202,1.891 0.582,0.444 -1.002,3.042 0.779,-2.747 -1.59,-1.851 2.453,-0.821 -0.02,0.042 m 415.31,-52.3 2.056,3.012 -1.453,4.002 -2.194,-2.811 1.786,-1.087 -2.097,-1.902 1.885,-1.231 0.017,0.017 m -323.218,-16.516 -1.017,2.909 -4.957,2.175 1.945,-3.27 -0.451,2.112 2.031,-0.486 2.451,-3.473 -0.002,0.033 m 374.945,325.465 -0.787,3.892 0.778,0.855 1.188,-1.799 -0.221,2.754 -2.387,-1.01 1.414,-4.697 h 0.015 M 769.232,820.27 l 0.462,3.316 -2.262,-2.611 -1.552,1.47 1.415,-1.552 -1.778,0.325 3.715,-0.948 m 381.247,192.805 2.157,3.171 9.152,-6.847 -9.083,6.878 -0.056,12.584 -0.145,-12.699 -2.025,-3.087 m -11.51,-7.648 3.009,0.738 0.13,5.859 -1.533,-2.063 1.231,-3.589 -2.838,-0.938 10e-4,-0.01 M 708.69,687.163 l -3.128,3.693 0.734,3.901 -0.755,-3.447 -4.064,4.04 7.227,-8.202 -0.014,0.015 m -27.699,71.337 3.99,3.707 -1.493,1.199 0.868,-1.64 -4.122,-1.734 0.706,-1.597 0.051,0.065 m 46.771,-50.076 6.356,0.166 2.495,7.657 -4.552,-5.591 -4.954,-0.578 0.656,-1.645 -0.001,-0.009 m 39.01,-27.94 -2.883,1.418 0.723,-1.701 -0.463,1.514 1.964,-2.043 0.681,0.771 -0.022,0.041 m 64.992,550.056 -0.833,-1.045 4.139,-0.93 0.146,1.218 -2.018,-0.364 -1.409,1.134 -0.025,-0.013 m 127.617,-641.267 7.207,0.772 0.17,-1.263 0.148,1.268 5.34,1.289 -12.894,-2.018 0.029,-0.048 m 88.233,118.218 1.543,1.274 -0.705,2.095 2.539,2.063 -4.736,-3.665 1.359,-1.767 m -321.071,73.707 -2.144,1.837 -2.001,-1.008 -0.146,-3.601 1.023,3.186 3.268,-0.414 m 470.559,249.829 -0.242,-3.979 1.509,-2.229 -0.817,2.516 0.989,-0.325 -1.439,4.017 m 9.398,35.254 3.691,-7.317 2.926,-5.058 -2.282,4.065 -4.337,8.315 v -0.01 m -455.01,-363.87 1.688,0.467 -1.524,0.013 -0.95,2.912 0.756,-3.392 h 0.03 m 297.11,-16.5 3.105,-0.428 -0.89,0.949 3.145,1.761 -5.434,-2.251 0.074,-0.031 m -311.33,38.871 -3.892,2.458 -1.027,-1.139 3.315,-2.101 1.632,0.76 -0.028,0.022 m -38.607,21.572 -0.664,2.027 -3.758,-2.295 2.445,1.355 1.995,-1.104 -0.018,0.017 m 340.143,-58.935 2.565,-0.545 -1.734,0.493 0.246,1.629 -1.16,-1.549 0.083,-0.028 m 181.945,338.915 0.446,-1.989 2.108,-4.91 -1.591,5.111 -0.965,1.794 v -0.01 m -422.14,-224.564 2.011,-1.699 -0.737,-1.806 1.098,2.087 -2.361,1.473 -0.011,-0.055 m 280.02,-180.501 -1.278,-1.567 2.37,1.393 0.898,1.609 -1.993,-1.433 v -0.002 m -28.695,88.003 1.464,3.182 1.556,0.096 -2.363,-0.067 -0.676,-3.196 0.019,-0.015 m -331.498,16.502 -3.404,2.662 1.536,-2.517 -0.126,1.341 2.006,-1.504 -0.012,0.018 m 455.575,22.463 3.401,1.727 0.816,2.435 -4.037,-2.57 -0.197,-1.6 0.017,0.008 m -441.171,40.961 -0.179,2.365 -3.2,2.209 -0.393,-3.278 3.762,-1.305 0.01,0.009 m 53.318,30.868 0.703,3.875 -1.048,-2.441 -3.239,0.769 3.601,-2.239 -0.017,0.036 m -177.383,97.247 -1.342,-1.965 -0.493,1.588 0.232,-4.044 1.593,4.229 0.01,0.192 m 613.787,118.407 0.596,-1.31 -0.762,1.822 0.701,-1.677 -0.543,1.185 0.01,-0.02 m 11.249,-74.957 1.623,-4.599 -0.675,2.162 0.347,0.737 -1.293,1.706 v -0.006 m -418.793,265.646 6.125,0.342 -3.046,0.046 0.999,0.52 -3.957,-0.86 -0.121,-0.048 M 690.63,780.486 l -7.928,11.16 -0.721,-3.292 2.39,-0.029 6.26,-7.882 -10e-4,0.043 m 436.413,-139.987 -0.136,-0.479 3.232,3.02 1.813,2.832 -4.901,-5.37 -0.01,-0.003 m -332.91,133.19 -2.25,0.669 0.649,1.136 -3.13,-1.225 4.759,-0.592 -0.028,0.012 m -50.23,-58.203 3.31,-2.91 -1.458,1.337 1.576,0.576 -3.472,1.034 0.044,-0.037 m 347.265,-48.629 -3.304,-4.304 -2.518,-0.558 3.219,0.709 2.609,4.157 -0.01,-0.004 m -377.103,93.89 -4.404,9.115 2.901,-6.176 -0.34,-2.52 1.866,-0.451 -0.023,0.032 m 166.307,-185.946 4.253,-2.524 -0.846,-2.504 1.029,2.676 -4.377,2.374 -0.059,-0.022 m 49.771,3.618 4.095,-1.712 -3.862,1.645 3.883,2.923 -4.116,-2.856 m -279.892,193.151 -1.724,5.292 0.197,-1.299 -1.626,1.368 3.153,-5.361 m 86.764,-33.173 4.029,-1.391 -2.62,2.174 -4.116,-1.243 2.707,0.46 m 374.625,-90.877 -2.57,-2.791 1.736,1.809 0.465,-0.157 0.369,1.139 m -49.245,-52.026 0.107,-0.513 3.155,1.762 -0.56,0.252 -2.702,-1.501 m -5.71,103.156 7.323,-0.041 2.364,5.392 -8.218,-1.585 -1.469,-3.766 m 173.25,271.586 -0.129,-2.22 1.758,-7.825 -0.204,3.976 -1.425,6.069 m -160.076,-253.432 2.994,0.783 -6.049,-1.321 0.273,-1.952 2.782,2.49 m 26.634,286.8 2.087,1.188 -1.173,0.942 -1,-2.122 0.086,-0.01 M 736.9,679.817 l 1.399,-5.176 3.659,-1.371 -3.581,1.509 -1.477,5.038 m -104.248,275.17 1.799,4.812 -2.419,-2.919 0.629,-1.921 -0.009,0.028 m 66.533,-29.826 -0.01,-0.054 0.314,-2.518 -0.372,7.825 0.068,-5.253 M 815.8,791.213 l -0.33,1.678 -1.434,-1.338 1.765,-0.369 -0.001,0.029 m -54.694,-110.594 -0.747,4.783 -1.498,0.706 2.253,-5.511 -0.008,0.022 m 20.555,128.173 -8.025,5.152 3.339,-4.741 4.699,-0.448 -0.013,0.037 m -126.869,188.384 3.261,8.054 -3.792,-4.048 0.529,-4.01 0.002,0.004 M 791.76,809.59 l -1.198,1.589 -0.018,-2.355 1.229,0.723 -0.013,0.043 m 4.861,-14.589 2.593,-1.298 -0.267,1.701 -2.308,-0.358 -0.018,-0.045 m -13.471,-92.837 -1.138,1.723 -1.376,-0.77 2.539,-0.978 -0.025,0.025 m -19.993,14.043 2.527,-0.312 -1.81,2.58 -0.749,-2.262 0.032,-0.006 m -12.866,461.228 -2.243,-2.306 0.311,-1.719 1.943,4.025 h -0.011 m 21.468,-367.859 1.14,1.318 -2.17,1.253 1.001,-2.583 0.029,0.012 m -118.717,184.254 0.366,2.073 -1.817,-2.236 1.451,0.161 v 0.002 m 510.449,-259.977 1.263,-0.48 -0.753,1.945 -0.526,-1.477 0.016,0.012 m -431.341,25.875 0.356,2.187 -1.736,-1.445 1.365,-0.766 0.015,0.024 m 5.246,-1.772 -3.939,-0.389 2.408,-1.382 1.542,1.782 -0.011,-0.011 m 302.629,-61.112 -1.841,-0.893 3.671,-0.728 -1.809,1.627 -0.021,-0.006 m -294.34,-13.645 0.933,-3.107 1.038,0.532 -1.958,2.591 -0.013,-0.016 m 52.751,119.848 3.745,-1.736 -1.914,2.584 -1.846,-0.804 0.015,-0.044 m 427.012,212.47 -1.729,4.237 0.956,-3.017 0.8,-1.283 -0.027,0.063 m -495.217,-276.313 -1.277,2.84 -0.759,-1.793 2.051,-1.068 -0.015,0.021 m 15.568,86.2 0.568,1.452 -3.375,-2.343 2.797,0.863 0.01,0.028 m 480.308,167.266 0.673,-4.906 0.573,0.945 -1.245,3.97 -10e-4,-0.009 m 8.35,-98.38 -1.07,-1.37 0.443,-2.418 0.63,3.781 v 0.007 m -487.855,-184.835 4.086,-1.301 -0.91,1.602 -3.194,-0.291 0.018,-0.01 m 286.65,-25.584 2.206,0.838 -1.476,0.529 -0.736,-1.367 h 0.01 m -288.183,36.921 0.419,-2.095 2.575,-1.221 -3.01,3.339 0.016,-0.023 m 370.644,269.703 0.029,-0.011 0.315,0.22 1.767,1.343 -2.111,-1.552 m -349.682,79.002 -1.018,4.585 -0.911,-4.337 1.906,-0.255 0.023,0.01 m 11.505,-245.429 0.208,2.027 -1.518,-1.767 1.313,-0.279 -0.003,0.019 m 445.314,202.305 -0.443,1.795 -0.859,1.78 1.219,-3.416 0.083,-0.159 m -508.504,-295.937 -0.325,1.426 -1.188,-0.488 1.5,-0.955 0.013,0.017 m 524.395,201.427 1.462,8.933 -1.521,-2.838 0.055,-6.119 v 0.024 M 771.1,712.596 l -1.582,0.396 0.212,-1.766 1.401,1.366 -0.031,0.004 m -13.951,110.029 0.625,1.453 -1.554,0.162 0.939,-1.656 -0.01,0.041 m -1.507,-131.627 -0.962,-2.246 1.604,0.147 -0.61,2.096 -0.032,0.003 m 34.658,88.815 0.057,2.387 -1.812,-1.683 1.739,-0.727 0.016,0.023 m -61.426,-58.141 -1.271,1.593 -2.194,-1.208 3.471,-0.411 -0.006,0.026 m -24.774,161.876 -0.552,1.401 -0.707,-2.043 1.256,0.614 0.003,0.028 m 467.398,-126.835 -0.948,-5.907 2.116,4.076 -1.155,1.833 -0.013,-0.002 m -360.26,54.722 0.658,-2.008 0.811,2.978 -1.462,-0.935 -0.007,-0.035 m 255.791,-214.649 -1.625,-1.392 1.704,0.97 -0.073,0.425 -0.01,-0.003 m -408.821,255.734 -0.786,1.292 -1.021,-1.643 1.813,0.331 -0.006,0.02 m 125.769,363.303 -1.638,-0.916 3.597,0.806 -1.924,0.122 -0.035,-0.012 m 378.759,-432.724 -1.421,0.104 -1.283,-2.412 2.722,2.311 -0.018,-0.003 m -110.48,-75.323 -1.167,-1.381 1.582,0.226 -0.397,1.156 -0.018,-0.001 m -316.715,-59.742 -3.374,1.453 2.42,-1.842 0.979,0.374 -0.025,0.015 m 8.597,52.586 4.13,-0.113 -5.145,1.707 1,-1.596 0.015,0.002 m 65.796,392.749 0.499,2.02 -2.894,-0.108 2.376,-1.928 0.019,0.016 m -35.138,-369.616 -1.61,-0.724 0.978,-1.512 0.685,2.181 -0.053,0.055 m -135,71.252 -2.843,2.326 -2.229,-1.293 5.078,-1.039 -0.006,0.006 M 792,816.828 l -1.341,6.071 -0.954,-3.501 2.277,-2.608 0.018,0.038 m 315.251,-191.219 -2.256,-1.67 1.795,0.49 0.469,1.179 -0.01,0.001 m -348.997,72.169 -1.908,-4.549 3.118,0.613 -1.18,3.939 -0.03,-0.003 m 241.227,-100.507 0.408,1.01 -4.85,-3.414 4.42,2.397 0.022,0.007 m -220.814,105.343 -3.106,-0.592 -1.305,-3.441 4.481,3.992 -0.07,0.041 m -63.002,83.532 -0.179,4.77 -1.205,-3.331 1.385,-1.452 -10e-4,0.013 m 355.991,-187.367 -0.438,-0.532 3.454,1.927 -3.013,-1.394 v -10e-4 m -312.196,92.49 -2.564,-0.887 0.875,-1.434 1.701,2.329 -0.012,-0.008 m 352.565,-24.285 1.774,0.149 0.732,1.578 -2.566,-1.748 0.06,0.021 m -352.143,156.435 -1.432,3.835 -0.481,-2.456 1.915,-1.393 -0.002,0.014 m -0.16,-114.668 4.404,0.225 -4.698,2.616 0.265,-2.82 0.029,-0.021 m 279.075,-126.528 0.402,-0.247 3.504,1.256 -3.901,-1.009 v 0 m -278.273,637.728 2.864,1.316 -1.887,-0.714 -1.006,-0.616 0.029,0.014 m 25.046,-443.652 0.056,2.676 -1.798,-1.041 1.746,-1.684 -0.004,0.049 m 7.116,-159.056 1.759,-0.852 -1.527,1.583 -0.236,-0.726 0.004,-0.005 m -18.045,92.431 -3.793,-0.545 -1.9,-4.241 5.701,4.759 -0.008,0.027 m 298.75,-0.507 2.005,0.331 -1.274,1.531 -0.739,-1.86 0.01,-0.002 m -332.466,6.834 2.629,-1.038 -1.648,2.316 -1.02,-1.254 0.039,-0.024 m -133.097,186.991 0.23,1.498 -1.728,-2.889 1.48,1.356 0.018,0.035 m 414.239,-218.901 -2.924,0.82 2.112,-2.228 0.917,1.448 -0.105,-0.04 m 84.927,-64.701 0.086,-0.101 2.037,1.74 -2.123,-1.638 v -10e-4 m -410.243,309.739 -0.903,2.75 -0.911,-2.362 1.82,-0.413 -0.006,0.025 m 67.461,-121.457 -0.55,2.537 -2.702,0.059 3.232,-2.613 0.02,0.017 m 251.766,-126.288 -1.328,-3.876 2.729,2.341 -1.395,1.55 -0.01,-0.015 m -279.93,6.351 -1.334,-4.274 2.176,2.604 -0.839,1.694 -0.003,-0.024 m 313.88,0.629 2.012,0.102 -0.973,1.164 -1.049,-1.269 0.01,0.003 m -55.886,-87.656 2.776,-0.44 -1.035,1.053 -1.737,-0.61 -0.004,-0.003 m -235.732,115.269 -0.246,-1.584 2.443,-1.299 -2.178,2.9 -0.019,-0.017 m 65.685,25.221 -2.95,-1.749 2.394,-3.729 0.556,5.472 v 0.006 m -23.838,21.649 1.545,2.643 -3.041,-2.489 1.489,-0.213 0.007,0.059 m 20.141,29.204 -0.756,1.537 -1.028,-1.665 1.818,0.09 -0.034,0.038 m -116.043,96.152 0.126,1.921 -1.54,-0.753 1.411,-1.171 0.003,0.003 m 319.447,-213.463 4.351,2.093 0.243,1.551 -4.603,-3.649 0.01,0.005 m -225.957,137.364 -4.373,5.477 0.496,-7.016 3.874,1.517 0.003,0.022 m 271.756,-121.649 1.317,0.455 -0.879,1.304 -0.438,-1.759 m 16.974,-1.559 -0.7,-2.411 5.509,4.674 -4.809,-2.263 m -287.024,432.663 4.143,1.36 0.728,1.706 -4.871,-3.066 m 431.076,-116.863 -1.015,1.69 0.307,-1.857 0.708,0.167 m -616.468,-166.052 -1.271,0.362 0.992,-2.565 0.279,2.203 m 150.735,-154.072 -2.5,5.488 -1.926,0.53 4.426,-6.018 m -82.959,118.153 -0.295,-3.863 1.722,-2.391 -1.427,6.254 m 487.278,245.457 -1.155,1.765 0.065,-1.605 1.09,-0.16 m -320.794,161.635 3.522,0.363 -0.115,0.786 -3.407,-1.149 m 143.902,-613.319 4.156,2.897 -2.52,-0.938 -1.636,-1.959 m -236.905,115.944 1.898,-1.37 0.603,1.086 -2.501,0.284 m 231.419,-151.414 -0.896,-0.27 4.454,1.127 -3.558,-0.857 m -388.928,288.522 0.97,-1.603 -1.159,2.813 0.189,-1.21 m 207.026,-89.956 -3.416,-2.91 4.09,0.965 -0.674,1.945 m -47.698,459.262 -0.554,-0.395 1.695,0.818 -1.141,-0.423 m 9.426,-414.815 2.157,1.298 -2.583,0.721 0.426,-2.019 m 461.279,175.534 0.855,-1.61 -1.144,4.322 0.289,-2.712 M 1188.197,806.501 V 806.5 l 1.875,3.501 -1.877,-3.5 m -166.082,-101.988 0.035,0.031 -4.852,-1.372 4.817,1.341 m -344.005,323.062 1.39,0.779 -1.438,-0.562 0.048,-0.217 m 423.248,-31.594 0.011,-0.026 8.275,-6.901 -8.286,6.927 m -25.166,-381.374 -7.274,-4.745 7.31,4.745 h -0.036 m 142.026,429.079 3.632,-7.134 -3.63,7.132 v 0 m -524.045,-87.792 10e-4,-0.004 1.196,1.758 -1.197,-1.754 m 390.062,67.761 0.015,-0.021 12.847,-12.132 -12.862,12.153 M 744.68,686.04 l 2.415,-0.196 -2.42,0.198 0.005,-0.002 m 8.074,4.433 4.036,2.174 -4.057,-2.135 0.021,-0.039 m 325.015,344.027 4.441,-7.929 -4.438,7.935 v -0.01 m -26.921,-328.6 2.492,0.456 -2.466,-0.437 -0.026,-0.019 M 723.467,895.781 v -0.002 l 1.66,-0.481 -1.66,0.483 m 52.59,-103.594 -2.702,2.048 2.713,-2.057 -0.011,0.009 m -75.018,-104.968 0.011,-0.011 -3.649,5.56 3.638,-5.549 m 88.287,100.475 4.718,0.39 -4.768,-0.378 0.05,-0.012 m -37.347,23.355 0.004,-0.021 1.179,3.926 -1.183,-3.905 m 266.109,-113.653 0.064,0.009 -7.145,0.592 7.081,-0.601 M 1233.26,960.67 v 0.003 l 1.3,-3.982 -1.297,3.979 m -41.961,-185.914 2.138,1.777 -2.15,-1.781 0.012,0.004 m -452.364,-152.313 0.56,-3.2 -0.542,3.208 -0.018,-0.008 m 53.355,179.491 -0.059,3.012 0.053,-3.036 0.006,0.024 m 223.127,-108.648 0.029,0.002 -5.882,0.323 5.853,-0.325 m -276.715,20.264 3.022,-0.157 -3.045,0.177 0.023,-0.02 m -46.985,-18.521 -0.002,0.021 -0.807,-3.171 0.809,3.15 m 57.36,23.281 3.788,-0.825 -3.809,0.84 0.021,-0.015 m -49.266,191.446 -1.948,4.1 1.955,-4.124 -0.007,0.024 m 91.507,-130.412 -0.033,-0.036 3.422,0.147 -3.389,-0.111 m -4.685,34.019 0.737,2.528 -0.75,-2.542 0.013,0.014 m -10.694,-97.046 -2.472,-3.599 2.569,3.546 -0.097,0.053 m 86.429,487.222 0.007,0.018 -2.77,-1.262 2.763,1.244 m -104.426,-479.077 2.128,-4.159 -2.133,4.176 0.005,-0.017 m 35.406,40.938 -0.008,-0.02 1.622,2.466 -1.614,-2.446 m 394.326,57.558 v -0.006 l 1.003,0.548 -1,-0.542 m -139.456,-124.696 -0.015,-0.018 2.64,1.063 -2.625,-1.045 m -363.334,19.779 -2.751,0.913 2.789,-0.932 -0.038,0.019 m 363.427,19.484 -0.01,-0.029 2.978,5.878 -2.968,-5.849 m -323.148,-29.451 2.542,-1.76 -2.57,1.79 0.028,-0.03 m 37.614,18.76 1.47,-3.06 -1.464,3.097 -0.006,-0.037 m -39.728,9.912 h 0.015 l -1.525,2.738 1.51,-2.738 m 131.147,472.32 0.028,0.017 -2.219,-0.88 2.191,0.863 m -89.155,-485.915 2.529,-0.467 -2.554,0.485 0.025,-0.018 m 341.651,14.834 2.776,2.457 -2.78,-2.439 v -0.018 m -386.659,-3.381 -2.628,0.108 2.648,-0.126 -0.02,0.018 m 335.364,-26.32 0.018,0.018 -3.07,-2.006 3.052,1.988 M 756.7,675.263 l 0.017,-0.003 -2.712,2.002 2.695,-1.999 m 345.066,112.942 0.996,-3.416 -0.98,3.436 -0.016,-0.02 m -369.853,-36.671 -4.24,-1.04 4.273,1.034 -0.033,0.006 m 101.59,85.331 -5.262,3.054 5.248,-3.081 0.014,0.027 M 681.542,726.8 l -4.174,4.403 4.19,-4.422 -0.016,0.019 m 358.296,12.846 -0.021,-0.035 2.486,2.47 -2.465,-2.435 m -408.635,143.631 0.337,-3.417 -0.286,3.398 -0.051,0.019 m 59.201,-173.398 -0.696,-2.82 0.714,2.823 -0.018,-0.003 m 330.596,4.679 7.135,0.913 -7.155,-0.901 0.02,-0.012 m -295.524,-54.234 -4.736,1.857 4.766,-1.869 -0.03,0.012 m 302.017,59.24 2.706,1.867 -2.721,-1.868 0.015,10e-4 m -299.942,-58.952 0.035,-0.026 -4.573,4.004 4.538,-3.978 m 113.637,473.447 -0.007,5.067 -0.045,-5.091 0.052,0.024 m 189.985,-445.065 0.338,-2.336 -0.324,2.32 -0.014,0.016 m -323.399,24.158 -0.005,0.018 0.094,-4.076 -0.089,4.058 m 39.956,-1.973 2.676,-0.543 -2.707,0.556 0.031,-0.013 m 19.263,8.944 2.859,-2.007 -2.853,2.036 -0.006,-0.029 m -36.549,61.263 0.022,0.021 -3.021,-0.92 2.999,0.899 m 319.935,89.95 -0.022,-10e-4 3.055,-1.088 -3.033,1.089 m -314.859,-83.612 -1.509,-1.467 1.521,1.477 -0.012,-0.01 m 74.085,23.166 -0.002,0.014 0.17,-2.185 -0.168,2.171 m 14.573,-107.946 1.367,2.394 -1.374,-2.398 0.007,0.004 m -121.014,-16.067 -3.031,3.45 3.051,-3.475 -0.02,0.025 m 73.811,6.807 0.017,-0.026 -1.138,2.815 1.121,-2.789 m 17.847,74.411 0.016,-0.023 -1.389,2.257 1.373,-2.234 m 12.993,18.029 0.008,-0.03 -0.289,2.39 0.281,-2.36 m 222.697,-51.534 -0.019,-0.013 4.283,1.91 -4.264,-1.897 m -265.454,108.749 -4.125,7.004 4.132,-7.038 -0.007,0.034 m 12.933,-132.225 -1.203,-0.701 1.212,0.704 -0.009,-0.003 M 1069.84,597.335 v 0 l 1.488,0.312 -1.488,-0.312 m 72.715,417.001 6.706,-0.961 -6.717,0.984 0.011,-0.023 m -405.621,-394.972 0.021,-0.016 -2.058,1.688 2.037,-1.672 m 503.339,295.806 -0.202,4.478 0.191,-4.495 0.011,0.017 m -74.57,87.75 -2.621,4.616 2.613,-4.603 0.01,-0.013 m -473.837,-290.46 -2.161,4.132 2.166,-4.191 -0.005,0.059 m -11.458,7.784 0.021,-0.003 -4.056,2.23 4.035,-2.227 m 369.608,-24.165 -4.667,-0.445 4.698,0.437 -0.031,0.008 m 5.289,175.937 -0.365,1.893 0.341,-1.893 h 0.024 M 750.068,822.1 l -0.734,2.476 0.724,-2.508 0.01,0.032 m -29.66,-82.843 -2.135,-0.053 2.177,0.04 -0.042,0.013 m -60.576,130.934 0.003,0.002 -0.813,5.311 0.81,-5.313 m 414.775,-55.987 1.657,-2.536 -1.647,2.573 -0.01,-0.037 m -268.426,-4.062 0.755,-2.851 -0.756,2.864 0.001,-0.013 m -74.175,-60.978 0.034,0.01 -2.428,-0.044 2.394,0.034 m 337.556,102.229 -1.708,1.727 1.687,-1.718 0.021,-0.009 m -273.304,-67.639 -0.211,1.707 0.128,-1.707 h 0.083 m 246.392,-88.352 0.604,-1.996 -0.585,2.009 -0.019,-0.013 m -136.163,457.316 -2.196,0.414 2.196,-0.426 v 0.012 m 227.707,-423.721 -0.03,2.795 v -2.755 l 0.035,-0.04 m -54.448,72.107 0.017,0.013 -2.298,-0.738 2.281,0.725 m -346.627,-33.328 -0.002,0.004 -2.042,-1.255 2.044,1.251 m 405.291,-56.937 v -0.02 l 3.054,0.59 -3.058,-0.57 m -385.756,0.694 -0.029,0.012 2.585,-1.376 -2.556,1.364 m -7.079,5.506 -0.027,10e-4 3.349,-1.183 -3.322,1.182 m 337.611,94.824 -0.727,-2.767 0.744,2.775 -0.017,-0.008 m -329.25,-133.892 -1.935,1.089 1.937,-1.105 -0.002,0.016 m 289.77,15.01 -1.957,-0.929 1.986,0.936 -0.029,-0.007 m -187.836,522.403 -0.009,-10e-4 0.95,-0.352 -0.941,0.353 m -101.365,-517.699 0.762,-2.232 -0.75,2.253 -0.012,-0.021 m 79.195,533.015 2.321,-0.87 -2.271,0.883 -0.05,-0.013 m -108.815,-350.493 0.4,2.553 -0.406,-2.558 0.006,0.005 m 364.445,-71.256 v 0.01 l -0.366,-2.61 0.365,2.6 m -339.405,10.387 -1.185,4.54 1.167,-4.581 0.018,0.041 m -54.97,-124.69 -0.01,0.011 -0.342,-3.532 0.352,3.521 m 324.259,4.622 0.073,-0.015 -3.348,1.132 3.275,-1.117 m -386.198,163.172 -0.006,-0.01 1.153,-0.025 -1.147,0.035 m 101.417,-243.189 0.014,-0.004 -2.758,1.237 2.744,-1.233 m 7.303,3.087 0.003,0.014 -0.497,-1.7 0.494,1.686 m 10.032,76.738 -0.035,-0.047 3.709,-0.446 -3.674,0.493 m 294.252,2.775 -2.206,-1.329 2.253,1.332 -0.047,-0.003 m -290.739,-15.659 -2.344,-1.965 2.377,1.958 -0.033,0.007 m 280.601,-2.415 3.378,0.421 -3.403,-0.417 0.025,-0.004 m 118.541,-23.544 -1.663,-1.993 1.673,2.001 -0.01,-0.008 m 22.28,344.674 v 0 l 1.137,0.131 -1.137,-0.127 m -9.275,-330.27 v 0.002 l -0.297,-0.178 0.295,0.176 m -479.267,196.851 0.003,0.002 1.403,2.969 -1.406,-2.971 m 359.151,-137.193 -0.031,-0.005 1.53,-1.389 -1.499,1.394 m -316.988,4.005 2.306,0.212 -2.312,-0.198 0.006,-0.014 m 298.364,-49.528 -0.035,-1.446 0.066,1.439 -0.031,0.007 m -287.527,86.134 -1.95,-0.555 1.976,0.546 -0.026,0.009 m -6.476,-20.787 -2.111,-0.607 2.129,0.601 -0.018,0.006 m 429.969,-13.795 1.971,-0.309 -1.979,0.343 0.01,-0.034 m -419.505,97.679 -1.651,-0.438 1.68,0.409 -0.029,0.029 m 455.408,169.609 0.011,-0.026 2.263,-3.885 -2.274,3.911 m -40.835,-215.807 v -0.028 l 1.408,1.957 -1.406,-1.929 m -129.144,-110.874 2.848,0.538 -2.854,-0.537 0.01,-10e-4 m -220.627,100.671 -0.467,4.106 0.468,-4.14 -10e-4,0.034 m 241.493,-71.009 1.171,1.382 -1.175,-1.376 v -0.006 m -12.751,-18.94 -1.137,-2.05 1.147,2.035 -0.01,0.015 m 99.665,34.908 2.754,-1.593 -2.759,1.8 v -0.207 m -16.293,78.421 1.777,0.223 -1.789,-0.21 0.012,-0.013 m -379.605,-34.981 -1.805,-1.437 1.844,1.431 -0.039,0.006 m -136.673,111.82 -0.973,4.095 0.965,-4.108 0.008,0.013 m 439.428,-155.529 0.02,2.941 -0.037,-2.969 0.017,0.028 m -46.281,-131.226 -5.998,-1.644 6.015,1.643 -0.017,10e-4 m -323.008,110.961 -2.233,1.228 2.235,-1.244 -0.002,0.016 m 47.213,86.29 -1.435,-0.313 1.444,0.292 -0.009,0.021 m 399.306,-154.693 2.152,2.648 -2.158,-2.653 0.01,0.005 m -355.391,190.613 0.036,-0.001 -1.18,1.346 1.144,-1.345 m -9.731,-6.793 -1.932,1.672 1.956,-1.706 -0.024,0.034 m 479.624,155.263 1.021,-4.08 -0.936,3.943 -0.085,0.137 m -436.494,-182.532 1.878,0.18 -1.85,-0.167 -0.028,-0.013 m 336.98,-66.744 -2.376,0.695 2.39,-0.703 -0.014,0.008 m -333.231,27.697 -0.02,-0.046 2.099,1.639 -2.079,-1.593 m -29.523,-89.866 -2.469,0.453 2.49,-0.471 -0.021,0.018 m -8.23,45.736 1.85,-0.452 -1.865,0.478 0.015,-0.026 m 34.757,42.254 -1.078,1.854 1.08,-1.882 -0.002,0.028 m 245.457,106.694 v -0.021 l -0.066,1.752 0.063,-1.731 m -323.481,-75.578 -1.434,-0.63 1.446,0.604 -0.012,0.026 m 19.194,50.561 -1.961,2.548 1.976,-2.569 -0.015,0.021 m -42.41,47.178 -1.408,1.088 1.405,-1.096 0.003,0.008 m 100.261,-77.896 1.812,-0.205 -1.827,0.257 0.015,-0.052 m 285.65,-112.168 0.992,-2.325 -0.802,2.407 -0.19,-0.082 m -41.102,12.419 -2.53,-1.528 2.562,1.542 -0.032,-0.014 m -327.895,88.632 -1.062,-2.065 1.091,2.03 -0.029,0.035 m -15.015,-43.736 -2.3,3.35 2.305,-3.382 -0.005,0.032 m 7.713,37.327 -2.456,0.3 2.412,-0.332 0.044,0.032 m 82.681,14.184 -1.347,0.386 1.356,-0.437 -0.009,0.051 m 220.351,-100.434 -0.364,-1.72 0.396,1.707 -0.032,0.013 m -223.369,-17.339 -2.008,-2.244 2.038,2.225 -0.03,0.019 m 309.49,317.04 2.445,-3.217 -2.438,3.221 h -0.01 M 741.413,781.44 l -0.442,-1.522 0.453,1.524 -0.011,-0.002 m 282.341,-73.056 -2.733,-0.267 2.739,0.258 -0.01,0.009 m -208.695,2.326 -1.735,0.294 1.743,-0.301 -0.008,0.007 m 207.797,-0.141 -0.021,-0.01 3.315,0.614 -3.294,-0.604 m 174.347,312.89 v 0.01 l -1.046,-0.526 1.048,0.521 M 745.61,613.27 l 0.048,-0.019 -2.089,1.2 2.041,-1.181 m -5.033,202.131 0.027,-0.021 -0.59,1.614 0.563,-1.593 m 8.233,-133.749 -0.038,0.015 1.98,-1.055 -1.942,1.04 m 353.322,-66.927 -0.019,-0.013 1.656,0.999 -1.637,-0.986 m 128.751,290.751 -0.957,-0.961 0.97,0.949 -0.013,0.012 m -103.168,-139.909 1.834,1.538 -1.838,-1.54 v 0.002 m -357.475,-55.123 -1.678,1.554 1.694,-1.576 -0.016,0.022 m 39.37,76.625 0.003,2.506 -0.006,-2.568 0.003,0.062 m -165.581,183.183 2.443,-0.638 -2.438,0.68 -0.005,-0.042 m 152.335,-294.903 -1.646,1.243 1.667,-1.265 -0.021,0.022 m -13.895,554.315 -0.029,-0.01 -1.723,-0.646 1.752,0.656 m 31.808,-442.328 -0.889,3.045 0.892,-3.068 -0.003,0.023 m -130.696,-64.599 0.035,-0.008 -3.119,1.896 3.084,-1.888 m 120.36,38.169 -1.552,-0.313 1.538,0.284 0.014,0.029 m -7.529,9.48 0.002,-0.039 1.713,1.437 -1.715,-1.398 m -173.55,162.951 -10e-4,1.718 -0.003,-1.724 0.004,0.006 m 472.4,65.316 2.645,-2.748 -2.659,2.766 0.014,-0.018 M 698.43,692.079 l -1.053,2.995 1.053,-3.007 v 0.012 m 352.146,5.578 0.027,0.019 -1.988,-0.962 1.961,0.943 m -325.73,77.635 -1.204,1.003 1.209,-1.041 -0.005,0.038 m 35.375,-88.204 -1.589,0.344 1.616,-0.373 -0.027,0.029 m 5.721,123.905 -2.108,1.002 2.141,-1.022 -0.033,0.02 m 30.039,-12.32 0.554,2.469 -0.571,-2.46 0.017,-0.009 m -29.37,-89.802 1.72,-0.355 -1.758,0.367 0.038,-0.012 m -1.496,-50.918 -0.025,0.009 1.594,-1.046 -1.569,1.037 m -96.441,69.107 1.719,-3.078 -1.724,3.09 0.005,-0.012 m 86.616,-24.378 1.487,0.662 -1.513,-0.659 0.026,-0.003 m -63.1,155.761 -0.676,2.818 0.668,-2.832 0.008,0.014 m 43.656,-150.312 0.02,-0.022 -0.282,1.52 0.262,-1.498 m -10.48,33.216 -1.526,0.448 1.538,-0.454 -0.012,0.006 m 12.453,-23.497 -2.75,-0.009 2.749,-0.019 10e-4,0.028 m 259.882,-119.587 -3.38,-2.353 3.375,2.344 0.005,0.009 m -250.839,222.289 -1.26,1.728 1.266,-1.763 -0.006,0.035 m 346.048,-188.43 10e-4,0.002 -0.738,0.238 0.737,-0.24 m 94.014,138.874 2.402,1.649 -2.418,-1.654 0.016,0.005 m -380.62,13.23 0.013,-0.011 -0.449,3.456 0.436,-3.445 m -53.43,374.017 -0.646,-1.224 0.649,1.218 -0.003,0.01 m -23.593,-403.1 -1.096,-1.48 1.183,1.46 -0.087,0.02 m 50.213,88.727 0.021,-0.019 -0.725,2.16 0.704,-2.141 m 39.803,-40.947 -1.667,0.507 1.677,-0.521 -0.01,0.014 m -112.015,-10.867 -1.653,0.529 1.656,-0.538 -0.003,0.009 m 205.514,364.316 -1.361,-0.129 1.361,0.118 v 0.011 m -157.978,-438.218 -0.403,1.356 0.385,-1.352 0.018,-0.004 m 333.788,-107.721 v -0.002 l 1.231,0.526 -1.229,-0.524 m 9.934,385.174 -0.05,2.746 0.037,-2.729 0.013,-0.017 m -358.058,-188.095 -2.061,0.094 2.09,-0.116 -0.029,0.022 m -0.41,-74.297 -2.725,1.143 2.73,-1.16 -0.005,0.017 m 72.208,75.246 -0.007,0.027 0.252,-2.354 -0.245,2.327 m -37.286,0.241 -1.898,1.066 1.897,-1.071 10e-4,0.005 m 270.735,53.108 1.673,-0.165 -1.695,0.191 0.022,-0.026 m -376.565,-3.216 0.004,0.004 -0.937,-0.64 0.933,0.636 m 343.22,-69.351 -0.547,1.449 0.532,-1.47 0.015,0.021 m -283.378,-134.499 -2.591,0.8 2.618,-0.818 -0.027,0.018 m 96.746,472.994 2.323,6.275 -2.438,-6.398 0.115,0.123 m -162.75,-239.905 0.052,1.634 -0.057,-1.644 0.005,0.01 m -32.634,60.027 -0.016,-0.028 1.192,2.097 -1.176,-2.069 m 420.43,-243.861 1.474,0.656 -1.496,-0.663 0.022,0.007 m -242.57,114.688 -0.439,3.456 0.439,-3.477 v 0.021 m -75.61,-122.925 -1.389,-1.233 1.415,1.222 -0.026,0.011 m -49.155,8.433 0.017,-0.007 -2.224,1.946 2.207,-1.939 m 349.333,17.181 1.114,1.334 -1.128,-1.331 0.014,-0.003 m -272.13,107.097 -1.761,0.991 1.799,-1.018 -0.038,0.027 m 250.277,-27.92 v -0.015 l -0.245,1.714 0.241,-1.699 m -270.947,-98.305 2.508,-0.347 -2.541,0.365 0.033,-0.018 m -0.886,44.847 0.013,0.02 -2.149,-0.359 2.136,0.339 m 451,26.839 0.865,0.338 -0.872,-0.338 h 0.01 m -58.983,32.371 0.564,1.45 -0.578,-1.46 0.014,0.01 m -84.868,-107.735 0.04,0.015 -1.291,-0.314 1.251,0.299 m 195.294,254.815 0.358,-1.727 -0.36,1.748 v -0.021 m -197.775,-246.788 -0.01,-0.006 1.853,1.779 -1.848,-1.773 m -325.179,23.081 -1.451,0.397 1.451,-0.401 v 0.004 m -46.177,5.984 1.302,-0.781 -1.329,0.805 0.027,-0.024 m 353.475,-18.627 -2.807,-0.526 2.844,0.52 -0.037,0.006 m 135.259,62.59 -1.324,0.101 1.335,-0.115 -0.011,0.014 m -485.207,-64.255 -1.848,2.319 1.857,-2.335 -0.009,0.016 m 85.949,-2.164 2.437,-0.662 -2.454,0.681 0.017,-0.019 m -93.733,28.816 -2.145,0.046 2.127,-0.069 0.018,0.023 m 125.196,40.237 -1.707,1.5 1.725,-1.519 -0.018,0.019 m 285.992,23.61 0.015,0.02 -1.284,-0.196 1.269,0.176 m -435.563,154.452 0.008,-0.011 0.93,0.515 -0.938,-0.504 m 428.841,-270.89 -0.032,-0.008 2.384,0.038 -2.352,-0.03 m -267.405,77.645 -0.488,2.196 0.493,-2.233 -0.005,0.037 m 227.985,-79.428 1.17,-0.896 -1.195,0.926 0.025,-0.03 m 80.238,299.908 0.011,0.005 1.842,2.215 -1.853,-2.22 m -377.622,-192.292 0.024,-0.012 -3.179,1.604 3.155,-1.592 m 367.971,-144.246 2.45,2.026 -2.465,-2.011 0.015,-0.015 m 3.022,-24.648 -1.138,-1.319 1.14,1.313 v 0.006 m -305.309,69.963 -1.576,1.577 1.563,-1.61 0.013,0.033 m 306.849,355.348 0.554,1.595 -0.56,-1.594 0.01,-10e-4 m -62.478,-347.31 -0.019,1.145 0.01,-1.17 0.013,0.025 m -227.319,101.531 -0.016,-0.011 2.981,0.803 -2.965,-0.792 m -51.867,2.605 -2.152,1.272 2.171,-1.308 -0.019,0.036 m 257.499,-89.349 1.537,1.201 -1.56,-1.202 0.023,0.001 m 215.037,247.341 0.181,-2.35 -0.174,2.345 -0.01,0.005 m -364.431,240.533 -0.85,-0.79 0.875,0.792 h -0.025 m 209.005,-587.531 v 0.002 l -1.31,-0.967 1.308,0.965 m 71.306,41.678 v 0 l -0.406,-0.642 0.406,0.642 m -383.763,54.567 -1.632,-1.48 1.664,1.482 -0.032,-0.002 m 301.28,-111.196 -0.506,0.306 0.507,-0.308 v 0.002 m -319.002,79.223 0.007,0.009 -1.649,-0.128 1.642,0.119 m -20.566,-64.231 -1.235,-0.149 1.271,0.139 -0.036,0.01 m 13.945,-6.502 0.019,-0.01 -1.521,1.666 1.502,-1.656 m 469.445,423.565 0.01,-0.016 -0.128,0.855 0.12,-0.839 m -453.845,86.899 -1.935,-1.709 1.94,1.71 h -0.005 m 286.863,-410.746 v -0.006 l 0.157,2.178 -0.16,-2.172 M 900.063,550.26 l 0.994,-0.064 -0.992,0.064 h -0.002 m -100.423,208.175 -0.485,1.543 0.496,-1.582 -0.011,0.039 m -37.018,-97.977 -0.724,1.441 0.7,-1.442 0.024,10e-4 m 44.449,104.521 h 0.023 l -1.854,1.549 1.831,-1.549 m 220.07,-87.354 -1.051,1.383 1.04,-1.377 0.011,-0.006 m 11.453,51.219 -0.021,-0.016 1.604,0.453 -1.583,-0.437 m -214.134,87.572 0.004,0.034 -1.674,-2.146 1.67,2.112 m -97.596,65.97 0.005,-0.007 1.203,1.403 -1.208,-1.396 m -109.932,-84.978 -1.032,2.67 1.028,-2.693 0.004,0.023 m 148.214,325.584 v 0 l -1.776,-1.322 1.776,1.318 m 259.648,-546.971 -0.366,-0.457 0.371,0.459 v -0.002 m -351.278,166.896 -0.014,10e-4 1.605,-1.397 -1.591,1.396 m 390.994,122.119 1.228,1.072 -1.241,-1.084 0.013,0.012 m -327.879,-92.176 -1.324,-0.606 1.317,0.566 0.007,0.04 m -45.125,85.689 -2.068,6.06 2.069,-6.081 -10e-4,0.021 m 184.689,-196.47 -3.733,-0.007 3.711,-0.01 0.022,0.017 m -133.694,155.299 0.016,-0.024 -1.232,2.146 1.216,-2.122 m 367.546,171.386 2.66,-0.792 -2.647,0.799 -0.013,-0.007 m -78.807,-252.512 2.58,2.141 -2.616,-2.144 0.036,0.003 m -257.488,78.271 -1.763,0.899 1.786,-0.93 -0.023,0.031 m 277.768,-74.086 1.553,0.467 -1.572,-0.47 0.019,0.003 m 45.278,44.324 -0.469,-1.348 0.488,1.369 -0.019,-0.021 m -343.134,-90.991 1.118,0.5 -1.139,-0.498 0.021,-0.002 m 75.971,18.409 -1.68,0.993 1.703,-1.01 -0.023,0.017 m 245.801,326.179 1.354,-2.477 -1.299,2.451 -0.055,0.026 m -410.272,-272.279 -1,0.947 1.022,-0.984 -0.022,0.037 m 49.621,-30.161 -2.142,1.261 2.149,-1.28 -0.007,0.019 m 64.763,69.192 -1.438,1.551 1.441,-1.581 -0.003,0.03 m 220.873,-213.615 -2.466,0.807 2.462,-0.81 v 0.003 m -280.124,192.857 -0.646,-1.327 0.648,1.314 -0.002,0.013 m 303.645,-74.464 0.021,0.008 -2.155,-0.638 2.134,0.63 m 114.828,104.93 1.037,0.21 -1.045,-0.203 0.01,-0.007 m -366.944,-95.06 -1.108,0.828 1.1,-0.867 0.008,0.039 m 341.928,-96.896 1.629,1.275 -1.627,-1.274 v -0.001 m -394.876,160.871 -0.48,-1.292 0.511,1.291 -0.031,0.001 m -1.055,-7.093 -1.159,-0.619 1.177,0.628 -0.018,-0.009 m 49.064,-61.352 1.786,-1.014 -1.797,1.038 0.011,-0.024 m 13.85,126.978 -0.02,2.146 0.019,-2.192 10e-4,0.046 m 11.924,-18.787 0.034,-0.028 -0.978,2.229 0.944,-2.201 M 755.984,710.1 h -0.024 l 1.701,-1.16 -1.677,1.16 m 294.805,-14.321 -0.943,-1.375 0.96,1.394 -0.017,-0.019 m -247.881,66.381 -0.594,1.203 0.582,-1.224 0.012,0.021 m 253.691,-54.56 0.626,-0.989 -0.611,1 -0.015,-0.011 m -222.185,132.671 -2.873,1.042 2.9,-1.057 -0.027,0.015 m 240.336,-31.778 -0.491,1.852 0.47,-1.866 0.021,0.014 m -339.778,-158.195 -2.392,1.593 2.406,-1.604 -0.014,0.011 m 411.947,1.852 -0.275,-0.33 0.28,0.334 v -0.004 m -430.904,110.621 0.005,0.005 -1.794,0.546 1.789,-0.551 m 35.973,-82.538 -1.567,0.065 1.582,-0.073 -0.015,0.008 m -25.318,11.142 0.282,-1.796 -0.264,1.806 -0.018,-0.01 m 405.693,52.688 1.233,1.016 -1.241,-1.02 0.01,0.004 m 17.737,-73.671 0.408,0.899 -0.41,-0.899 v 0 m -378.092,43.498 -0.329,-1.094 0.355,1.098 -0.026,-0.004 m -16.808,-12.078 -0.079,0.002 1.115,-1.162 -1.036,1.16 m 292.709,4.916 1.638,1.294 -1.661,-1.29 0.023,-0.004 m -327.384,83.632 -1.061,-0.463 1.062,0.455 -10e-4,0.008 m -75.556,-48.658 -1.435,1.775 1.461,-1.813 -0.026,0.038 m 100.645,-15.642 -10e-4,-0.006 1.164,0.332 -1.163,-0.326 m -4.035,22.449 -0.565,-1.642 0.597,1.634 -0.032,0.008 m -103.74,-0.95 -0.749,-0.088 0.766,0.063 -0.017,0.025 m 106.904,30.973 0.525,-1.261 -0.518,1.273 -0.007,-0.012 m 2.117,-106.928 1.906,-1.084 -1.891,1.095 -0.015,-0.011 m -5.003,28.334 2.005,-0.957 -2.037,0.979 0.032,-0.022 m 285.799,26.665 2.021,2.174 -2.06,-2.174 h 0.039 m -258.337,-55.655 -1.16,2.037 1.175,-2.071 -0.015,0.034 m -138.093,214.448 -0.8,0.854 0.813,-0.876 -0.013,0.022 m 529.12,-90.275 0.118,1.84 -0.147,-1.878 0.029,0.038 m -134.593,-102.242 -0.736,-1.188 0.759,1.189 -0.023,-10e-4 m -264.497,124.184 -1.617,1.266 1.625,-1.287 -0.008,0.021 m 284.085,-125.385 1.968,0.483 -1.972,-0.476 v -0.007 m -305.935,34.862 -0.088,0.04 1.47,-1.036 -1.382,0.996 m 411.598,-35.652 0.465,1.124 -0.477,-1.135 0.012,0.011 m -420.875,85.102 -1.778,0.427 1.819,-0.439 -0.041,0.012 m 16.58,73.49 0.021,-0.064 -0.325,2.926 0.304,-2.862 m -36.059,44.849 0.946,1.628 -0.94,-1.603 -0.006,-0.025 m 129.668,-53.24 2.601,0.404 -2.619,-0.371 0.018,-0.033 m -86.232,-148.743 0.02,0.008 -2.045,-0.388 2.025,0.38 m 59.17,436.339 h -0.005 l 1.313,-0.15 -1.308,0.153 m 203.536,-418.483 -0.57,-1.533 0.597,1.491 -0.027,0.042 m -53.724,30.675 -0.335,1.768 0.309,-1.756 0.026,-0.012 m -230.53,-50.525 -1.413,-0.58 1.433,0.547 -0.02,0.033 m 494.314,334.769 0.544,-1.482 -0.54,1.472 v 0.01 m -77.031,-358.567 v 10e-4 l 1.455,1.965 -1.457,-1.966 m -471.031,58.737 0.018,-0.005 -1.87,2.145 1.852,-2.14 m 436.096,-31.467 -3.661,-4.222 3.71,4.26 -0.049,-0.038 m -400.428,49.975 -1.505,-0.348 1.52,0.304 -0.015,0.044 m 85.292,67.701 0.019,-0.033 0.052,1.792 -0.071,-1.759 m -91.204,-91.297 -0.307,1.173 0.314,-1.203 -0.007,0.03 m 104.137,54.312 -1.491,1.979 1.511,-2.012 -0.02,0.033 m 284.379,-159.106 1.506,1.043 -1.511,-1.045 v 0.002 m -375.148,131.724 -1.011,-0.951 1.012,0.939 -10e-4,0.012 m 58.247,481.697 h -0.013 l -0.25,-0.117 0.263,0.122 m -44.753,-493.521 0.018,-0.005 -1.526,1.587 1.508,-1.582 m 85.146,55.375 0.04,-0.02 -1.008,1.185 0.968,-1.165 m -69.279,-77.139 1.278,0.281 -1.338,-0.264 0.06,-0.017 m 408.204,74.802 0.289,1.316 -0.305,-1.339 0.016,0.023 m -426.529,-133.47 0.04,-0.013 -2.374,1.149 2.334,-1.136 m 20.964,184.769 0.027,-0.01 -1.699,1.11 1.672,-1.1 m -19.295,-92.256 0.011,0.01 -1.496,-0.246 1.485,0.236 m 482.778,281.05 -10e-4,0.01 -0.703,1.687 0.704,-1.693 m -433.502,-211.607 -0.845,1.895 0.836,-1.936 0.009,0.041 m -130.233,-34.59 -1.546,1.354 1.584,-1.417 -0.038,0.063 m 57.68,-48.576 -1.271,2.004 1.279,-2.022 -0.008,0.018 m -3.189,83.24 0.009,-0.007 -1.36,1.746 1.351,-1.739 m 31.699,-72.133 -1.526,-0.033 1.542,0.015 -0.016,0.018 m 13.541,-36.695 0.037,1.337 -0.051,-1.349 0.014,0.012 m 10.18,14.643 -0.083,1.36 0.068,-1.34 0.015,-0.02 m 155.99,-55.963 0.013,-0.022 -1.146,2.389 1.133,-2.367 m -159.681,553.154 -1.277,-0.549 1.271,0.543 0.006,0.01 m 369.93,-413.588 0.846,1.38 -0.868,-1.359 0.022,-0.021 m -63.952,-94.366 0.339,1.333 -0.341,-1.34 v 0.007 m -353.904,13.418 -1.76,-0.063 1.767,0.036 -0.007,0.027 m 33.805,124.062 -0.881,2.72 0.882,-2.752 -0.001,0.032 m 59.89,-79.274 -1.745,-0.022 1.75,10e-4 -0.005,0.021 m -94.309,-9.366 -0.945,1.898 0.963,-1.954 -0.018,0.056 m 48.543,-74.326 -1.57,0.351 1.613,-0.364 -0.043,0.013 m -65.048,2.252 -1.279,-0.15 1.293,0.137 -0.014,0.013 m 59.28,-25.571 -0.029,0.023 1.553,-1.912 -1.524,1.889 m -32.813,78.9 -1.535,0.762 1.536,-0.774 -0.001,0.012 m 376.918,266.634 0.01,-0.032 0.962,-2.59 -0.968,2.622 M 913.537,550.485 h -0.044 l -1.377,-0.054 1.421,0.054 m 127.267,189.184 1.43,0.818 -1.461,-0.827 0.031,0.009 m -227.945,64.501 1.709,1.698 -1.727,-1.707 0.018,0.009 m 417.757,200.502 v -0.01 l 0.205,0.256 -0.208,-0.248 m -220.592,-231.93 -0.217,1.645 0.201,-1.679 0.016,0.034 m -312.559,141.487 -0.15,1.918 0.145,-1.907 0.005,-0.011 m 17.8,-156.421 -1.464,1.53 1.466,-1.538 -0.002,0.008 m 24.172,-17.586 0.033,0.007 -1.704,0.17 1.671,-0.177 m -3.772,11.301 -1.725,-0.577 1.75,0.561 -0.025,0.016 m 413.435,-90.216 1.155,1.128 -1.163,-1.134 0.01,0.006 m -430.057,70.057 0.019,0.007 -1.262,-0.457 1.243,0.45 m 89.447,59.496 0.257,1.583 -0.264,-1.603 0.007,0.02 m -134.661,-61.521 0.017,-0.007 -2.057,1.458 2.04,-1.451 m 112.926,-52.551 0.173,-1.706 -0.156,1.713 -0.017,-0.007 m 9.297,34.984 0.016,-0.005 -1.844,0.614 1.828,-0.609 m 425.726,318.041 -10e-4,0.01 -0.5,1.513 0.501,-1.522 m -196.327,-293.531 -0.011,-0.008 1.688,-1.15 -1.677,1.158 m 17.455,-48.27 0.08,1.131 -0.104,-1.135 0.024,0.004 M 720.041,788.5 l -1.253,0.028 1.271,-0.059 -0.018,0.031 m 291.608,-96.135 -2.299,0.172 2.299,-0.182 v 0.01 m 24.164,-10.551 v -0.002 l 1.424,1.141 -1.427,-1.139 m -425.627,160.016 -0.772,1.609 0.756,-1.594 0.016,-0.015 m 130.635,-120.642 0.005,0.002 -1.364,1.118 1.359,-1.12 m 18.085,111.605 0.006,-0.005 -1.103,1.67 1.097,-1.665 m 37.601,-119.168 -0.116,-1.297 0.139,1.303 -0.023,-0.006 m 16.593,101.125 -0.012,0.023 -0.042,-1.6 0.054,1.577 m -83.204,-78.137 0.012,10e-4 -1.648,0.772 1.636,-0.773 m 24.364,-36.519 1.52,0.705 -1.555,-0.707 0.035,0.002 m -16.116,-73.01 -1.672,0.958 1.675,-0.974 -0.003,0.016 m 19.174,85.627 1.003,0.817 -1.043,-0.808 0.04,-0.009 m -45.029,107.391 -1.338,2.029 1.313,-2.049 0.025,0.02 m 516.326,167.697 v -0.007 l 0.28,0.268 -0.283,-0.261 m -158.326,-349.95 0.023,-0.005 -0.175,1.15 0.152,-1.145 m 12.72,-21.176 -1.813,-1.105 1.813,1.105 v 0 m -325.361,602.144 1.349,0.6 -1.356,-0.603 h 0.007 m 368.363,-462.792 v -0.007 l 1.189,0.506 -1.184,-0.499 m -69.561,-8.802 1.251,0.619 -1.264,-0.621 0.013,0.002 m -292.515,-88.332 1.527,0.215 -1.565,-0.19 0.038,-0.025 m 256.145,42.701 0.028,0.002 -1.632,0.245 1.604,-0.247 m -297.113,48.814 -1.144,1.374 1.145,-1.39 -10e-4,0.016 m 63.231,96.356 -0.03,-0.044 1.023,1.46 -0.993,-1.416 M 1185,758.263 l 0.469,1.272 -0.478,-1.288 0.01,0.016 m -430.861,-30.577 0.626,-1.432 -0.636,1.461 0.01,-0.029 m 35.525,-50.896 0.415,1.275 -0.435,-1.293 0.02,0.018 m 4.255,170.482 0.035,-0.02 -1.504,0.906 1.469,-0.886 m 226.106,-127.124 0.366,-1.951 -0.357,1.983 -0.01,-0.032 m -263.795,82.724 0.031,-0.045 -0.878,1.433 0.847,-1.388 m -37.904,-24.354 -0.365,-1.163 0.38,1.163 h -0.015 m 123.876,-65.917 0.014,0.007 -2.518,0.474 2.504,-0.481 m -105.448,77.269 -1.104,-0.376 1.114,0.363 -0.01,0.013 m -4.401,-2.957 0.036,10e-4 -1.434,0.576 1.398,-0.577 m 77.897,14.88 0.302,1.66 -0.323,-1.708 0.021,0.048 m 428.236,171.096 0.326,-2.154 -0.322,2.165 v -0.011 M 768.36,853.51 l -0.071,1.548 0.053,-1.575 0.018,0.027 m 257.296,-273.241 -1.308,-0.717 1.334,0.727 -0.026,-0.01 m -268.56,637.987 -0.695,-0.197 0.684,0.191 0.011,0.01 m -23.151,-494.926 -1.24,0.597 1.256,-0.632 -0.016,0.035 m 0.695,28.903 0.009,0.011 -1.508,-0.98 1.499,0.969 m 373.259,-128.148 v -0.001 l 0.331,-0.081 -0.329,0.082 m -119.355,-62.699 1.406,0.371 -1.406,-0.371 v 0 m 79.483,125.665 1.817,0.882 -1.814,-0.875 v -0.007 m -349.066,49.729 -0.893,-1.209 0.9,1.21 -0.007,-10e-4 m -48.36,-0.369 -1.126,1.066 1.132,-1.085 -0.006,0.019 m 360.67,-45.673 0.017,0.005 -1.455,-0.382 1.438,0.377 m 8.935,47.063 1.947,0.852 -1.98,-0.846 0.033,-0.006 m -231.727,60.288 0.002,-0.023 0.086,2.158 -0.088,-2.135 m -46.779,-114.24 -0.261,-0.999 0.295,1.001 -0.034,-0.002 m 341.527,315.133 -1.405,1.313 1.383,-1.314 0.022,10e-4 m -329.89,-151.822 -1.022,1.072 1.027,-1.078 -0.005,0.006 m -18.198,368.057 0.732,0.548 -0.74,-0.549 h 0.008 m 5.655,-365.381 0.042,-0.033 -1.898,1.722 1.856,-1.689 m 478.987,112.825 0.087,-1.269 -0.085,1.247 v 0.022 m -448.034,-196.606 -0.4,1.375 0.355,-1.4 0.045,0.025 m 177.706,-173.135 -0.873,-0.775 0.933,0.786 -0.06,-0.011 m 60.633,150.339 1.337,0.614 -1.343,-0.616 0.01,0.002 m -349.389,-17.456 -1.525,1.152 1.524,-1.161 10e-4,0.009 m 88.088,117.823 -0.911,1.871 0.891,-1.858 0.02,-0.013 m -35.891,-94.354 0.002,0.007 -1.341,-1.24 1.339,1.233 m -4.333,27.906 -1.208,0.323 1.237,-0.338 -0.029,0.015 m -1.637,-25.812 0.029,10e-4 -1.848,0.433 1.819,-0.434 m 47.615,30.841 1.136,1.235 -1.163,-1.249 0.027,0.014 m 313.163,-170.258 0.014,0.02 -1.284,-0.855 1.27,0.835 M 750.611,1157.98 h -0.008 l 0.081,-0.836 -0.073,0.832 m -113.537,-399.623 -1.145,1.443 1.165,-1.473 -0.02,0.03 m 412.908,-172.211 -0.795,-0.504 0.801,0.507 -0.01,-0.003 m -279.669,93.25 -1.387,-0.024 1.429,0.01 -0.042,0.014 m -37.582,68.065 -1.428,0.095 1.452,-0.115 -0.024,0.02 m 455.115,299.136 -0.993,1.314 0.995,-1.32 v 0.01 m -467.01,-299.957 -1.194,0.333 1.189,-0.341 0.005,0.008 m 87.26,28.443 0.055,1.425 -0.06,-1.432 0.005,0.007 m 245.673,-27.755 0.724,1.529 -0.748,-1.553 0.024,0.024 m -15.977,274.194 0.01,-0.01 -0.736,1.429 0.729,-1.419 m 198.254,-66.931 v -0.009 l 0.426,-0.618 -0.428,0.627 m -496.842,-239.598 1.54,-0.616 -1.555,0.64 0.015,-0.024 m -2.554,-94.838 0.051,-0.033 -1.857,1.364 1.806,-1.331 m -14.723,123.672 -0.966,-0.664 0.988,0.653 -0.022,0.011 m 296.462,-41.812 -2.033,-0.395 2.072,0.4 -0.039,-0.005 m 162.999,55.664 -0.018,-0.019 0.837,0.879 -0.819,-0.86 m -154.895,-85.045 1.862,1.266 -1.874,-1.269 0.012,0.003 m -303.695,104.556 0.018,0.006 -1.271,-0.016 1.253,0.01 m 66.293,-100.752 -0.503,-1.277 0.518,1.266 -0.015,0.011 m 201.035,-82.943 -0.601,0.95 0.591,-0.958 0.01,0.008 m -250.452,89.914 0.16,-1.307 -0.14,1.319 -0.02,-0.012 m 33.474,440.009 0.01,0.01 -2.023,-0.276 2.013,0.267 m 290.385,-492.728 -1.747,-1.342 1.758,1.336 -0.011,0.006 m -325.822,124.012 -1.865,0.217 1.894,-0.246 -0.029,0.029 m 24.463,104.325 -0.73,1.18 0.743,-1.241 -0.013,0.061 m 258.887,-182.923 0.01,-0.031 0.84,2.123 -0.847,-2.092 m -321.766,16.072 -0.544,-0.825 0.577,0.822 -0.033,0.003 m 358.329,-6.413 1.548,0.979 -1.586,-0.994 0.038,0.015 m -299.168,0.488 0.042,-0.063 -0.837,1.485 0.795,-1.422 m 168.031,-0.168 -2.326,0.3 2.315,-0.314 0.011,0.014 m -180.493,46.173 1.217,0.646 -1.244,-0.634 0.027,-0.012 m 43.505,31.557 0.69,1.296 -0.715,-1.331 0.025,0.035 m -74.927,-9.91 -1.039,1.047 1.066,-1.083 -0.027,0.036 m -105.001,93.457 -0.171,1.726 0.158,-1.704 0.013,-0.022 m 189.337,-133.032 -0.049,-1.233 0.086,1.204 -0.037,0.029 m -89.2,11.76 -1.085,0.022 1.097,-0.045 -0.012,0.023 m 329.516,126.565 0.4,1.667 -0.427,-1.673 0.027,0.006 m -279.674,-247.492 -0.006,0.016 -0.263,-0.447 0.269,0.431 m 344.809,28.242 v 0 l -1.009,-1.11 1.011,1.11 m -82.369,72.495 0.033,0.019 -1.914,-0.075 1.881,0.056 m 50.429,-90.124 -1.513,-1.133 1.512,1.13 10e-4,0.003 m -42.734,104.555 -0.04,-0.039 1.535,1.182 -1.495,-1.143 m -368.279,65.277 -0.945,0.837 0.96,-0.899 -0.015,0.062 m 419.349,-76.025 v -0.007 l 1.028,0.981 -1.025,-0.974 m -353.996,28.889 0.023,0.017 -1.251,-0.464 1.228,0.447 m 101.092,66.745 0.027,-0.01 -0.768,1.43 0.741,-1.42 m -122.179,-6.954 -1.084,0.922 1.094,-0.963 -0.01,0.041 m 60.147,-138.126 1.263,-0.522 -1.28,0.551 0.017,-0.029 m 17.293,15.623 -0.888,-0.807 0.916,0.801 -0.028,0.006 m -2.827,-73.782 0.765,-0.788 -0.762,0.789 -0.003,-10e-4 m 459.8,303.054 0.045,1.661 -0.055,-1.657 0.01,-0.004 m -537.927,-95.87 0.002,-0.029 0.51,1.863 -0.512,-1.834 m -69.127,-48.193 -1.162,0.827 1.185,-0.855 -0.023,0.028 m 104.28,4.873 -0.694,-1.071 0.75,1.052 -0.056,0.019 m -0.412,-15.25 -1.481,0.264 1.495,-0.271 -0.014,0.007 m 282.789,-41.558 -1.295,-0.262 1.315,0.25 -0.02,0.012 m 41.566,151.62 0.01,-0.01 -0.094,1.373 0.085,-1.363 M 745.64,736.464 h 0.007 l -1.779,1.144 1.772,-1.144 m 62.54,65.574 -0.569,1.495 0.552,-1.457 0.017,-0.038 m -58.213,-89.25 1.897,-0.744 -1.911,0.757 0.014,-0.013 m 49.875,40.319 -1.192,0.938 1.197,-0.951 -0.005,0.013 m -155.869,-4.998 -1.411,1.063 1.41,-1.083 10e-4,0.02 m 138.338,-71.224 -0.377,-0.962 0.402,0.938 -0.025,0.024 m 250.863,51.091 1.849,0.323 -1.876,-0.326 0.027,0.003 m -33.796,-134.297 1.083,-0.051 -1.067,0.053 -0.016,-0.002 m -377.103,204.416 0.019,-0.034 -0.312,1.865 0.293,-1.831 m 178.22,-41.074 -0.798,1.165 0.812,-1.194 -0.014,0.029 m 428.494,219.573 v -0.006 l 0.551,-0.97 -0.549,0.976 m -514.574,-244.096 -1.146,0.136 1.164,-0.146 -0.018,0.01 m 110.785,71.507 -1.386,-0.069 1.35,0.024 0.036,0.045 m -175.066,26.56 0.028,-0.006 -1.385,0.317 1.357,-0.311 m 430.37,-200.263 1.129,0.871 -1.141,-0.855 0.012,-0.016 m -246.534,213.041 0.033,-0.011 -1.374,0.563 1.341,-0.552 m -86.438,-169.066 1.129,-0.98 -1.114,0.988 -0.015,-0.008 m 49.378,454.323 h -0.007 l 1.412,-0.58 -1.405,0.582 m 397.6,-375.916 0.331,1.458 -0.342,-1.492 0.011,0.034 m -459.472,8.435 -0.815,-0.979 0.827,0.988 -0.012,-0.009 m 307.336,-67.286 -0.899,-1.145 0.919,1.148 -0.02,-0.003 m -266.577,113.288 -1.554,0.632 1.565,-0.672 -0.011,0.04 m -56.597,-87.666 -0.904,1.037 0.885,-1.065 0.019,0.028 m 42.921,-60.083 1.583,-0.608 -1.613,0.631 0.03,-0.023 m -23.216,43.156 -0.042,0.008 1.551,-0.855 -1.509,0.847 m 7.235,455.472 0.012,1.089 -0.026,-1.097 0.014,0.01 m -16.635,-410.752 0.033,-0.009 -2.066,0.647 2.033,-0.638 m 9.444,301.16 1.41,0.34 -1.394,-0.314 -0.016,-0.026 m 63.985,-354.284 -1.311,0.738 1.304,-0.767 0.007,0.029 m 222.634,19.663 1.526,0.713 -1.547,-0.696 0.021,-0.017 M 743.464,674.22 v 0.008 l -0.461,-0.735 0.461,0.727 m 283.459,0.274 2.008,0.788 -2.021,-0.787 0.013,-10e-4 m -293.355,15.134 0.516,-1.504 -0.504,1.51 -0.012,-0.006 m 402.557,315.352 1.441,0.229 -1.454,-0.202 0.013,-0.027 m -387.487,-328.362 0.844,-1.232 -0.849,1.243 0.005,-0.011 m -16.299,70.252 -1.313,-0.148 1.406,0.118 -0.093,0.03 m 308.728,-9.704 1.353,0.865 -1.391,-0.864 0.038,-10e-4 m 80.489,259.006 1.151,0.89 -1.15,-0.863 -10e-4,-0.027 m -375.877,-382.661 -1.39,0.987 1.421,-1.01 -0.031,0.023 m 10.029,-7.807 0.711,-1.183 -0.717,1.202 0.006,-0.019 m 43.157,523.185 -0.005,-10e-4 0.43,-0.993 -0.425,0.994 m 441.251,-209.036 -0.029,1.731 0.02,-1.748 0.01,0.017 m -117.355,-257.386 0.845,1.094 -0.855,-1.091 0.01,-0.003 m -346.77,405.13 -1.541,0.079 1.513,-0.09 0.028,0.011 m -19.746,149.987 -0.016,-0.01 0.871,0.495 -0.855,-0.486 m -36.795,-484.537 -1.145,-0.17 1.148,0.169 -0.003,0.001 m 106.437,393.771 1.895,0.339 -1.956,-0.332 0.061,-0.01 m -65.497,-435.354 -1.152,0.827 1.172,-0.883 -0.02,0.056 m 9.062,112.024 -1.163,-0.544 1.189,0.539 -0.026,0.005 m -44.344,192.581 -0.019,-0.034 1.467,1.041 -1.448,-1.007 m -69.256,-230.135 -1.229,0.498 1.253,-0.527 -0.024,0.029 m 82.905,-19.503 -1.551,-0.311 1.59,0.29 -0.039,0.021 m -81.623,135.579 -0.794,1.112 0.79,-1.142 0.004,0.03 m 373.433,-162.229 -0.022,-0.028 1.495,0.414 -1.473,-0.386 m -399.964,32.878 -0.629,1.368 0.635,-1.41 -0.006,0.042 m 93.537,-6.799 -0.9,-0.63 0.957,0.62 -0.057,0.01 m 290.589,-51.334 -1.507,0.828 1.521,-0.836 -0.014,0.008 m -326.043,23.948 -0.707,1.424 0.709,-1.454 -0.002,0.03 m -16.79,35.202 -0.991,1.57 1.016,-1.625 -0.025,0.055 m 139.807,20.309 -0.745,1.783 0.756,-1.811 -0.011,0.028 m -93.402,260.385 0.15,1.386 -0.172,-1.376 0.022,-0.01 m 7.223,-248.138 -0.002,0.017 -1.357,-0.211 1.359,0.194 m 44.059,-77.483 -10e-4,0.035 -1.437,0.157 1.438,-0.192 m 250.964,5.755 -1.376,-0.616 1.407,0.611 -0.031,0.005 m -256.239,507.966 h 0.002 l -1.29,-0.574 1.288,0.573 m -29.43,-507.118 -0.279,-1.046 0.291,1.048 -0.012,-0.002 m 383.353,-88.974 -0.01,-0.004 1.081,0.869 -1.075,-0.865 m -375.324,102.169 0.831,0.87 -0.85,-0.883 0.019,0.013 m 25.473,495.655 -1.365,-0.554 1.362,0.552 h 0.003 m -27.434,-526.527 1.213,0.089 -1.249,-0.074 0.036,-0.015 m 295.432,41.029 1.568,1.151 -1.601,-1.156 0.033,0.005 m -297.368,42.069 0.024,0.021 -1.304,-0.454 1.28,0.433 m 15.758,-116.644 1.199,-1.141 -1.225,1.176 0.026,-0.035 m 114.263,70.843 1.554,-0.565 -1.583,0.588 0.029,-0.023 m -139.38,-4.884 h 0.008 l -1.33,0.702 1.322,-0.702 m 7.055,29.963 -1.241,-0.721 1.289,0.709 -0.048,0.012 m -3.69,25.467 -0.006,0.008 -1.047,-0.579 1.053,0.571 m 458.155,305.271 0.929,-1.385 -0.91,1.36 -0.019,0.025 m -150.597,-73.422 -1.336,1.329 1.36,-1.373 -0.024,0.044 m -230.209,-248.799 0.04,0.003 -1.611,0.132 1.571,-0.135 m -29.16,-64.205 0.02,0.003 -1.471,0.781 1.451,-0.784 m -28.262,-22.47 h 0.016 l -1.445,0.3 1.429,-0.3 m 77.735,157.249 -0.025,0.034 -1.694,0.953 1.719,-0.987 m -158.662,-117.661 1.242,-0.934 -1.241,0.937 -10e-4,-0.003 m 154.059,404.765 -1.52,0.454 1.512,-0.475 0.008,0.021 m 86.919,-458.419 -1.28,1.274 1.282,-1.278 -0.002,0.004 m -102.223,10.819 0.005,1.207 -0.041,-1.215 0.036,0.008 m -63.484,-65.673 0.031,-0.018 -0.646,0.998 0.615,-0.98 m 58.157,195.214 -0.397,1.755 0.392,-1.808 0.005,0.053 m 422.244,214.412 -0.344,0.996 0.336,-0.979 0.01,-0.017 m -409.108,-323.415 -2.073,-0.069 2.118,0.034 -0.045,0.035 m -73.772,-2.533 1.026,0.516 -1.046,-0.514 0.02,-0.002 m 427.105,361.707 h -0.932 l 0.934,-0.01 v 0 m -399.36,-268.009 -1.164,-0.431 1.207,0.437 -0.043,-0.006 m 46.3,-0.394 -0.717,1.737 0.717,-1.764 v 0.027 m -117.034,28.554 -0.941,1.43 0.917,-1.449 0.024,0.019 m 345.749,-130.841 1.282,0.462 -1.276,-0.458 -0.01,-0.004 m -302.764,162.81 -1.084,0.969 1.094,-0.989 -0.01,0.02 m -8.347,-149.395 -0.032,0.023 1.214,-1.138 -1.182,1.115 m 71.82,80.992 -0.775,1.167 0.778,-1.21 -0.003,0.043 m 312.056,211.301 -0.187,1.877 0.163,-1.852 0.024,-0.025 m -311.496,223.394 1.272,-0.038 -1.244,0.055 -0.028,-0.017 m 202.479,-519.676 -1.437,-0.332 1.459,0.333 -0.022,-10e-4 m -267.036,-83.303 0.061,-0.026 -1.303,0.717 1.242,-0.691 m 127.227,142.247 1.704,-0.074 -1.73,0.094 0.026,-0.02 m -90.011,85.553 v -0.029 l 0.421,1.331 -0.421,-1.302 m 59.99,294.466 0.02,0.012 0.063,1.372 -0.083,-1.384 m 359.854,-413.001 0.717,1.198 -0.726,-1.213 0.01,0.015 m -184.432,-19.359 -1.365,-0.259 1.409,0.224 -0.044,0.035 m -207.694,510.869 h 0.027 l 1.441,0.416 -1.468,-0.418 m 38.01,10.514 0.902,-0.365 -0.82,0.388 -0.082,-0.023 m 193.605,-488.989 1.507,1 -1.537,-1.008 0.03,0.008 m -279.083,426.908 0.477,0.903 -0.486,-0.918 0.009,0.015 m -8.216,-460.757 0.537,0.912 -0.573,-0.915 0.036,0.003 m 18.107,-55.744 1.302,-0.174 -1.317,0.184 0.015,-0.01 m -52.48,96.094 -0.771,-0.689 0.795,0.686 -0.024,0.003 m 425.866,-92.044 0.961,1.002 -0.971,-1.012 0.01,0.01 M 617.977,858.944 h -0.032 l -0.784,-0.755 0.816,0.755 m 191.588,-92.823 -1.33,-0.101 1.353,0.077 -0.023,0.024 m -75.708,-45.236 -1.344,0.283 1.394,-0.306 -0.05,0.023 m -37.495,73.128 -1.429,0.497 1.432,-0.513 -0.003,0.016 m 42.582,-9.412 -0.399,-1.319 0.407,1.288 -0.008,0.031 m -16.112,-35.534 -1.379,0.614 1.404,-0.645 -0.025,0.031 m 293.9,-41.465 0.021,0.01 -1.374,0.021 1.353,-0.031 m -274.439,-73.931 -10e-4,0.002 -1.091,-0.083 1.092,0.081 m 281.224,100.127 1.229,-0.836 -1.255,0.859 0.026,-0.023 m -9.109,-31.26 0.015,-0.035 0.876,-0.71 -0.891,0.745 m -288.206,48.566 0.009,0.007 -1.022,-0.492 1.013,0.485 m 271.513,-160.352 0.076,-0.014 -0.721,0.502 0.645,-0.488 m 35.987,154.822 1.224,1.355 -1.259,-1.362 0.035,0.007 m -1.956,-3.512 1.427,0.752 -1.445,-0.748 0.018,-0.004 m -275.058,33.098 0.009,-0.008 -1.296,1.155 1.287,-1.147 m -154.829,129.572 0.536,1.481 -0.554,-1.469 0.018,-0.012 m 565.82,-214.452 10e-4,0.003 0.01,0.55 -0.01,-0.553 m -412.787,4.249 1.248,0.029 -1.279,-0.011 0.031,-0.018 m -9.33,145.213 -1.392,0.395 1.434,-0.417 -0.042,0.022 m -120.069,-47.245 0.022,-0.029 -0.741,1.223 0.719,-1.194 m 219.19,332.101 -0.3,1.21 0.295,-1.245 0.005,0.035 m 198.253,-422.223 -1.342,-0.417 1.391,0.417 h -0.049 m 1.772,-115.287 -0.897,-0.597 0.899,0.599 v -0.002 m -284.546,632.136 -1.068,-0.382 1.07,0.378 h -0.002 m 304.139,-533.968 10e-4,-0.003 1.169,1.09 -1.17,-1.087 m -233.622,119.124 -0.027,-0.01 1.379,-0.089 -1.352,0.099 m 198.797,-73.547 1.372,1.059 -1.394,-1.065 0.022,0.006 m 107.938,-55.664 -0.583,-1.019 0.607,1.028 -0.024,-0.009 m -408.545,109.101 -1.231,0.368 1.24,-0.375 -0.009,0.007 m 195.243,-99.674 1.457,1.082 -1.506,-1.095 0.049,0.013 m -163.297,535.356 -0.064,-0.031 1.381,0.633 -1.317,-0.602 m 14.191,-153.033 1.513,0.065 -1.509,-0.035 -0.004,-0.03 m -82.59,-285.039 -0.912,-0.466 0.917,0.46 -0.005,0.006 m 469.15,9.663 1.478,1.482 -1.502,-1.489 0.024,0.007 m -339.146,-86.279 -0.005,-0.027 0.557,1.135 -0.552,-1.108 m 200.022,18.824 -0.92,0.839 0.887,-0.843 0.033,0.004 m -284.867,-103.923 -0.918,0.854 0.924,-0.863 -0.006,0.009 m 18.145,597.298 1.311,0.612 -1.345,-0.627 0.034,0.015 m 301.22,-630.03 -0.866,-0.473 0.88,0.479 -0.014,-0.006 m -424.317,178.715 -0.827,1.121 0.844,-1.168 -0.017,0.047 m 198.083,-207.076 -0.575,0.266 0.556,-0.264 0.019,-0.002 m 184.515,137.917 -1.153,0.254 1.165,-0.27 -0.012,0.016 m 24.106,37.984 1.236,0.886 -1.29,-0.884 0.054,-0.002 m 138.615,327.209 v 0 l -0.89,1.063 0.886,-1.065 m -408.102,162.701 -1.265,-0.506 1.273,0.51 h -0.008 m 58.827,-507.807 -0.008,-0.021 1.182,0.771 -1.174,-0.75 m -204.118,94.116 0.003,-0.019 0.043,1.362 -0.046,-1.343 m 443.22,-91.771 1.308,1.201 -1.324,-1.201 h 0.016 m 90.669,-54.911 -0.01,-0.006 0.523,0.492 -0.517,-0.486 m -124.396,84.365 1.042,1.003 -1.096,-1.024 0.054,0.021 m -141.174,-83.218 0.426,1.099 -0.448,-1.134 0.022,0.035 m -36.248,-91.135 -0.003,-10e-4 1.646,-0.059 -1.643,0.06 m 227.627,235.79 -0.263,-2.33 0.271,2.351 -0.01,-0.021 m -245.043,-78.521 -0.986,-0.934 1.025,0.927 -0.039,0.007 m 168.901,-130.888 v -0.003 l 1.274,-0.201 -1.275,0.204 m 24.371,150.394 0.733,1.168 -0.76,-1.187 0.027,0.019"
+           id="polygon8" />
+      </g>
+      <g
+         id="layer3-0">
+        <radialGradient
+           gradientUnits="userSpaceOnUse"
+           gradientTransform="matrix(0.0222,0,0,-0.0248,721.1671,674.6745)"
+           r="13293.867"
+           cy="-10508.842"
+           cx="7976.3457"
+           id="radialGradient8507">
+          <stop
+             id="stop8503"
+             style="stop-color:#80FF80"
+             offset="0" />
+          <stop
+             id="stop8505"
+             style="stop-color:#0f0"
+             offset="1" />
+        </radialGradient>
+        <path
+           style="fill:url(#polygon413_1_)"
+           inkscape:connector-curvature="0"
+           d="m 738.059,824.52 -4.896,-2.991 3.183,4.563 1.697,-1.541 0.016,-0.031 m 315.115,-124.435 -0.383,1.419 1.727,0.363 -1.317,-1.773 -0.027,-0.009 m -257.087,112.336 -2.255,0.589 0.465,1.879 1.814,-2.44 -0.024,-0.028 m -70.86,-12.684 -3.059,0.086 3.033,-0.077 0.026,-0.009 m 507.893,171.781 -0.121,-1.182 0.118,1.188 v -0.006 m 1.431,4.062 -0.34,-0.164 0.341,0.166 -10e-4,-0.002 m -490.636,-279.995 -1.29,-0.768 1.215,0.783 0.075,-0.015 m 461.488,304.626 1.548,-2.094 -1.536,2.067 -0.012,0.027 m -461.774,-304.148 -2.035,-0.956 2.023,0.955 0.012,10e-4 m 305.072,4.142 -1.344,-0.514 1.317,0.515 0.027,-10e-4 m 186.587,263.978 v -0.003 l -0.166,-0.673 0.163,0.676 m -97.138,-286.087 0.064,0.801 -0.063,-0.798 -10e-4,-0.003 m -373.039,161.109 -2.353,0.707 2.337,-0.677 0.016,-0.03 m 46.254,289.391 -0.434,-1.414 0.419,1.393 0.015,0.021 m -40.176,-62.291 -1.831,-0.333 1.871,0.346 -0.04,-0.013 m 61.266,62.881 1.77,0.989 -1.741,-0.978 -0.029,-0.011 m 399.868,-148.699 -0.027,1.02 0.03,-1.032 v 0.012 m -85.152,-270.635 1.13,0.812 -1.113,-0.81 -0.017,-0.002 m -427.622,49.937 -0.003,10e-4 -1.005,1.075 1.008,-1.076 m 9.885,37.886 -1.26,0.07 1.234,-0.036 0.026,-0.034 m 411.98,-115.919 -0.672,-1.176 0.654,1.173 0.018,0.003 m -343.025,536.588 0.573,0.66 -0.549,-0.659 -0.024,-10e-4 m 260.171,-528.531 1.178,0.889 -1.171,-0.889 h -0.01 M 939.115,568.803 h -0.003 l -0.188,0.437 0.191,-0.437 m -4.625,-9.775 -1.369,-0.157 1.377,0.166 -0.008,-0.009"
+           id="polygon413" />
+      </g>
+      <path
+         d="m 1250,900 c 0,193.3 -156.701,350 -350,350 -193.3,0 -350,-156.7 -350,-350 0,-193.3 156.7,-350 350,-350 193.299,0 350,156.7 350,350 z"
+         id="path3517"
+         inkscape:connector-curvature="0"
+         style="fill:url(#path3517_1_)" />
+    </g>
+  </g>
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="globe (monochrome)">
+    <g
+       id="g7683-2"
+       transform="matrix(0.23553622,0,0,0.23553622,38.625256,4.6984589)">
+      <g
+         id="layer8-0">
+        <radialGradient
+           id="radialGradient8123-2"
+           cx="6611.7559"
+           cy="-7278.2686"
+           r="17925.004"
+           gradientTransform="matrix(0.0195,0,0,-0.0195,770.9,757.886)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="0"
+             style="stop-color:#0101FF"
+             id="stop8119-3" />
+          <stop
+             offset="1"
+             style="stop-color:#000080"
+             id="stop8121-7" />
+        </radialGradient>
+        <path
+           id="path125302-5"
+           d="m 1250,900 c 0,193.3 -156.701,350 -350,350 -193.3,0 -350,-156.7 -350,-350 0,-193.3 156.7,-350 350,-350 193.299,0 350,156.7 350,350 z"
+           inkscape:connector-curvature="0"
+           style="fill:#444444;fill-opacity:1" />
+      </g>
+      <g
+         id="layer9-9">
+        <path
+           id="path130576-2"
+           d="m 1058.456,587.924 -4.442,-2.216 -4.931,-2.369 -2.926,-1.361 -2.383,-1.084 -0.302,-0.135 -2.006,-0.895 -1.82,-0.798 1.232,0.539 -2.489,-1.083 -5.279,-2.222 -3.805,-1.538 5.467,2.227 -1.812,-0.75 -4.051,-1.634 2.525,1.012 1.911,0.781 1.396,0.579 -0.57,-0.238 -4.806,-1.952 3.92,1.586 -2.005,-0.818 2.842,1.164 -1.145,-0.472 1.367,0.565 1.709,0.716 -1.613,-0.676 -1.881,-0.776 0.127,0.053 -1.889,-0.768 -2.91,-1.157 0.884,0.348 -2.64,-1.032 3.294,1.292 -0.579,-0.229 3.352,1.347 -6.096,-2.42 8.953,3.601 0.013,0.005 2.229,0.942 0.181,0.077 3.246,1.406 1.71,0.756 3.918,1.774 -3.626,-1.644 2.951,1.334 2.511,1.161 0.996,0.467 3.643,1.742 0.01,0.003 3.925,1.935 -0.677,-0.338 2.213,1.113 1.422,0.725 -0.917,-0.469 -1.395,-0.706 3.513,1.793 -0.449,-0.232 1.187,0.615 -0.438,-0.228 3.684,1.939 -2.331,-1.234 1.015,0.534 6.16,3.336 2.787,1.563 0.68,0.386 3.52,2.032 -0.824,-0.481 3.08,1.812 0.293,0.175 -1.801,-1.066 2.302,1.366 -2.318,-1.376 1.702,1.008 2.138,1.284 0.306,0.186 3.081,1.892 -0.045,-0.028 -1.346,-0.832 6.817,4.3 -0.906,-0.585 1.797,1.163 -3.312,-2.13 9.036,5.939 -1.417,-0.959 -5.027,-3.318 -1.427,-0.919 2.375,1.536 -0.184,-0.12 1.117,0.731 -1.167,-0.763 2.86,1.883 5.063,3.432 1.408,0.979 -0.964,-0.671 3.156,2.213 -4.351,-3.038 3.933,2.742 2.376,1.695 -0.437,-0.313 3.043,2.208 -2.081,-1.516 1.168,0.848 -3.848,-2.766 -3.046,-2.134 -0.98,-0.676 1.354,0.935 -2.46,-1.693 3.201,2.209 0.806,0.564 3.469,2.469 0.117,0.084 5.851,4.314 5.422,4.17 -5.168,-3.979 -4.247,-3.156 1.746,1.285 -0.94,-0.694 1.504,1.113 -1.645,-1.217 1.819,1.347 3.198,2.412 1.939,1.491 2.695,2.108 0.873,0.691 -2.134,-1.683 -1.603,-1.247 2.313,1.804 3.861,3.082 -1.041,-0.839 7.889,6.531 1.363,1.169 -0.738,-0.634 2.123,1.834 0.763,0.666 0.396,0.348 3.3,2.936 3.028,2.762 1.401,1.301 2.45,2.308 -1.567,-1.482 -1.718,-1.603 1.074,1 3.38,3.203 -0.282,-0.271 6.513,6.402 -0.134,-0.135 1.878,1.907 1.691,1.744 2.414,2.53 0.363,0.386 -3.265,-3.42 -0.397,-0.41 3.426,3.58 -0.466,-0.493 4.845,5.221 1.521,1.685 3.182,3.595 2.563,2.967 1.038,1.223 2.154,2.572 1.092,1.324 -1.084,-1.313 1.329,1.613 1.414,1.737 -1.057,-1.301 2,2.473 1.802,2.267 -1.321,-1.667 -1.91,-2.373 1.433,1.776 -1.284,-1.592 0.494,0.61 -6.703,-8.053 -5.271,-6.004 -0.07,-0.078 3.089,3.482 1.909,2.199 1.585,1.855 -1.743,-2.039 1.494,1.745 -0.719,-0.842 -1.089,-1.267 0.631,0.733 1.823,2.138 0.271,0.322 1.406,1.678 -0.28,-0.336 -1.457,-1.734 -1.692,-1.984 0.98,1.145 2.262,2.685 -2.045,-2.43 0.502,0.592 2.225,2.656 0.866,1.049 -1.699,-2.05 3.757,4.575 -2.791,-3.415 0.924,1.121 3.712,4.599 0.891,1.128 1.02,1.302 0.097,0.124 3.159,4.122 -2.212,-2.899 2.071,2.712 -1.122,-1.476 1.196,1.575 0.542,0.72 0.577,0.771 2.522,3.42 1.51,2.089 -1.018,-1.412 1.515,2.108 1.29,1.821 -0.757,-1.071 1.165,1.652 -0.087,-0.124 0.941,1.349 -0.086,-0.124 2.176,3.169 -0.55,-0.808 2.063,3.056 -0.01,-0.011 2.44,3.708 -1.342,-2.05 1.903,2.917 0.205,0.319 0.188,0.294 2.359,3.725 -1.01,-1.608 2.486,3.993 -0.92,-1.491 1.335,2.168 0.231,0.38 0.865,1.43 -0.549,-0.909 3.586,6.052 -0.521,-0.897 -2.142,-3.623 2.022,3.418 1.228,2.121 -0.608,-1.055 1.435,2.499 1.273,2.261 0.177,0.318 0.315,0.566 0.424,0.767 -0.202,-0.367 1.639,2.998 0.521,0.969 -0.221,-0.411 0.67,1.251 0.149,0.281 0.129,0.243 0.518,0.979 0.67,1.279 -1.107,-2.106 1.131,2.151 0.86,1.663 -0.292,-0.567 0.685,1.331 -0.35,-0.681 0.933,1.827 -1.114,-2.181 -0.696,-1.344 0.212,0.409 -0.993,-1.899 0.53,1.009 1.311,2.533 -0.403,-0.785 1.463,2.869 v -0.006 l 0.587,1.169 0.404,0.813 -0.813,-1.626 1.273,2.558 0.376,0.765 -0.823,-1.669 1.317,2.683 -2.533,-5.11 3.574,7.274 0.317,0.665 -1.338,-2.786 1.566,3.269 -0.454,-0.956 0.729,1.54 0.055,0.117 1.011,2.171 0.299,0.647 -1.113,-2.4 -3.258,-6.766 -0.532,-1.071 -2.2,-4.334 3.188,6.331 -0.585,-1.187 1.242,2.532 -1.193,-2.434 1.579,3.229 1.44,3.021 0.994,2.13 1.648,3.616 -1.134,-2.5 -2.069,-4.431 -0.8,-1.67 -3.772,-7.59 -2.037,-3.915 -0.485,-0.915 0.317,0.598 -1.526,-2.851 -1.062,-1.947 0.623,1.139 -1.843,-3.338 0.262,0.468 -1.72,-3.051 -0.965,-1.681 0.576,1.002 -6.11,-10.25 0.173,0.279 -5.012,-7.872 -2.558,-3.845 -1.851,-2.715 -0.153,-0.222 -1.414,-2.035 -0.104,-0.148 -1.186,-1.681 -1.852,-2.583 1.065,1.479 10.059,14.85 2.491,3.945 2.502,4.084 -0.208,-0.343 -0.974,-1.601 1.53,2.524 -8.667,-13.703 0.957,1.446 -1.151,-1.736 3.088,4.711 1.117,1.747 1.914,3.046 3.442,5.66 1.78,3.025 -0.859,-1.469 2.666,4.611 1.439,2.561 -0.71,-1.27 1.382,2.48 3.051,5.651 3.139,6.088 0.714,1.426 -2.219,-4.38 1.896,3.735 0.964,1.943 0.633,1.291 -0.588,-1.2 1.95,4.028 -1.356,-2.816 1.64,3.412 -0.237,-0.5 4.451,9.734 0.964,2.217 -0.412,-0.954 2.587,6.115 -1.034,-2.481 0.87,2.084 -0.487,-1.171 -1.882,-4.422 -2.583,-5.809 0.063,0.139 -2.623,-5.631 2.878,6.192 5.104,11.848 -0.49,-1.19 0.5,1.213 0.67,1.65 0.611,1.527 0.112,0.282 1.113,2.842 -0.292,-0.75 0.823,2.133 0.46,1.213 0.668,1.784 0.924,2.516 0.576,1.603 0.844,2.387 -0.861,-2.438 2.188,6.31 0.064,0.193 0.984,2.98 -0.15,-0.46 2.194,6.956 1.038,3.478 2.048,7.288 0.26,0.971 1.284,4.968 0.707,2.871 -0.366,-1.499 1.114,4.663 0.108,0.467 0.124,0.542 0.517,2.291 -0.347,-1.545 1.006,4.581 -0.052,-0.239 0.755,3.635 0.098,0.481 2.284,12.573 1.313,8.761 -0.107,-0.783 0.856,6.611 0.348,3.011 1.205,13.056 0.533,8.783 -0.107,-2.098 0.186,3.811 -0.041,-0.925 0.022,0.496 0.266,8.069 -0.146,-5.088 0.147,5.168 -0.188,-6.241 -0.197,-4.374 -0.332,-5.566 -0.146,-2.076 -0.356,-4.458 -0.339,-3.695 -0.122,-1.233 -0.369,-3.489 -1.165,-9.371 -1.37,-9.042 -0.787,-4.578 -0.584,-3.191 -0.567,-2.946 -0.274,-1.377 -2.803,-12.702 -0.162,-0.673 1.396,5.994 0.245,1.105 0.967,4.53 1.128,5.701 -0.119,-0.63 -1.17,-5.847 -0.557,-2.616 -0.398,-1.814 -0.998,-4.354 -0.406,-1.704 0.282,1.178 -0.513,-2.128 -0.035,-0.146 -0.67,-2.691 0.649,2.608 -1.214,-4.81 -0.128,-0.491 -1.448,-5.364 -1.461,-5.095 1.231,4.275 -1.174,-4.082 1.593,5.585 -0.477,-1.707 0.193,0.687 0.263,0.944 -0.499,-1.785 0.333,1.188 2.003,7.515 0.841,3.373 -0.363,-1.474 0.521,2.123 0.321,1.336 -1.212,-4.935 0.492,1.966 0.682,2.807 0.585,2.495 0.766,3.396 -0.489,-2.19 0.467,2.089 -0.549,-2.446 0.048,0.208 -0.953,-4.077 -0.386,-1.592 -0.17,-0.689 -0.564,-2.249 0.119,0.467 -0.664,-2.587 0.248,0.958 -0.573,-2.195 -0.348,-1.301 -0.082,-0.304 -1.108,-4.012 -0.489,-1.715 0.158,0.551 -0.397,-1.378 -0.254,-0.866 -0.294,-0.996 -1.512,-4.958 -0.907,-2.854 1.416,4.493 -2.545,-7.932 -1.409,-4.136 -1.006,-2.852 0.437,1.227 -3.045,-8.28 -2.811,-7.123 0.335,0.827 -0.948,-2.323 -1.768,-4.206 0.279,0.656 -0.976,-2.271 1.034,2.408 -1.736,-4.015 -0.191,-0.435 0.18,0.408 -1.194,-2.684 -2.082,-4.538 0.218,0.466 0.938,2.033 -0.344,-0.751 0.605,1.323 -1.962,-4.232 0.5,1.064 2.289,4.995 -0.966,-2.131 1.384,3.068 -0.362,-0.812 -5.234,-11.147 1.673,3.453 -0.792,-1.647 0.829,1.726 0.473,0.994 -0.417,-0.876 -2.1,-4.328 1.124,2.298 -2.333,-4.719 -5.816,-11.057 2.166,4.007 1.167,2.211 0.088,0.167 v -0.004 l 2.749,5.372 1.602,3.24 -1.914,-3.862 1.223,2.454 1.412,2.894 2.545,5.396 2.382,5.278 1.869,4.312 0.183,0.431 2.07,4.992 3.858,9.942 1.868,5.164 0.565,1.615 -0.537,-1.535 1.051,3.024 0.424,1.244 1.963,5.98 1.214,3.893 0.683,2.263 -0.868,-2.868 1.452,4.847 -0.098,-0.333 0.588,2.03 -0.281,-0.979 0.699,2.449 -0.445,-1.564 0.621,2.193 0.02,0.068 0.663,2.409 -0.979,-3.529 1.246,4.52 -1.123,-4.083 -0.047,-0.167 -0.703,-2.458 -1.085,-3.67 -0.476,-1.56 -0.362,-1.174 -1.404,-4.416 -1.529,-4.595 -0.352,-1.023 -1.316,-3.755 2.342,6.779 1.227,3.74 5.753,19.893 2.007,8.206 -0.39,-1.663 0.583,2.505 2.11,9.853 0.685,3.536 0.915,5.061 -0.263,-1.5 0.7,4.084 -0.291,-1.735 0.432,2.589 1.269,8.425 0.871,6.798 0.658,6.015 v -0.03 l 0.337,3.519 -0.345,-3.593 0.216,2.208 0.286,3.176 0.024,0.291 -0.137,-1.574 -0.836,-8.271 -0.366,-3.109 -0.841,-6.39 0.469,3.449 -0.226,-1.694 0.882,7.03 0.237,2.114 0.491,4.813 0.153,1.658 0.653,8.344 0.338,5.838 0.116,2.541 0.193,5.684 0.036,1.524 -0.037,-1.588 0.089,4.563 -0.044,-2.606 0.028,1.551 -0.01,11.643 -0.454,12.79 -0.489,7.56 -0.63,7.32 -0.557,5.331 -0.991,8.002 -0.599,4.219 -1.388,8.634 -0.703,3.917 -1.866,9.353 -1.469,6.566 0.297,-1.279 -3.599,14.269 -1.597,5.628 0.611,-2.112 -1.243,4.246 -1.624,5.268 -2.764,8.356 -4.428,12.113 -2.644,6.636 -1.317,3.167 -1.188,2.784 0.975,-2.278 -1.135,2.647 0.251,-0.581 -2.131,4.841 0.463,-1.035 -0.869,1.938 0.38,-0.844 -0.837,1.85 0.1,-0.22 -0.702,1.531 1.355,-2.974 -0.898,1.979 v 0.01 l -1.121,2.426 -0.616,1.313 0.635,-1.352 -0.712,1.516 0.684,-1.456 -1.976,4.16 -0.288,0.594 -0.895,1.83 -0.082,0.167 -1.967,3.924 0.378,-0.745 -0.773,1.52 -0.966,1.873 -1.083,2.066 -0.342,0.645 -2.706,4.998 0.196,-0.355 3.251,-6.046 3.084,-6.012 1.143,-2.305 7.049,-15.253 3.684,-8.83 -0.912,2.252 1.036,-2.562 -0.466,1.157 0.744,-1.854 -0.818,2.037 0.321,-0.797 -0.513,1.271 -0.147,0.36 0.66,-1.629 -1.117,2.744 -1.013,2.432 0.91,-2.183 0.57,-1.389 -0.338,0.824 0.512,-1.251 -0.322,0.79 0.803,-1.98 -0.272,0.676 1.265,-3.172 0.698,-1.791 -0.483,1.245 0.813,-2.1 -1.081,2.781 0.892,-2.287 -0.418,1.08 -0.337,0.86 -0.886,2.236 -4.609,10.968 0.261,-0.593 -1.353,3.048 -0.35,0.775 0.194,-0.431 -0.921,2.026 0.454,-0.994 -2.638,5.666 -0.508,1.06 -2.597,5.29 -1.443,2.846 -2.255,4.32 0.166,-0.313 -0.963,1.808 -3.459,6.288 -2.417,4.219 -3.19,5.371 -3.521,5.687 -5.364,8.222 -8.323,11.838 -5.99,7.919 -6.712,8.35 -9.737,11.245 -6.515,7.013 -2.004,2.07 -2.114,2.162 -2.767,2.546 1.679,-1.687 0.92,-1.38 8.717,-9.585 4.422,-5.998 6.484,-8.38 12.571,-16.45 7.58,-10.271 4.397,-6.79 7.532,-10.854 -0.748,1.209 0.306,-0.098 9.183,-17.275 4.562,-7.737 2.182,-3.323 1.785,-3.544 -0.019,-0.085 3.96,-9.114 2.6,-6.112 6.076,-17.13 3.579,-10.626 2.32,-6.675 0.486,-1.737 1.493,-5.192 1.032,-3.989 -0.163,0.644 1.5,-6.125 0.67,-2.904 -0.238,1.049 1.124,-5.067 0.301,-1.423 1.569,-7.94 2.13,-12.788 0.74,-5.294 0.093,-0.709 0.25,-1.969 1.982,-21.236 0.659,-17.623 -0.214,-17.237 -2.943,-34.127 -0.625,-4.397 -0.393,-2.572 0.25,1.622 -1.221,-7.5 0.207,1.199 1.302,8.241 1.132,8.483 0.677,6.039 0.16,1.588 0.622,7.025 -0.027,-0.345 0.213,2.823 -0.428,-5.416 -0.188,-2.089 -0.188,-1.956 0.205,2.148 -0.129,-1.374 0.235,2.546 -0.994,-9.656 0.04,0.343 -1.291,-9.895 -0.01,-0.043 -0.473,-3.159 0.029,0.192 -0.632,-3.956 -0.165,-0.987 -0.094,-0.552 -1.91,-10.29 -0.427,-2.085 -0.856,-4.005 0.848,3.964 0.104,0.504 -2.409,-10.821 1.821,8.027 -0.429,-1.968 1.325,6.274 0.612,3.113 -0.172,-0.888 0.738,3.905 1.027,5.897 0.078,0.48 1.043,6.774 0.983,7.387 0.947,8.632 -0.678,-6.365 -0.63,-5.116 -2.251,-14.774 -0.939,-5.161 -3.231,-15.182 -1.166,-4.788 -3.238,-11.994 -1.512,-5.083 -1.207,-3.869 -1.705,-5.212 -1.693,-4.922 -1.898,-5.254 -1.063,-2.831 -0.131,-0.346 -4.89,-12.131 -0.653,-1.528 1.663,3.928 -0.106,-0.254 -1.437,-3.395 -1.644,-3.766 7.262,17.661 1.872,5.049 1.053,2.947 0.446,1.275 -2.813,-7.791 0.661,1.781 2.188,6.119 -0.932,-2.648 -1.19,-3.29 0.209,0.57 -1.763,-4.713 0.482,1.27 -0.905,-2.372 -0.534,-1.376 -1.146,-2.896 -0.678,-1.675 -0.232,-0.568 -1.059,-2.56 1.923,4.69 -0.998,-2.458 -0.276,-0.671 -1.214,-2.904 -4.136,-9.383 1.544,3.417 -5.851,-12.47 -9.834,-18.509 1.282,2.268 -1.105,-1.957 1.478,2.622 -1.783,-3.158 1.037,1.828 -1.749,-3.068 1.543,2.701 -0.043,-0.075 -2.743,-4.765 1.48,2.551 2.896,5.137 -0.284,-0.236 -3.724,-6.36 -2.788,-4.939 -1.179,-1.799 1.496,2.445 0.592,1.085 -0.883,-1.364 1.504,2.545 0.355,0.934 2.42,4.511 4.721,12.281 0.455,12.158 0.32,7.235 -2.059,0.173 -1.735,-3.145 -1.081,-3.466 -2.901,-4.275 0.667,0.093 -1.86,-4.645 -1.786,-2.174 -1.014,-5.348 -3.596,-8.628 -1.428,-6.277 -1.476,-3.09 -2.083,-2.36 -1.829,-3.347 -3.588,-4.354 -0.725,-1.867 -7.784,-10.543 -4.742,-6.795 -5.41,-6.039 -3.698,-4.806 -0.541,-1.713 -3.714,-3.835 -1.699,-2.43 0.392,1.624 -2.3,-2.89 -0.533,0.537 -0.897,-1.677 -0.053,0.62 -1.686,-2.006 -0.467,0.168 -1.448,-2.262 -0.029,1.177 -2.653,-3.645 0.733,1.785 -1.034,-1.092 -0.544,-1.639 -2.816,-2.079 -0.749,5.137 -1.847,-2.197 1.025,1.772 -2.655,-1.263 -0.263,1.185 2.212,1.498 -1.106,0.595 -1.349,-2.235 0.433,5.101 3.468,6.858 -1.93,-2.157 1.454,2.209 -1.315,-1.643 -0.901,0.465 -1.163,-1.875 -0.915,0.568 -1.701,-2.601 -2.765,-2.229 0.413,-0.857 -1.034,0.274 -2.278,-2.349 -0.77,-2.453 -0.832,2.423 -1.745,-1.197 1.682,6.171 -0.163,4.174 -0.841,-1.867 -1.116,3.246 1.599,4.107 -1.393,-0.145 2.728,5.165 0.081,2.658 -1.198,-1.975 3.537,10.021 -1.854,-1.779 -5.691,4.148 -1.245,8.685 -3.117,4.767 -10.527,1.884 -2.149,-2.805 -1.633,0.583 3.845,-4.751 -0.497,-7.678 1.341,-2.779 7.02,-2.705 5.232,1.427 1.496,-7.504 2.874,1.711 -0.402,-4.284 -5.413,-9.565 -0.637,-4.194 -4.926,-3.258 1.356,3.624 -4.396,-2.478 -3.603,0.062 -1.342,4.069 -2.28,-2.182 0.184,2.533 -1.349,-1.404 -5.535,0.086 2.141,5.581 -2.384,-0.885 -4.914,-4.56 1.453,-1.732 -3.075,0.351 1.259,-1.825 -1.979,0.529 1.084,-0.978 -2.053,-0.45 1.585,-0.195 -1.705,-0.595 -0.011,-1.115 -2.468,-0.289 -9.563,-7.47 -1.738,-5.291 -1.4,-0.597 0.715,-8.66 2.318,-2.02 5.258,-0.119 5.092,-3.977 -2.483,-3.876 -3.546,-2.63 -0.465,-1.499 -1.142,-0.248 0.558,-0.746 -3.513,-1.368 -2.696,-2.503 -3.407,-1.465 -0.794,-1.257 -2.348,0.456 -2.596,-1.932 -1.437,0.199 2.085,2.268 -0.525,1.771 -1.795,-0.697 -1.734,-3.863 -0.081,0.569 -6.282,-3.123 -0.486,-0.932 -3.254,-0.874 -0.413,-0.915 -2.604,-0.479 -0.742,-2.012 -0.503,1.012 -1.164,-1.169 -1.148,0.11 -0.066,-2.446 -3.816,1.033 0.172,-0.686 -3.21,-1.775 -0.226,0.705 -2.565,-1.713 -1.084,0.327 -5.021,-2.178 -1.557,-1.248 1.265,-0.165 -4.2,-1.558 -0.887,-1.122 -0.979,0.337 -3.355,-2.28 1.602,-0.19 -4.541,-1.29 0.125,-0.846 -2.159,-0.472 0.26,-0.835 -2.057,-0.319 -0.655,-1.235 -1.442,0.279 0.069,-1.708 -2.577,-1.318 1.899,0.338 -1.313,-0.374 1.131,-0.568 -2.792,-0.252 -4.943,-3.938 1.197,-0.207 -5.462,-1.554 1.016,-0.722 -2.18,-0.964 1.379,-0.166 -2.867,-0.733 -0.462,-0.851 2.99,0.871 -3.978,-1.684 3.965,-0.017 5.742,1.55 -9.574,-3.54 4.623,-0.676 3.453,0.587 -8.855,-1.551 4.279,-0.617 0.829,-2.524 4.733,0.548 -0.47,-0.568 -6.302,-2.827 0.511,-0.191 -2.646,-0.513 -0.885,-0.841 -5.984,-1.797 -2.402,-0.334 -1.413,-0.92 8.498,1.301 7.968,2.676 0.124,-1.184 4.869,1.063 -1.157,-1.017 -5.797,-1.566 -10.847,-4.005 -4.262,-1.1 -1.018,0.285 5.903,2.261 -3.131,-0.688 4.442,1.649 -12.615,-3.797 -8.467,-1.233 2.753,1.294 -1.981,-0.08 3.022,0.573 1.889,0.861 -2.78,-0.43 1.47,0.434 -2.478,-0.377 -0.66,-0.283 -3.929,-0.294 -0.761,1.14 1.483,-0.137 2.086,0.704 -1.151,0.323 -0.674,-0.477 0.543,0.824 -1.929,-0.304 4.011,2.111 -1.467,0.515 1.699,0.311 -0.955,0.328 -3.897,-1.343 -0.224,0.488 -1.198,-0.865 -1.186,0.301 0.101,-0.623 -3.277,-0.078 -1.124,-0.838 -2.349,-0.053 -3.043,-1.803 0.045,-1.438 3.889,-1.524 4.138,-0.014 -1.033,-0.7 -10.943,-2.492 -0.867,-0.922 -4.572,-0.937 -0.136,-0.303 -2.352,-0.148 -2.867,-0.841 -5.316,0.023 -9.641,-1.24 -13.524,-1.996 -9.571,-0.78 6.271,-0.028 9.708,0.266 4.944,0.239 -0.488,-0.027 1.959,0.111 5.438,0.366 0.397,0.031 -1.699,-0.126 -1.123,-0.079 3.854,0.285 -1.724,-0.133 4.734,0.385 1.345,0.121 2.736,0.262 4.883,0.522 16.957,2.355 3.999,0.68 -1.18,-0.205 2.354,0.414 2.346,0.429 3.49,0.669 2.888,0.581 -3.006,-0.604 -0.754,-0.147 9.913,2.075 0.765,0.172 -2.068,-0.462 1.957,0.438 11.913,2.919 9.523,2.656 -3.927,-1.13 -1.036,-0.29 1.873,0.527 -2.048,-0.575 8.643,2.52 2.2,0.68 2.54,0.805 3.539,1.157 0.956,0.32 -3.265,-1.079 -5.092,-1.613 -5.785,-1.729 -16.651,-4.381 -4.563,-1.049 -5.735,-1.228 -5.156,-1.019 -0.674,-0.127 7.118,1.413 -0.042,-0.009 5.879,1.283 0.682,0.156 7.973,1.927 1.595,0.409 4.19,1.113 -0.186,-0.05 2.681,0.74 -3.652,-1.002 9.729,2.766 2.493,0.758 0.162,0.05 5.43,1.724 -1.467,-0.476 3.275,1.072 6.365,2.185 1.636,0.584 1.495,0.541 10.105,3.864 10.298,4.313 4.777,2.134 1.701,0.78 -0.89,-0.41 -0.403,-0.185 -0.707,-0.323 -3.787,-1.694 0.695,0.307 -2.229,-0.978 9.947,4.509 3.815,1.83 1.09,0.533 2.014,0.998 -1.38,-0.686 4.367,2.195 1.469,0.756 3.683,1.933 0.982,0.525 0.122,0.065 2.222,1.204 -1.966,-1.066 2.686,1.461 0.419,0.23 -1.826,-1 4.082,2.254 -0.575,-0.322 1.737,0.977 2.279,1.301 -3.468,-1.971 -3.81,-2.105 -2.107,-1.139 0.305,0.164 -0.706,-0.378 -6.418,-3.357 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon3-2"
+           d="m 980.896,1212.152 -2.02,1.006 -1.485,-1.202 -5.012,0.664 -10.71,3.47 -1.309,1.148 -8.205,0.43 -2.948,-0.854 -3.872,1.085 -5.252,-0.102 -2.18,0.864 -5.206,-2.121 -12.506,-2.132 -1.213,-1.509 -7.194,-2.144 -3.15,-0.021 -3.119,-2.003 -6.944,1.149 -0.913,-0.758 -0.729,0.824 -3.546,-1.492 -27.458,4.7 -0.232,4.626 -7.5,5.571 -0.361,4.514 -2.189,-0.473 -5.213,1.958 0.601,5.169 4.135,1.438 -2.098,0.172 -7.916,-3.102 -2.765,-2.76 -2.171,-0.36 1.612,-0.498 -3.157,-2.102 1.173,-0.903 -1.927,-0.495 1.877,-0.875 -2.817,-0.283 1.037,-0.832 2.168,0.832 -0.449,-1.206 2.128,0.073 -1.235,-3.331 1.79,-0.292 -0.904,-0.852 -5.867,0.958 -2.132,-1.617 1.752,-0.04 -1.937,-0.716 0.934,-0.48 -5.94,-2.674 6.039,0.229 -1.175,-1.349 4.525,1.264 -1.807,-2.573 6.531,1.181 3.955,-1.616 -10.512,-2.025 -0.744,-1.818 2.999,-0.549 -3.506,-0.206 -11.246,-6.897 -2.036,0.84 -7.245,-7.236 -2.038,-0.968 0.085,1.047 -3.365,-0.509 -4.449,-5.483 0.566,-2.253 4.902,0.318 3.621,2.154 -1.14,-1.35 8.408,-0.049 -3.79,-3.131 2.055,-0.516 -5.195,0.71 -1.545,-2.397 2.113,-1.361 -7.842,-5.12 -1.806,-5.411 -5.542,-7.326 6.383,-4.493 4.27,-5.996 -1.373,-2.202 5.026,0.01 4.032,-4.847 2.273,1.737 3.737,-5.608 1.62,2.282 3.52,-0.393 1.874,-5.485 4.558,1.938 5.655,-2.254 2.089,0.72 9.709,-8.399 5.112,-8.089 7.366,-4.254 1.982,3.085 2.781,-0.276 0.252,-5.426 -4.037,-6.744 -2.531,1.252 0.946,-2.211 -2.176,-2.427 -2.096,0.622 -0.387,-2.776 -2.029,0.51 -4.129,-2.645 -2.17,1.158 -4.531,-5.363 -3.206,-0.832 -0.366,-2.95 1.15,1.623 3.318,-7.639 8.321,-3.023 3.247,-7.07 7.567,-3.428 2.6,-3.838 11.989,-1.116 -0.904,-3.021 7.282,-2.167 -3.561,-1.729 0.335,-1.87 4.333,1.332 19.904,-4.275 4.309,-5.947 0.664,5.176 12.204,-0.237 -1.949,5.125 3.677,1.3 5.483,-3.667 5.33,0.048 1.669,4.218 6.292,-5.316 -2.181,5.712 7.366,3.31 5.378,-2.184 3.276,1.513 4.653,-2.735 3.512,2.407 2.656,7.226 17.701,-3.814 -1.19,3.136 4.801,0.454 0.251,3.656 10.058,-0.022 -3.764,5.302 0.216,3.35 4.456,2.178 2.444,4.394 5.933,-1.563 3.718,7.828 6.251,-0.676 -1.851,2.432 -5.682,2.25 -1.573,3.492 0.898,4.714 -3.457,4.401 -0.404,3.791 2.128,-0.6 -1.271,3.836 5.183,-0.559 3.211,1.601 5.571,-1.604 7.818,14.389 3.63,2.641 2.37,-1.764 4.11,3.975 -2.502,6.223 -4.532,0.941 2.067,1.782 -2.037,1.929 -0.716,-1.129 -2.104,2.26 2.252,1.504 -2.458,1.485 -6.266,8.654 -9.662,4.804 2.974,0.511 -1.245,1.196 4.39,3.136 -1.842,1.477 -3.745,0.242 -0.896,1.726 2.013,1.171 -5.251,2.56 -7.749,6.334 -2.548,7.439 -3.24,2.479 1.872,0.76 -6.59,2.266 -6.915,5.599 -2.644,0.543 -7.475,5.681 2.977,1.816 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon4-8"
+           d="m 870.356,893.079 -8.664,-4.229 2.565,0.918 -1.084,-1.312 -11.291,-0.992 -1.985,-10.84 -3.788,-3.435 1.049,-1.358 -3.848,-7.813 -7.458,-5.508 0.743,-1.678 -4.376,-6.242 -4.658,-13.971 2.34,-8.456 -1.741,-7.9 6.629,-12.293 5.115,-3.67 0.167,-6.84 0.316,1.796 3.078,-3.489 0.112,3.102 1.267,-1.758 1.093,1.066 3.975,-14.054 13.97,-9.06 1.356,-11.231 3.156,-2.798 0.087,-8.284 4.802,-4.588 4.408,1.078 1.205,-8.563 5.896,-11.803 2.433,1.393 0.35,5.489 2.967,3.035 -2.326,0.244 3.117,6.8 -1.167,6.57 6.287,14.313 5.886,-0.431 3.291,-3.5 13.88,-5.19 7.545,-5.174 -3.759,-7.16 1.001,-2.046 -3.272,-0.311 0.038,-2.592 -3.038,-2.439 2.502,-2.44 3.21,3.48 -0.13,-2.354 2.323,0.876 -1.523,-1.442 4.117,2.085 2.817,-1.729 3.524,1.426 1.454,-2.236 2.403,0.911 9.23,-3.289 1.185,1.174 -5.714,1.099 -0.321,2.84 7.667,1.391 1.079,-1.193 2.73,2.242 -0.955,1.33 2.347,-1.19 -0.988,1.641 2.252,-0.076 0.032,3.841 2.903,1.018 2.408,4.909 -3.785,1.581 2.143,3.025 1.932,-1.681 0.826,2.431 0.307,-2.056 3.131,-0.37 1.983,1.945 -1.136,2.23 1.509,-1.528 0.573,1.903 -0.991,-4.583 4.867,-3.588 3.264,-0.6 1.343,2.98 0.553,-1.673 1.649,2.015 1.388,-1.603 0.244,4.227 1.912,-2.164 2.526,3.282 -2.275,1.991 3.865,0.577 -2.567,1.93 3.405,-1.241 1.604,2.611 -0.911,1.706 -1.361,-1.319 1.794,3.29 -3.326,-0.346 3.172,1.595 4.933,-1.299 0.058,2.771 -2.701,0.417 0.009,2.509 2.14,-0.907 -0.287,3.297 4.241,-6.21 3.717,5.715 -1.573,4.555 6.02,9.472 10.63,4.906 8.475,6.974 3.231,-0.613 10.014,10.682 0.933,4.375 2.382,-3.144 0.296,15.359 -6.34,9.647 2.217,-1.596 0.427,1.716 1.871,-3.656 -2.909,5.731 3.891,-1.47 -12.017,14.531 -2.68,7.854 -5.859,7.354 -0.94,8.114 2.913,2.289 -1.803,4.782 -7.828,2.06 -6.225,-1.23 -7.669,-9.351 -17.438,-3.683 -2.604,-6.139 -7.945,-5.841 -25.876,-8.384 -15.987,4.869 0.479,2.634 -3.391,1.41 -4.512,8.465 2.041,-0.04 -4.338,2.327 0.236,-2.874 -9.08,-9.641 0.207,-3.275 -1.281,6.607 2.595,3.631 -0.131,4.67 2.189,-0.011 0.746,2.4 -4.514,-1.156 -1.543,-6.013 -2.454,4.158 2.263,4.913 -3.93,-0.632 -3.128,2.576 -1.019,1.992 0.547,-0.803 -0.649,6.258 -4.063,5.192 -14.108,5.371 -6.837,-5.883 -0.801,1.913 2.242,0.873 -3.99,-0.236 0.666,1.82 -4.107,3.087 0.089,-1.866"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon7-9"
+           d="m 840.162,728.83 1.668,-1.605 -1.826,-0.794 4.581,-1.181 -0.159,-2.63 3.872,0.06 2.691,-5.58 5.658,-3.601 1.291,-3.841 -5.46,0.037 1.342,-2.868 11.219,-4.042 -0.315,-3.133 7.734,-5.61 40.418,-11.939 4.741,1.718 -0.354,1.52 4.749,0.674 3.79,4.552 3.996,1.449 2.923,-4.192 1.035,1.937 1.737,-2.375 1.189,-7.72 9.511,-1.084 7.212,2.978 1.748,3.062 -6.239,-0.397 -2.107,3.694 -9.881,-1.705 1.639,3.211 2.723,-1.368 2.984,2.174 4.7,0.25 -5.403,2.116 -0.395,3.832 -3.329,-1.345 -2.141,-4.844 1.128,2.842 -2.145,1.78 -5.846,-0.11 1.9,1.085 -3.534,1.499 -17.757,3.925 0.374,1.803 -1.901,-0.362 -0.185,3.373 -3.198,2.476 2.287,0.664 -4.246,0.904 3.469,0.417 -2.843,1.853 1.107,3.525 -6.539,-1.347 -6.566,6.441 -6.595,-0.695 -2.52,1.42 -4.63,-2.866 7.168,-3.253 -8.954,0.587 1.812,-1.647 -3.242,0.465 1.729,-2.977 -5.222,2.238 0.779,-2.011 -0.972,1.383 -1.322,-1.417 -0.633,1.964 -7.373,2.081 -9.555,11.298 -11.952,2.463 -2.643,2.195 -4.085,-2.04 5.129,-1.362 0.034,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon9-7"
+           d="m 1047.553,715.374 -6.958,-6.394 1.03,-1.018 -1.203,0.14 -1.529,-4.151 2.471,-1.2 -2.959,-4.268 -1.106,0.583 -4.019,-3.415 0.873,-3.869 -3.258,-4.09 0.822,-1.322 -2.683,0.781 -3.622,-1.756 6.515,-2.36 0.591,-1.324 -2.048,-1.094 5.939,-4.139 -4.255,-1.364 2.222,-1.664 -6.759,-2.584 2.32,-1.705 -6.547,-3.684 5.068,-0.73 2.345,1.282 -0.468,-1.79 2.567,1.358 -1.141,-2.492 3.129,-1.587 2.014,2.449 0.237,-1.943 5.297,7.571 2.772,1.529 -1.267,0.399 1.353,1.783 7.792,3.683 5.373,7.987 8.714,4.998 1.546,6.608 6.77,0.94 1.282,-1.268 3.938,5.703 0.017,3.884 -1.945,0.713 0.893,2.802 -2.534,0.099 1.826,0.319 -2.097,0.75 1.085,1.842 -2.754,-1.888 -1.809,8.319 -7.672,-3.536 -1.202,3.357 -5.954,-5.104 -3.257,-0.015 -0.163,1.499 -4.896,-2.092 -0.491,3.898 -2.198,-1.418 -0.01,-0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon14-3"
+           d="m 920.309,564.506 -4.666,-1.138 1.92,-0.542 -1.133,-0.684 -0.822,0.503 -0.509,-0.405 -1.932,0.23 1.835,0.382 -6.1,-0.19 -2.63,-0.901 -0.465,0.843 -1.672,-1.058 -2.54,0.161 -0.513,-0.82 -1.715,0.154 1.183,1.046 -4.841,-1.21 1.534,-0.88 -2.036,-0.993 0.381,-1.584 -2.908,-0.053 -2.432,-1.444 3.049,-1.959 2.878,-0.026 -1.4,0.529 3.666,-0.397 2.204,0.618 0.741,0.71 -1.716,-0.077 -0.16,0.344 3.25,1.807 10.291,2.025 2.24,-0.367 -2.436,-0.661 2.881,0.297 3.747,2.568 14.737,0.981 11.679,3.115 0.012,0.625 -6.149,-0.453 -1.563,-1.038 -0.643,0.449 -8.423,-1.722 -5.748,-0.313 1.645,1.477 -3.403,0.587 -1.308,-0.529 -0.01,-0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon17-6"
+           d="m 1022.229,713.473 0.1,3.056 -5.889,-1.261 2.043,-12.74 -3.236,-2.438 -1.962,0.016 1.003,4.395 -4.139,1.541 0.273,3.587 -2.7,0.076 -0.541,-2.143 -4.484,-1.307 4.093,-3.202 -1.609,-2.422 7.037,-4.99 -2.195,0.039 -10.389,-7.727 10.674,2.309 3.067,3.656 2.41,0.449 3.568,-2.891 -1.428,-5.252 -23.296,-4.692 -5.104,-6.819 7.222,5.151 17.699,1.23 1.811,3.16 1.811,-0.621 1.38,1.542 1.171,4.097 1.333,-0.112 -1.547,3.649 0.835,-0.83 2.254,3.042 -0.18,3.446 3.375,5.088 -1.111,3.614 -3.294,-0.873 -0.05,7.179 v -0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon18-1"
+           d="m 1104.841,743.663 -3.093,1.753 0.406,-1.989 -3.235,0.01 -0.491,-2.082 -2.357,1.309 -1.104,-13.985 2.503,-3 3.884,1.209 0.624,1.822 -0.753,-2.854 2,0.455 0.647,-4.373 5.397,1.054 -2.209,-5.685 1.964,-0.315 3.154,3.034 -2.069,-2.078 0.947,-0.75 2.408,0.773 6.394,-3.56 0.61,2.536 5.311,-3.271 7.115,0.053 -0.709,-1.887 3.262,-1.582 9.886,4.701 -0.988,3.213 -5.55,0.707 -3.656,4.067 -4.689,-0.237 -1.46,5.963 -5.562,2.184 -6.276,8.137 -12.307,4.666 v 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon19-2"
+           d="m 1214.737,1033.074 2.082,-9.48 15.724,-37.886 1.769,-4.286 0.681,-3.141 2.208,-5.021 0.176,-1.513 -0.929,1.528 0.898,-3.623 3.623,-8.872 0.957,-0.538 0.456,-1.911 -0.688,4.343 -1.266,3.904 -0.712,4.072 0.249,0.408 -0.955,2.456 -0.037,0.993 -1.365,4.813 0.648,-1.781 -0.914,3.846 -0.425,0.693 -0.32,1.812 0.681,-2.066 -0.663,3.213 -0.796,2.051 0.367,-0.07 -1.649,8.685 -2.602,7.599 -4.54,8.67 -3.428,9.212 -2.459,5.196 -6.022,8.149 -0.75,-1.449 10e-4,-0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon20-9"
+           d="m 748.734,936.726 1.885,1.101 -1.608,2.828 -3.56,-0.792 -8.843,-9.553 -3.808,1.3 -5.415,-6.912 1.816,-1.938 4.336,1.262 3.491,-4.104 -0.369,-7.622 1.243,4.304 2.892,-3.713 -1.918,-2.541 1.146,-4.008 -1.369,-3.732 1.276,0.568 1.832,-4.483 1.127,1.042 -0.35,-3.774 1.588,-0.584 -1.86,13.686 -0.234,-2.477 -1.932,2.481 1.054,2.12 0.787,-1.644 -0.123,3.982 -1.756,0.848 1.576,-0.701 -0.167,4.984 3.706,5.125 4.289,1.158 -3.609,5.987 2.859,5.79 0.018,0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon23-3"
+           d="m 994.018,629.089 -0.299,1.52 -0.828,-2.08 2.458,0.468 1.108,-1.622 -2.592,-1.029 1.389,-0.534 2.561,0.006 0.967,1.591 1.649,-1.945 2.995,0.882 0.271,1.285 2.988,-1.151 1.13,-2.998 -6.895,-6.636 1.31,-2.63 -1.354,-2.173 9.224,1.462 2.544,8.254 2.856,-0.1 0.98,1.667 -1.185,3.723 -1.999,0.856 -0.646,-1.558 -2.166,0.128 2.3,3.42 -3.636,-0.043 -2.782,-1.917 -4.429,1.965 0.011,-2.865 -4.058,2.636 -3.871,-0.583 -10e-4,0.001"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon24-1"
+           d="m 990.114,656.457 -1.595,-1.267 -0.621,2.162 -1.832,-2.051 1.705,-2.897 -1.997,-2.698 -2.738,3.828 0.107,-2.642 -2.713,-1.987 1.008,-4.792 1.81,-0.165 -0.901,-2.928 4.355,-1.34 -0.373,3.352 4.328,0.607 0.442,2.074 2.063,-0.026 4.325,3.394 -1.11,-2.136 2.582,-0.715 6.877,4.465 2.087,3.918 -1.427,0.539 -2.943,-4.17 -4.433,0.851 -1.726,-2.203 -3.241,1.207 1.385,4.382 -5.419,1.235 -0.005,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon28-9"
+           d="m 778.997,958.978 -3.606,-1.151 -6.262,-9.797 -3.56,0.742 1.194,-2.968 -1.214,2.968 -3.304,1.063 1.093,-1.884 -1.633,-2.706 -8.794,-5.45 -1.352,-2.912 1.714,-0.309 -2.195,-0.935 5.034,0.069 0.625,-4.702 -1.544,-0.225 3.991,0.494 10.155,10.752 7.692,2.826 3.358,-0.938 7.633,4.719 -0.102,2.113 1.073,-1.331 2.27,5.017 -3.754,0.966 -3.965,4.673 -4.537,-1.086 -0.01,-0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon39-4"
+           d="m 885.214,553.677 -3.065,-0.614 -7.933,0.107 2.581,-0.125 -0.107,-0.641 2.323,0.122 4.616,-0.333 8.183,-1.036 1.891,1.267 4.771,-0.056 -0.811,0.254 3.129,0.282 -0.718,0.89 -5.48,-0.181 4.088,-0.414 -0.827,-0.27 -2.389,0.25 -2.969,-0.234 -7.283,0.732 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon42-7"
+           d="m 809.728,1234.884 4.308,1.66 -10.268,-2.616 -6.15,-1.147 -4.824,-1.927 1.452,0.046 3.652,1.294 -0.826,-0.847 4.447,1.236 -0.612,-0.446 -1.239,-0.094 -0.367,-0.365 -4.737,-1.331 3.616,0.932 -1.782,-0.731 -0.968,-0.068 -2.684,-1.36 16.977,5.766 h 0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon45-8"
+           d="m 1051.708,740.11 -3.291,-0.162 1.208,-4.696 6.98,1.986 3.6,-3.513 8.261,0.646 3.107,3.892 7.757,2.342 3.482,-1.744 11.684,2.963 0.982,3.6 2.85,2.624 -6.602,-1.764 0.346,2.34 -7.487,-1.246 -5.196,-2.742 -9.896,-0.588 -17.775,-3.928 -0.01,-0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon49-4"
+           d="m 891.51,550.961 -2.024,-0.24 -3.664,0.183 -0.299,0.217 -0.755,-0.11 4.852,-0.601 -1.565,-0.169 -4.166,0.155 -3.024,0.212 34.6,-0.266 13.385,0.849 -1.274,-0.103 -2.643,-0.199 -3.268,-0.218 -6.149,-0.328 -4.401,-0.167 -19.599,0.784 -0.006,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon52-5"
+           d="m 948.644,571.622 -3.695,-1.087 -4.503,-3.319 5.195,-1.079 7.347,1.682 -1.977,0.616 1.538,-0.263 -0.003,0.936 -3.163,-0.546 0.92,-0.703 -1.809,-0.492 -0.67,1.099 3.5,2.648 -2.341,0.239 -1.365,-1.188 1.026,1.457"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon58-0"
+           d="m 873.391,921.229 -3.689,2.163 -1.912,-5.433 -3.309,3.364 -1.639,-7.698 -0.548,1.567 0.459,-8.796 6.975,2.425 8.594,-4.169 -0.027,4.609 -3.333,5.917 1.68,-1.089 -0.231,2.63 -3.023,4.509 h 0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon61-3"
+           d="m 833.267,708.441 -6.424,-2.203 0.971,-2.109 -2.783,-2.942 1.387,-1.205 4.055,-0.16 -1.11,3.414 4.777,2.503 4.806,-0.421 -0.041,-2.613 1.374,2.475 9.333,-0.727 -7.668,4.452 -8.675,-0.446 -0.002,-0.018"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon69-6"
+           d="m 972.768,681.361 0.452,-3.51 -5.95,0.425 4.364,-2.153 -3.067,-1.691 -0.131,-2.365 6.535,3.916 -2.318,-2.131 0.359,-4.123 3.353,5.865 -1.549,5.674 -4.707,2.622 2.657,-2.519 0.002,-0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon73-1"
+           d="m 935.786,566.73 -3.05,-1.228 -3.042,0.327 -3.095,-1.208 0.684,-0.636 3.436,-0.013 4.018,1.077 0.866,-0.32 4.997,1.772 -2.1,-0.386 -0.75,1.17 -1.963,-0.547 -0.001,-0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon77-0"
+           d="m 1200.664,759.246 -3.429,-4.453 -2.263,-5.505 0.639,-4.655 2.414,-1.952 0.981,1.34 -1.252,-0.496 0.948,0.676 2.006,7.811 0.219,-0.553 -0.256,7.784 -0.01,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon79-6"
+           d="m 1113.967,1057.18 0.715,-1.696 -2.278,-1.297 2.226,0.175 -1.387,-1.773 1.35,-1.574 0.779,3.411 1.017,-1.754 0.115,1.969 2.139,-1.593 -4.675,4.149 v -0.017"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon85-3"
+           d="m 829.933,1242.238 1.416,0.326 -1.655,-0.277 4.292,0.95 -1.119,-0.134 -0.941,-0.288 -3.161,-0.547 0.833,-0.01 -2.156,-0.616 1.702,0.288 0.789,0.305"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon94-2"
+           d="m 972.669,694.622 0.495,2.496 -1.559,-2.713 -1.65,1.72 -8.721,-1.673 -5.707,2.004 3.149,-4.056 7.782,0.029 6.205,2.192 0.006,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon97-0"
+           d="m 799.887,1231.362 2.826,0.61 -0.991,-0.069 1.885,0.687 0.554,-0.071 3.242,0.937 -4.822,-1.065 1.596,0.694 -4.293,-1.723 h 0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon98-6"
+           d="m 1029.539,652.503 -4.591,-5.273 -5.655,-3.625 0.849,-3.245 0.446,2.729 1.327,-0.549 -0.025,1.777 12.451,11.62 -4.798,-3.436 v 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon100-1"
+           d="m 1091.937,726.278 -0.71,-2.402 2.841,0.438 1.352,-3.364 3.537,1.778 1.017,2.58 -3.17,-1.149 -1.051,2.812 -3.815,-0.688 v -0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon108-5"
+           d="m 999.532,641.324 -2.263,-3.51 2.064,-0.401 2.269,4.024 2.811,1.485 -3.427,2.462 -1.798,-1.389 0.35,-2.669 -0.006,-0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon110-5"
+           d="m 1001.248,726.009 0.844,-1.238 2.379,2.987 5.297,1.5 6.299,-0.672 3.383,3.459 -10.598,-1.459 -7.599,-4.577 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon115-4"
+           d="m 771.371,1224.032 1.162,0.612 -4.187,-1.195 1.389,0.232 -2.169,-0.931 2.982,0.968 0.017,0.373 0.803,-0.061 h 0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon117-7"
+           d="m 1071.091,632.522 -2.664,-0.415 -4.695,-3.25 -4.132,-4.37 0.173,-1.028 8.442,3.45 3.77,3.282 -0.881,2.334 -0.013,-0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon118-6"
+           d="m 1035.038,737.895 -12.135,-5.689 7.322,-0.928 1.272,1.147 -3.419,1.313 6.571,0.21 1.946,2.064 -1.558,1.879 10e-4,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon121-5"
+           d="m 826.406,1241.457 1.824,0.64 -5.382,-1.233 2.944,0.558 -2.335,-0.531 1.8,0.397 -2.512,-0.74 3.633,0.903 0.028,0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon137-6"
+           d="m 992.391,636.137 -3.332,3.253 0.232,-1.406 -1.715,-0.058 1.346,-3.919 3.798,0.042 -0.325,2.085 -0.004,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon143-9"
+           d="m 788.198,1227.821 1.796,1.039 -3.828,-1.173 -1.081,-0.762 2.633,0.752 0.875,0.542 -0.407,-0.402 h 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon147-3"
+           d="m 988.781,634.341 -4.267,0.371 1.066,-4.258 1.994,-1.105 4.98,0.878 -4.115,2.37 0.342,1.744"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon151-7"
+           d="m 785.749,1227.705 2.388,0.704 -1.178,-0.217 2.234,1.29 -3.61,-1.436 0.181,-0.338 h -0.015"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon152-4"
+           d="m 1006.384,640.996 -6.722,-4.154 -0.293,-1.675 1.692,1.006 5.433,-0.694 -0.104,5.521 -0.01,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon153-5"
+           d="m 1003.215,709.3 0.611,3.686 -3.253,-2.782 1.773,-0.215 -0.784,-4.189 1.646,3.493 0.01,0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon154-2"
+           d="m 1017.87,738.622 -2.658,0.82 -2.017,-1.998 5.277,-2.799 5.542,2.611 -6.137,1.362 -0.01,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon156-5"
+           d="m 994.925,735.047 -18.813,-12.994 12.725,3.298 8.207,6.643 1.002,4.077 -3.103,-1.021 -0.018,-0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon158-4"
+           d="m 1012.377,632.733 -1.646,2.373 -1.62,-0.497 -1.272,-3.327 6.633,0.086 -2.097,1.353 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon159-7"
+           d="m 1006.379,602.496 -8.36,-9.743 2.006,-0.302 8.966,6.234 0.982,1.699 -3.59,2.113 v -10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon160-4"
+           d="m 953.685,734.935 0.991,1.168 2.777,-1.792 -3.659,3.768 -3.341,-2.923 3.227,-0.221 h 0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon163-4"
+           d="m 683.9,809.026 7.549,-0.011 -6.57,3.152 -0.306,-1.596 2.297,0.183 -2.988,-1.718 0.018,-0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon168-3"
+           d="m 934.578,705.397 0.627,4.828 -3.287,-3.736 0.807,-4.121 2.517,1.605 -0.663,1.416 v 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon170-0"
+           d="m 912.083,716.708 -5.768,-1.877 -0.899,-2.472 5.68,-0.125 3.311,4.504 -2.318,-0.034 -0.006,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon178-7"
+           d="m 1136.905,729.777 -2.096,0.584 -0.245,-2.124 2.497,-0.855 1.3,1.365 -1.454,1.015 v 0.015"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon179-8"
+           d="m 1003.634,709.381 -0.117,-1.82 2.107,0.919 0.435,3.364 -1.86,-0.153 -0.564,-2.301 v -0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon182-6"
+           d="m 995.121,642.04 -3.336,-1.114 0.043,-1.19 2.306,-0.018 2.188,1.791 -1.193,0.527 -0.008,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon190-8"
+           d="m 809.945,712.987 -2.919,3.729 -2.533,0.059 7.033,-8.135 -1.576,4.343 -0.005,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon196-8"
+           d="m 1046.413,736.298 2.597,0.59 -3.446,2.695 -3.141,-3.282 3.985,-0.005 0.01,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon198-4"
+           d="m 781.933,735.365 1.697,-1.342 0.662,1.303 -6.915,3.43 4.532,-3.385 0.024,-0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon201-3"
+           d="m 997.225,640.884 -2.439,-1.94 -0.538,-3.565 4.969,8.165 -1.991,-2.653 v -0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon202-1"
+           d="m 994.435,633.489 4.094,-2.215 0.696,2.713 -2.271,-1.582 -2.497,1.073 -0.022,0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon205-4"
+           d="m 748.664,775.076 -0.425,3.885 -2.622,0.107 2.708,-5.942 0.34,1.944 -10e-4,0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon207-9"
+           d="m 1085.201,724.732 -1.338,-2.963 3.192,0.308 0.215,3.353 -2.07,-0.682 10e-4,-0.016"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon213-2"
+           d="m 692.116,815.749 1.32,-4.801 5.049,1.354 -2.631,3.21 -3.733,0.26 -0.005,-0.023"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon219-0"
+           d="m 984.542,697.453 -4.093,2.084 -3.375,-1.745 2.764,-2.188 4.694,1.848 0.01,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon220-6"
+           d="m 821.468,700.511 13.046,-9.321 -9.185,6.534 -3.053,6.432 -0.833,-3.641 0.025,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon226-8"
+           d="m 921.247,747.002 0.507,1.375 -3.707,0.179 1.378,-3.545 1.817,1.987 0.005,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon229-9"
+           d="m 853.35,1234.181 1.907,0.829 -2.411,0.111 -1.205,-0.684 1.684,-0.252 h 0.025"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon231-2"
+           d="m 875.203,552.705 0.362,0.197 -4.189,-0.208 1.985,-0.171 1.846,0.182 h -0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon240-6"
+           d="m 1103.472,712.313 -0.723,0.555 v -1.951 l 1.842,1.483 -1.123,-0.089 v 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon255-6"
+           d="m 745.342,781.851 1.287,0.084 -1.069,2.914 -1.8,0.703 1.583,-3.697 -10e-4,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon258-4"
+           d="m 612.105,704.15 -0.939,1.147 1.689,-2.571 0.526,-0.456 -1.263,1.865 -0.013,0.015"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon260-9"
+           d="m 1111.847,716.288 1.258,-0.046 0.392,1.489 -3.006,-0.67 1.356,-0.771 v -0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon262-5"
+           d="m 977.045,682.786 -1.111,1.531 -2.577,-0.549 2.009,-1.966 1.68,0.93 v 0.054"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon264-0"
+           d="m 972.748,687.057 2.21,-0.542 1.487,1.625 -4.6,-0.335 0.897,-0.748 h 0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon266-4"
+           d="m 989.623,723.983 -0.463,-1.183 3.294,0.436 1.014,1.753 -3.815,-1.001 -0.03,-0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon272-8"
+           d="m 1083.176,690.24 0.642,-0.792 1.382,1.53 -0.916,1.277 -1.14,-2.026 0.032,0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon274-7"
+           d="m 1040.702,737.634 -3.231,-0.103 -0.602,-3.066 2.546,0.181 1.287,2.988"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon281-1"
+           d="m 812.739,1180.886 -2.258,0.396 -3.779,-1.36 3.404,-0.475 2.633,1.439"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon288-7"
+           d="m 924.414,681.044 -2.327,-0.383 6.212,-1.916 -3.874,2.298 h -0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon290-2"
+           d="m 828.903,817.191 -0.253,1.827 -1.618,-5.938 1.866,4.106 0.005,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon292-7"
+           d="m 794.443,1230.412 2.672,0.784 -2.468,-0.31 -0.21,-0.477 h 0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon298-2"
+           d="m 984.955,721.333 -6.028,-2.3 5.157,0.351 0.873,1.953 -0.002,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon299-2"
+           d="m 605.727,712.977 2.284,-3.312 -1.453,2.367 -0.832,0.947 10e-4,-0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon301-6"
+           d="m 862.744,902.328 -1.492,0.774 1.567,-3.157 -0.071,2.383 h -0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon302-1"
+           d="m 857.644,553.313 -2.064,0.086 4.442,-0.246 -2.374,0.159 -0.004,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon303-0"
+           d="m 589.357,787.293 0.524,-0.089 -1.134,2.148 0.609,-2.056 10e-4,-0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon304-6"
+           d="m 857.377,687.168 -2.647,-0.65 5.639,0.2 -2.981,0.45 h -0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon306-1"
+           d="m 959.431,737.838 -3.685,-0.534 1.881,-2.158 1.804,2.678 v 0.014"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon307-5"
+           d="m 1129.849,735.077 1.56,1.931 -3.008,1.053 1.447,-2.975 10e-4,-0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon308-9"
+           d="m 1116.459,714.028 1.695,0.647 -0.295,0.734 -1.408,-1.384 0.01,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon311-4"
+           d="m 798.513,720.558 -3.263,1.146 6.351,-5.25 -3.078,4.094 -0.01,0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon312-9"
+           d="m 1151.307,694.824 0.053,-0.775 0.65,3.051 -0.692,-2.269 -0.011,-0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon314-0"
+           d="m 771.209,745.325 -2.189,0.779 6.045,-4.982 -3.854,4.2 -0.002,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon315-9"
+           d="m 958.978,687.773 -0.317,-1.65 3.809,1.433 -3.502,0.225 0.01,-0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon318-1"
+           d="m 856.344,1236.894 -0.625,-0.583 3.556,0.846 -2.868,-0.254 -0.063,-0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon319-7"
+           d="m 924.448,684.193 -5.526,-0.367 9.1,-0.505 -3.567,0.876 -0.007,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon321-7"
+           d="m 914.816,875.955 -5.551,-1.461 7.641,-0.093 -2.086,1.558 -0.004,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon322-1"
+           d="m 958.118,578.458 -1.219,0.179 -1.873,-1.16 3.091,0.978 0.001,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon323-1"
+           d="m 1151.047,692.619 -0.512,0.607 -0.745,-2.485 1.253,1.865 v 0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon324-5"
+           d="m 1058.971,734.14 -4.129,-0.025 -3.231,-2.461 7.35,2.472 0.01,0.014"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon327-9"
+           d="m 796.379,724.725 1.157,1.418 -3.34,2.341 2.176,-3.765 0.007,0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon328-7"
+           d="m 776.229,735.84 -2.055,2.478 4.227,-7.879 -2.168,5.396 -0.004,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon330-7"
+           d="m 794.816,1230.264 -2.784,-0.735 0.533,-0.068 2.261,0.806 h -0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon331-6"
+           d="m 984.641,690.208 3.968,0.955 -6.061,-1.191 2.083,0.235 0.01,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon332-7"
+           d="m 787.179,727.033 -5.013,3.756 8.197,-7.333 -3.183,3.576 h -10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon336-3"
+           d="m 602.02,720.179 -1.469,1.275 3.99,-6.381 -2.516,5.096 -0.005,0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon337-6"
+           d="m 1122.668,740.865 1.218,-0.353 -1.407,1.972 0.189,-1.614 v -0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon339-5"
+           d="m 774.486,1224.709 1.401,0.558 -1.79,-0.513 0.377,-0.049 h 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon341-6"
+           d="m 771.224,1223.9 -1.419,-0.601 1.291,0.302 0.134,0.301 h -0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon342-3"
+           d="m 1142.846,725.319 1.351,0.9 -3.458,-0.342 2.104,-0.557 v -0.001"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon343-9"
+           d="m 767.189,1222.976 1.947,0.832 -2.177,-0.729 0.236,-0.101 h -0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon344-4"
+           d="m 788.188,961.288 -0.131,-2.752 2.467,3.017 -2.333,-0.266 -0.003,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon346-8"
+           d="m 1002.304,692.046 -3.259,-1.762 3.813,0.271 -0.549,1.492 v -10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon352-1"
+           d="m 869.578,552.822 -7.457,0.138 4.082,-0.347 3.38,0.209 h -0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon354-2"
+           d="m 833.958,729.109 1.667,-1.725 -2.652,2.873 0.985,-1.144 v -0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon355-9"
+           d="m 782.541,1226.397 3.452,1.222 -6.669,-2.271 3.22,1.05 h -0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon357-3"
+           d="m 954.751,679.411 -1.787,-1.022 6.561,0.906 -4.73,0.123 -0.044,-0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon358-9"
+           d="m 914.073,1248.455 -1.991,0.41 -4.984,0.199 6.971,-0.609 h 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon361-0"
+           d="m 727.219,968.545 -2.252,-0.563 2.001,-1.083 0.249,1.641 0.002,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon364-8"
+           d="m 965.131,583.405 -1.631,-1.088 3.683,2.412 -2.03,-1.312 -0.022,-0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon365-8"
+           d="m 753.032,816.52 13.274,-17.503 -3.774,8.668 -9.483,8.833 -0.017,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon378-5"
+           d="m 1019.207,665.009 1.053,1.026 -2.513,-1.56 1.455,0.536 v -0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon381-0"
+           d="m 1226.046,963.96 -0.978,2.848 0.184,-2.387 0.795,-0.468 -10e-4,0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon386-9"
+           d="m 851.523,704.216 1.509,-0.397 -1.475,1.799 -0.039,-1.402 h 0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon391-6"
+           d="m 1098.418,677.062 1.447,1.239 -2.584,-1.688 1.133,0.448 v 10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon393-3"
+           d="m 1100.748,717.115 2.533,-0.255 0.311,1.251 -2.854,-0.991 0.01,-0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon394-8"
+           d="m 1240.388,978.724 -0.084,-0.287 0.372,-1.197 -0.286,1.475 v 0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon400-5"
+           d="m 739.464,800.686 -1.583,0.904 0.853,-2.229 0.741,1.312 -0.011,0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon401-6"
+           d="m 984.606,692.479 0.555,-1.326 -0.903,2.353 0.326,-1.011 0.022,-0.016"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon408-1"
+           d="m 841.395,1230.995 -1.695,0.226 -1.269,-1.193 2.93,0.956 0.034,0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon411-1"
+           d="m 1114.095,717.409 -1.017,-1.616 1.313,-0.188 -0.274,1.793 -0.022,0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon420-5"
+           d="m 971.134,670.506 -1.814,-0.749 -0.023,-2.392 1.838,3.137 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon432-9"
+           d="m 872.593,619.563 -0.667,0.763 -1.317,-1.206 1.985,0.438 -0.001,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon436-8"
+           d="m 606.74,749.648 1.135,-1.68 -1.972,3.332 0.832,-1.645 0.005,-0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon444-4"
+           d="m 646.987,819.261 -1.527,1.231 2.399,-2.655 -0.869,1.415 -0.003,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon446-8"
+           d="m 849.348,1237.1 0.675,0.383 -3.127,-1.129 2.128,0.693 0.324,0.053"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon448-1"
+           d="m 947.16,572.368 -0.444,-0.633 1.206,1.116 -0.761,-0.478 -10e-4,-0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon455-0"
+           d="m 1225.371,976.813 -1.029,-0.478 1.003,-1.402 0.028,1.869 v 0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon461-3"
+           d="m 797.713,727.419 -1.218,1.048 0.077,-1.633 1.14,0.577 10e-4,0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon462-0"
+           d="m 609.015,708.267 -0.583,0.639 1.45,-1.755 -0.863,1.114 -0.004,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon466-4"
+           d="m 1007.412,656.033 0.322,1.462 -2.184,-1.318 1.856,-0.146 0.01,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon470-4"
+           d="m 1016.493,717.227 -0.321,2.439 0.111,-3.696 0.212,1.215 v 0.042"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon477-4"
+           d="m 835.328,1222.713 1.699,0.979 -1.474,1.478 -0.361,-2.459 h 0.136"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon481-4"
+           d="m 842.798,1232.258 -1.572,-0.244 0.464,-0.712 1.139,0.957 -0.031,-10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon489-7"
+           d="m 998.932,629.907 1.152,-0.2 -2.429,1.063 1.276,-0.856 v -0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon500-6"
+           d="m 954.742,683.883 -0.199,-1.79 2.377,0.48 -2.178,1.313 v -0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon503-3"
+           d="m 1240.287,980.537 v -0.372 l 0.559,-1.878 -0.555,2.242 v 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon515-1"
+           d="m 1150.063,712.329 1.077,0.008 -0.379,1.399 -0.697,-1.404 -10e-4,-0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon518-7"
+           d="m 995.454,724.87 -0.884,0.927 -0.94,-1.997 1.815,1.068 0.009,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon531-5"
+           d="m 994.111,692.821 -5.459,-1.984 4.668,0.031 0.791,1.953"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon554-9"
+           d="m 925.131,563.258 1.452,0.771 -1.477,-0.773 0.025,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon556-6"
+           d="m 763.682,1221.771 1.354,0.592 -1.357,-0.593 0.003,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon559-2"
+           d="m 774.355,736.763 -1.019,2.629 1.018,-2.638 10e-4,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon561-1"
+           d="m 1007.722,711.015 0.211,1.759 -0.215,-1.76 v 10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon563-7"
+           d="m 950.248,569.069 -1.385,-0.457 1.384,0.451 0.001,0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon565-8"
+           d="m 1128.827,682.523 -0.892,-1.778 0.887,1.752 0.01,0.026"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon568-5"
+           d="m 780.499,1226.217 -1.223,-0.383 1.215,0.38 h 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon570-7"
+           d="m 1004.637,625.124 0.729,-1.146 -0.726,1.146 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon572-4"
+           d="m 736.782,910.205 -0.613,1.24 0.61,-1.242 0.003,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon573-1"
+           d="m 801.475,721.958 -1.118,1.73 1.117,-1.739 10e-4,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon574-8"
+           d="m 921.093,733.139 -0.007,-0.007 -1.67,-2.371 1.677,2.378"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon576-5"
+           d="m 1104.528,719.741 -1.771,-0.913 1.771,0.901 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon577-9"
+           d="m 1240.129,978.027 -0.281,0.596 0.282,-0.6 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon579-7"
+           d="m 1124.733,740.31 -1.045,-0.019 1.049,0.017 v 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon581-5"
+           d="m 1130.588,696.381 0.044,0.953 -0.047,-0.978 v 0.025"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon582-3"
+           d="m 761.622,1221.41 -0.324,-0.106 0.318,0.104 h 0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon584-8"
+           d="m 839.281,690.402 0.08,-0.005 -2.789,0.984 2.709,-0.979"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon587-8"
+           d="m 1105.866,713.422 -0.849,-1.232 0.851,1.231 v 10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon588-3"
+           d="m 618.314,695.994 -1.025,0.958 1.03,-0.968 -0.005,0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon590-1"
+           d="m 760.941,1221.189 -1.708,-0.745 1.698,0.741 h 0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon591-8"
+           d="m 764.755,1221.916 1.551,0.647 -1.553,-0.648 0.002,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon595-9"
+           d="m 796.402,1230.242 h -0.007 l -1.499,-0.535 1.506,0.537"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon597-6"
+           d="m 837.527,725.402 -2.984,1.887 2.983,-1.918 0.001,0.031"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon598-4"
+           d="m 696.413,820.24 -0.023,0.011 -2.377,0.546 2.4,-0.557"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon604-3"
+           d="m 768.41,1223.277 1.056,0.332 -1.031,-0.322 -0.025,-0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon605-3"
+           d="m 742.707,792.644 -2.261,0.645 2.258,-0.663 0.003,0.018"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon607-3"
+           d="m 749.721,809.598 1.443,-2.117 -1.441,2.131 -0.002,-0.014"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon608-8"
+           d="m 1005.756,634.481 -0.861,-2.202 0.866,2.203 v -10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon611-6"
+           d="m 776.534,1224.754 v 0 l -0.695,0.057 0.695,-0.057"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon613-0"
+           d="m 768.691,1223.951 -1.601,-0.72 1.604,0.721 -0.003,-10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon615-4"
+           d="m 933.442,643.225 -1.014,-1.228 1.014,1.224 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon616-8"
+           d="m 988.114,665.552 -1.505,1.012 1.505,-1.019 v 0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon618-8"
+           d="m 585.683,908.99 -0.417,3.119 0.41,-3.121 0.007,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon621-8"
+           d="m 793.043,728.212 -0.063,1.242 0.058,-1.241 0.005,-10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon623-9"
+           d="m 985.275,638.775 0.094,-1.822 -0.089,1.826 -0.005,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon624-7"
+           d="m 972.629,697.253 -2.045,-0.675 2.04,0.67 0.005,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon625-7"
+           d="m 1132.292,731.725 v 0.008 l -0.633,1.482 0.633,-1.49"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon626-6"
+           d="m 1129.622,684.983 -0.736,0.267 0.729,-0.301 0.01,0.034"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon627-4"
+           d="m 777.125,1225.308 2.003,0.647 -2.012,-0.648 0.009,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon628-3"
+           d="m 850.272,553.876 h 0.003 l -0.935,0.062 0.932,-0.062"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon630-0"
+           d="m 979.919,662.835 0.068,-2.381 -0.068,2.385 v -0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon631-3"
+           d="m 1020.531,732.372 -1.08,-0.971 1.08,0.966 v 0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon632-0"
+           d="m 767.324,1223.246 0.95,0.318 -0.952,-0.319 h 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon633-9"
+           d="m 954.184,568.22 -1.222,-0.54 1.22,0.535 0.002,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon635-2"
+           d="m 670.536,847.165 -1.222,1.13 1.217,-1.148 0.005,0.018"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon637-5"
+           d="m 996.129,577.796 -3.313,-0.184 3.311,0.18 0.002,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon639-4"
+           d="m 798.69,724.764 -0.688,-1.156 0.693,1.16 -0.005,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon641-0"
+           d="m 983.442,639.328 -0.437,-1.165 0.443,1.162 -0.006,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon642-5"
+           d="m 880.685,900.453 0.736,-2.604 -0.732,2.609 -0.004,-0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon645-9"
+           d="m 1132.895,734.547 -0.717,-1.74 0.717,1.736 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon649-4"
+           d="m 954.472,566.704 -1.028,-0.44 1.028,0.438 v 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon652-6"
+           d="m 868.621,922.144 -1.378,-2.078 1.378,2.068 v 0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon654-9"
+           d="m 749.283,751.573 0.004,-0.004 1.641,-0.452 -1.645,0.456"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon655-2"
+           d="m 650.449,813.958 -2.441,2.604 2.441,-2.608 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon659-2"
+           d="m 1041.841,837.054 1.813,-2.556 -1.811,2.559 v -0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon660-4"
+           d="m 871.037,553.116 -1.452,0.087 1.452,-0.087 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon663-7"
+           d="m 987.462,592.159 -1.565,-0.738 1.564,0.735 10e-4,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon671-7"
+           d="m 767.824,1223.041 -0.997,-0.336 0.989,0.331 h 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon673-5"
+           d="m 762.166,1221.701 0.026,0.023 -0.034,-0.026 h 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon675-4"
+           d="m 1127.623,680.666 -0.513,0.626 0.508,-0.631 0.01,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon678-8"
+           d="m 978.177,682.727 -1.234,-0.906 1.234,0.901 v 0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon679-1"
+           d="m 1000.005,726.779 -4.092,-2.261 4.093,2.252 -10e-4,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon681-2"
+           d="m 944.821,704.131 -1.01,1.667 1.01,-1.679 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon684-8"
+           d="m 738.996,804.098 -0.941,1.516 0.936,-1.544 0.005,0.028"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon697-9"
+           d="m 1127.051,739.074 -1.621,0.316 1.621,-0.323 v 0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon698-3"
+           d="m 766.581,1222.475 1.256,0.557 -1.252,-0.555 h -0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon700-6"
+           d="m 747.29,814.317 0.69,-1.886 -0.682,1.882 -0.008,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon702-8"
+           d="m 989.727,592.897 -1.525,-0.422 1.523,0.416 0.002,0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon705-0"
+           d="m 742.075,786.91 -1.739,1.481 1.737,-1.5 0.002,0.019"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon706-2"
+           d="m 993.424,580.595 -1.5,-0.352 1.537,0.36 -0.037,-0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon710-1"
+           d="m 1153.966,700.87 -0.401,0.671 0.398,-0.681 v 0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon713-0"
+           d="m 943.393,706.044 -1.82,-3.812 1.82,3.795 v 0.017"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon714-5"
+           d="m 764.487,1222.62 h 0.002 l 1.014,0.402 -1.016,-0.403"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon715-1"
+           d="m 774.677,1224.499 -0.018,-0.01 -0.101,-0.281 0.119,0.288"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon716-1"
+           d="m 958.058,680.588 -1.456,-0.497 1.456,0.493 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon720-0"
+           d="m 954.206,717.756 1.423,1.452 -1.428,-1.457 0.005,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon721-8"
+           d="m 880.791,717.078 -2.738,1.556 2.738,-1.564 v 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon724-5"
+           d="m 1000.498,739.204 -2.041,-2.668 2.046,2.665 v 0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon727-0"
+           d="m 925.452,736.303 -0.993,-1.347 1.006,1.359 -0.013,-0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon734-6"
+           d="m 1045.183,729.816 v 0.004 l -1.504,-0.804 1.504,0.8"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon735-4"
+           d="m 754.022,806.431 -0.007,-0.005 -0.943,-1.572 0.95,1.577"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon740-6"
+           d="m 763.888,1222.407 0.399,0.189 -0.401,-0.189 h 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon742-2"
+           d="m 996.568,630.793 -1.101,0.872 1.101,-0.875 v 0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon744-5"
+           d="m 1234.703,978.84 0.529,-1.818 -0.531,1.825 v -0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon746-8"
+           d="m 956.289,565.513 0.701,0.554 -0.704,-0.555 0.003,0.001"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon748-6"
+           d="m 905.001,761.219 -3.291,-0.652 3.291,0.634 v 0.018"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon749-2"
+           d="m 799.835,1231.455 2.294,0.886 -2.3,-0.885 0.006,-10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon750-8"
+           d="m 740.925,783.354 -0.21,-3.007 0.215,2.994 -0.005,0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon751-4"
+           d="m 822.273,726.191 3.113,-1.002 -3.118,1.007 0.005,-0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon758-7"
+           d="m 1125.231,699.644 -1.252,-0.32 1.249,0.292 v 0.028"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon759-2"
+           d="m 992.014,625.012 0.7,1.838 -0.7,-1.835 v -0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon762-4"
+           d="m 1003.656,640.288 -1.46,-1.204 1.459,1.19 10e-4,0.014"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon772-0"
+           d="m 792.025,655.397 -1.338,0.615 1.339,-0.636 -10e-4,0.021"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon775-6"
+           d="m 1103.358,715.782 -1.111,0.517 1.111,-0.529 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon778-2"
+           d="m 862.918,904.255 h 0.007 l -2.203,0.289 2.196,-0.289"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon781-9"
+           d="m 1008.154,687.915 2.04,1.242 -2.045,-1.243 v 10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon783-9"
+           d="m 643.555,823.722 -1.173,0.414 1.171,-0.418 0.002,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon784-0"
+           d="m 1151.326,694.525 -0.734,-1.212 0.731,1.199 v 0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon785-8"
+           d="m 1035.488,658.401 -0.457,-1.24 0.462,1.242 v -0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon787-1"
+           d="m 803.152,980.313 -1.49,-1.688 1.495,1.688 h -0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon789-3"
+           d="m 1244.535,958.52 0.129,-1.262 -0.128,1.258 -10e-4,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon790-1"
+           d="m 1005.297,630.453 0.614,-1.198 -0.609,1.196 v 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon793-1"
+           d="m 1127.198,677.416 0.094,1.197 -0.096,-1.203 v 0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon794-0"
+           d="m 1140.387,664.024 -0.209,0.368 0.203,-0.379 0.01,0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon799-3"
+           d="m 922.955,734.532 -1.229,-0.791 1.229,0.782 v 0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon801-4"
+           d="m 1035.41,660.941 -1.302,-1.043 1.3,1.015 v 0.028"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon803-0"
+           d="m 1140.315,666.801 -0.704,0.023 0.702,-0.029 v 0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon805-3"
+           d="m 1093.52,1060.711 -1.381,-0.855 1.399,0.838 -0.018,0.017"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon808-9"
+           d="m 1035.379,676.453 -2.39,-0.396 2.389,0.366 10e-4,0.03"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon813-1"
+           d="m 1015.581,637.12 v -0.004 l 2.059,-0.74 -2.054,0.744"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon816-9"
+           d="m 1150.102,690.666 -1.434,-2.849 1.433,2.846 10e-4,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon817-6"
+           d="m 1002.055,705.091 -1.491,-0.971 1.495,0.972 v -10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon820-9"
+           d="m 753.043,934.446 -1.273,-1.134 1.271,1.129 0.002,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon828-3"
+           d="m 781.019,733.326 -1.549,1.076 1.548,-1.09 10e-4,0.014"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon829-3"
+           d="m 908.12,557.729 -1.009,-0.438 1.012,0.434 -0.003,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon831-8"
+           d="m 1017.68,643.013 1.472,0.495 -1.472,-0.493 v -0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon832-0"
+           d="m 833.95,721.216 -0.712,1.662 0.707,-1.661 0.005,-10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon833-5"
+           d="m 964.74,678.915 -1.372,0.82 1.372,-0.828 v 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon835-6"
+           d="m 817.785,1237.578 h 0.005 l -2.181,-0.728 2.176,0.725"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon836-6"
+           d="m 958.419,682.589 -3.218,-1.046 3.21,1.04 0.008,0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon840-4"
+           d="m 779.95,1226.157 1.554,0.445 -1.549,-0.44 -0.005,-0.01"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon841-0"
+           d="m 773.265,1224.543 2.685,0.927 -2.689,-0.928 0.004,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon844-0"
+           d="m 782.626,1226.618 1.464,0.615 -1.46,-0.613 h -0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon845-4"
+           d="m 1001.228,726.359 -1.931,-1.098 1.933,1.072 v 0.026"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon855-6"
+           d="m 1041.739,713.609 -1.189,-4.227 1.19,4.218 -10e-4,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon858-2"
+           d="m 929.959,682.958 -1.516,-0.189 1.516,0.181 v 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon861-6"
+           d="m 740.527,777.784 v 0.005 l 0.032,2.293 -0.032,-2.298"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon862-7"
+           d="m 828.227,830.911 -0.537,-1.841 0.535,1.826 0.002,0.015"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon868-5"
+           d="m 742.203,784.009 -1.515,1.193 1.505,-1.199 0.01,0.006"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon871-6"
+           d="m 1114.066,748.181 -1.426,0.089 1.427,-0.102 -10e-4,0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon874-9"
+           d="m 953.434,717.2 -3.366,-4.776 3.367,4.768 -10e-4,0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon879-8"
+           d="m 908.518,716.382 -2.226,0.013 2.227,-0.026 -10e-4,0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon885-7"
+           d="m 825.688,1241.563 1.606,0.345 -1.608,-0.345 h 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon887-2"
+           d="m 1239.873,981.452 0.024,-0.473 -0.022,0.465 v 0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon889-8"
+           d="m 1133.389,1128.916 0.449,-0.953 -0.445,0.951 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon890-2"
+           d="m 940.712,696.313 -1.862,0.903 1.862,-0.916 v 0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon892-9"
+           d="m 821.808,738.1 -3.421,1.888 3.421,-1.893 v 0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon894-9"
+           d="m 825.43,733.588 -2.097,0.557 2.096,-0.566 10e-4,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon897-6"
+           d="m 559.689,901.656 -0.194,1.296 0.184,-1.348 0.01,0.052"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon900-0"
+           d="m 1006.86,686.759 -0.989,0.61 0.988,-0.629 10e-4,0.019"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon901-2"
+           d="m 1151.376,709.312 -0.253,-1.083 0.258,1.082 -0.01,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon904-7"
+           d="m 833.306,693.309 1.532,-0.062 -1.537,0.066 0.005,-0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon906-6"
+           d="m 1131.804,730.835 -1.507,-0.625 1.507,0.598 v 0.027"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon907-1"
+           d="m 766.008,1222.657 -0.016,-0.01 0.874,0.235 -0.858,-0.228"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon908-3"
+           d="m 741.504,779.101 1.752,0.406 -1.753,-0.403 10e-4,-0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon912-2"
+           d="m 965.267,562.938 -0.588,0.146 0.588,-0.146 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon918-1"
+           d="m 842.219,684.83 -1.473,0.651 1.473,-0.663 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon919-5"
+           d="m 1004.881,626.879 -0.019,0.009 -0.979,0.39 0.998,-0.399"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon921-9"
+           d="m 953.996,566.229 -1.387,-0.718 1.386,0.715 10e-4,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon927-9"
+           d="m 812.622,707.057 -0.559,1.765 0.558,-1.786 10e-4,0.021"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon934-1"
+           d="m 576.247,915.756 0.053,1.839 -0.055,-1.847 0.002,0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon935-4"
+           d="m 1108.757,669.845 0.701,-0.203 -0.706,0.205 0.01,-0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon941-9"
+           d="m 1015.811,630.463 -1.144,0.309 1.143,-0.321 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon943-1"
+           d="m 961.359,718.064 1.276,-0.784 -1.277,0.801 0.001,-0.017"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon944-0"
+           d="m 720.937,675.316 -1.658,0.955 1.659,-0.962 -10e-4,0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon947-7"
+           d="m 1028.882,669.857 -1.515,-0.265 1.515,0.262 v 0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon952-5"
+           d="m 969.978,570.237 -4.024,-0.898 4.021,0.891 0.003,0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon953-8"
+           d="m 1139.057,663.216 -0.133,0.459 0.129,-0.47 v 0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon955-7"
+           d="m 797.028,1230.538 1.179,0.454 -1.19,-0.454 h 0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon958-0"
+           d="m 998.41,644.281 -1.434,-0.093 1.433,0.086 10e-4,0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon962-4"
+           d="m 791.565,1229.063 h 0.01 l -0.7,0.099 0.69,-0.103"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon963-8"
+           d="m 1036.655,804.483 -0.646,-1.301 0.646,1.296 v 0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon967-0"
+           d="m 1003.224,632.809 -1.453,0.088 1.451,-0.109 v 0.021"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon968-4"
+           d="m 962.394,684.321 -1.487,-0.31 1.487,0.294 v 0.016"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon970-2"
+           d="m 791.178,723.573 -1.333,0.722 1.333,-0.726 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon974-9"
+           d="m 1008.086,739.238 -1.718,-1.004 1.718,1 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon977-6"
+           d="m 958.282,569.731 -1.192,-0.48 1.191,0.478 0.001,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon981-1"
+           d="m 619.19,695.014 0.019,0.279 -0.031,-0.268 0.012,-0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon982-0"
+           d="m 827.969,827.063 -0.163,1.845 0.162,-1.854 0.001,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon985-4"
+           d="m 743.924,772.825 -1.111,-0.401 1.11,0.397 10e-4,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon989-2"
+           d="m 1126.981,665.034 -0.184,0.645 0.18,-0.657 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon994-2"
+           d="m 816.992,738.819 -1.639,0.438 1.634,-0.437 0.005,-0.001"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon997-2"
+           d="m 796.625,1230.234 h 0.007 l 2.485,0.848 -2.492,-0.85"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon998-0"
+           d="m 1092.481,670.569 -0.837,0.504 0.834,-0.521 v 0.017"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1001-5"
+           d="m 972.014,720.74 1.433,-0.559 -1.417,0.557 -0.016,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1005-5"
+           d="m 1123.115,702.416 -0.427,0.658 0.426,-0.673 10e-4,0.015"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1012-2"
+           d="m 857.534,702.511 -1.314,0.552 1.319,-0.556 -0.005,0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1013-9"
+           d="m 1032.656,733.399 -1.137,-1.311 1.138,1.293 -10e-4,0.018"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1017-0"
+           d="m 1023.75,602.534 -1.301,-0.763 1.297,0.751 v 0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1029-2"
+           d="m 950.038,712.496 -1.671,0.172 1.672,-0.188 -10e-4,0.016"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1030-8"
+           d="m 1138.031,724.9 -1.018,0.201 1.017,-0.212 10e-4,0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1032-3"
+           d="m 1144.674,662.33 -0.953,-1.459 0.944,1.442 0.01,0.017"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1039-8"
+           d="m 1102.575,674.016 -0.26,-1.64 0.268,1.643 -0.01,-0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1043-0"
+           d="m 1011.24,659.97 v 10e-4 l 2.817,0.878 -2.822,-0.879"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1045-4"
+           d="m 1115.398,715.32 -2.408,0.36 2.41,-0.36 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1046-0"
+           d="m 950.482,573.068 -1.54,-0.172 1.537,0.163 0.003,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1048-9"
+           d="m 709.461,703.377 0.466,-1.302 -0.453,1.294 -0.013,0.008"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1054-1"
+           d="m 880.005,716.851 -1.867,0.381 1.867,-0.394 v 0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1064-9"
+           d="m 771.125,1223.443 1.037,0.593 -1.048,-0.595 h 0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1081-6"
+           d="m 1022.436,667.211 -0.038,1.093 0.036,-1.14 v 0.047"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1083-2"
+           d="m 778.543,1225.564 1.448,0.552 -1.456,-0.553 0.008,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1097-5"
+           d="m 796.377,728.434 -1.275,0.741 1.274,-0.753 10e-4,0.012"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1098-4"
+           d="m 1043.416,831.446 -0.086,1.636 0.078,-1.638 0.01,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1105-4"
+           d="m 1017.135,637.856 0.431,0.993 -0.436,-0.993 v 0"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1108-9"
+           d="m 768.158,1222.793 2.08,0.792 -2.082,-0.792 h 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1109-9"
+           d="m 1201.521,748.463 -0.604,-0.298 0.604,0.291 v 0.007"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1114-3"
+           d="m 1105.665,711.608 0.013,0.006 1.788,1.018 -1.801,-1.024"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1116-6"
+           d="m 944.366,732.174 0.005,0.005 -0.107,1.896 0.102,-1.901"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1147-0"
+           d="m 976.016,686.287 -1.401,-0.151 1.402,0.127 -0.001,0.024"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1149-5"
+           d="m 1090.154,667.508 -1.336,-0.314 1.335,0.312 10e-4,0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1152-0"
+           d="m 910.384,716.857 -1.563,-0.522 1.563,0.509 v 0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1167-2"
+           d="m 1043.446,831.356 0.062,-1.375 -0.061,1.37 -10e-4,0.005"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1171-9"
+           d="m 1240.502,968.457 -0.182,-0.022 0.183,0.019 -10e-4,0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1186-4"
+           d="m 839.463,724.817 -1.431,1.268 1.431,-1.281 v 0.013"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1188-3"
+           d="m 685.235,813.403 -1.43,-1.1 1.432,1.068 -0.002,0.032"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1189-5"
+           d="m 573.376,942.355 0.072,1.385 -0.074,-1.386 0.002,10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1196-1"
+           d="m 1247.323,900.722 -0.182,0.073 0.182,-0.077 v 0.004"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1206-7"
+           d="m 805.159,1233.359 3.894,1.163 -3.896,-1.163 h 0.002"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1209-4"
+           d="m 774.96,1224.532 0.668,0.522 -0.671,-0.524 h 0.003"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1421-3"
+           d="m 1108.448,720.966 -1.622,-0.875 1.622,0.859 v 0.016"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1649-1"
+           d="m 863.529,698.109 0.466,1.127 -0.479,-1.116 0.013,-0.011"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1833-4"
+           d="m 844.965,1235.294 -3.25,-0.729 3.301,0.73 -0.051,-10e-4"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1857-6"
+           d="m 882.033,1243.437 2.708,-0.04 -2.604,0.106 -0.104,-0.066"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1858-9"
+           d="m 836.684,1227.618 0.279,-0.383 -0.263,0.422 -0.016,-0.039"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1862-4"
+           d="m 856.21,1237.044 -1.603,-0.35 1.631,0.348 h -0.028"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1863-2"
+           d="m 807.966,1184.32 1.634,0.452 -1.638,-0.431 0.004,-0.021"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1864-2"
+           d="m 846.257,1062.711 0.25,-1.271 -0.271,1.392 0.021,-0.121"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+        <path
+           id="polygon1865-6"
+           d="m 855.764,1234.773 0.054,0.035 -1.105,-0.468 1.051,0.433"
+           inkscape:connector-curvature="0"
+           style="fill:#2e2e2e;fill-opacity:1" />
+      </g>
+      <g
+         id="layer1-1-4"
+         style="fill:#ffffff;fill-opacity:1">
+        <path
+           id="polygon0-1"
+           d="m 819.353,587.924 9.754,-2.216 4.568,-2.369 5.829,-1.361 -0.81,-1.084 -3.542,-0.135 0.54,-0.895 5.403,-0.798 2.43,0.539 0.972,-1.083 9.278,-2.222 1.374,-1.538 7.689,2.227 6.042,-0.75 6.165,-1.634 8.078,1.012 -2.094,0.781 3.513,0.579 2.289,-0.238 2.849,-1.952 0.096,1.586 -1.13,-0.818 -1.497,1.164 4.954,-0.472 -4.772,0.565 11.07,0.716 -0.778,-0.676 4.011,-0.776 -2.005,0.053 1.688,-0.768 -1.542,-1.157 3.868,0.348 0.589,-1.032 3.425,1.292 4.36,-0.229 1.615,1.347 4.376,-2.42 3.822,3.601 -2.444,0.005 1.683,0.942 -1.959,0.077 0.515,1.406 4.288,0.756 2.287,1.774 4.246,-1.644 4.898,1.334 1.836,1.161 -1.422,0.467 4.677,1.742 4.677,0.003 -1.043,1.935 1.615,-0.338 0.1,1.113 2.406,0.725 1.468,-0.469 -2.048,-0.706 8.498,1.793 2.701,-0.232 -5.111,0.615 -13.943,-0.228 -0.015,1.939 -0.83,-1.234 -1.271,0.534 1.099,3.336 6.325,1.563 -2.532,0.386 3.277,2.032 -3.378,-0.481 1.188,1.812 5.223,0.175 2.574,-1.066 2.383,1.366 0.646,-1.376 0.291,1.008 5.122,1.284 -1.649,0.186 2.995,1.892 1.42,-0.028 -1.473,-0.832 10.582,4.3 2.488,-0.585 -0.146,1.163 3.509,-2.13 7.776,5.939 5.358,-0.959 1.035,-3.318 9.28,-0.919 -0.812,1.536 -4.286,-0.12 2.861,0.731 -7.007,-0.763 1.868,1.883 -0.532,3.432 1.775,0.979 1.504,-0.671 1.434,2.213 2.784,-3.038 0.846,2.742 -7.696,1.695 3.239,-0.313 5.766,2.208 3.21,-1.516 7.993,0.848 -2.492,-2.766 0.164,-2.134 2.694,-0.676 3.255,0.935 -0.051,-1.693 0.378,2.209 -5.585,0.564 2.854,2.469 5.395,0.084 10.251,4.314 0.423,4.17 -3.744,-3.979 -9.596,-3.156 -1.828,1.285 -10.365,-0.694 -2.43,1.113 -7.37,-1.217 -0.266,1.347 1.147,2.412 8.129,1.491 3.597,2.108 8.517,0.691 -0.708,-1.683 2.396,-1.247 5.086,1.804 -3.766,3.082 -0.031,-0.839 -1.698,6.531 1.943,1.169 3.841,-0.634 1.02,1.834 2.188,0.666 -3.405,0.348 3.134,2.936 0.433,2.762 2.369,1.301 v 2.308 l -3.537,-1.482 -1.161,-1.603 0.218,1 3.926,3.203 -1.537,-0.271 3.804,6.402 1.792,-0.135 0.051,1.907 3.829,1.744 0.219,2.53 -3.616,0.386 -1.852,-3.42 -1.819,-0.41 -3.745,3.58 2.505,-0.493 12.89,5.221 -3.654,1.685 2.424,3.595 2.406,2.967 5.538,1.223 -2.575,2.572 0.998,1.324 -1.229,-1.313 -2.512,1.613 2.171,1.737 3.155,-1.301 2.375,2.473 -5.583,2.267 -4.975,-1.667 -2.212,-2.373 -3.346,1.776 -0.368,-1.592 -5.209,0.61 10.02,-8.053 -4.667,-6.004 -6.378,-0.078 -8.257,3.482 -1.274,2.199 1.941,1.855 -2.543,-2.039 -0.91,1.745 -1.832,-0.842 0.789,-1.267 -1.883,0.733 1.539,2.138 -2.421,0.322 0.619,1.678 -3.467,-0.336 1.743,-1.734 -1.195,-1.984 -4.063,1.145 1.62,2.685 -2.383,-2.43 -1.526,0.592 3.118,2.656 0.067,1.049 -3.085,-2.05 3.49,4.575 -3.594,-3.415 -1.682,1.121 4.188,4.599 -3.565,1.128 3.517,1.302 -2.273,0.124 2.312,4.122 -3.111,-2.899 2.118,2.712 -1.891,-1.476 0.087,1.575 2.684,0.72 -2.789,0.771 3.311,3.42 -0.717,2.089 2.205,-1.412 -1.797,2.108 2.932,1.821 -2.771,-1.071 0.027,1.652 1.482,-0.124 -1.187,1.349 2.754,-0.124 -0.658,3.169 2.339,-0.808 -2.068,3.056 1.41,-0.011 1.377,3.708 1.032,-2.05 -1.064,2.917 1.868,0.319 -1.223,0.294 2.158,3.725 0.986,-1.608 -0.737,3.993 1.063,-1.491 -0.079,2.168 1.807,0.38 -0.467,1.43 -1.704,-0.909 1.587,6.052 1.925,-0.897 -0.676,-3.623 2.123,3.418 -1.413,2.121 -1.47,-1.055 -1.166,2.499 2.647,2.261 -2.215,0.318 2.508,0.566 -4.062,0.767 3.239,-0.367 -3.164,2.998 3.741,0.969 -1.952,-0.411 0.666,1.251 -1.685,0.281 1.391,0.243 -2.938,0.979 1.3,1.279 3.429,-2.106 -3.351,2.151 0.754,1.663 2.23,-0.567 -1.667,1.331 1.632,-0.681 0.095,1.827 2.282,-2.181 -0.388,-1.344 2.176,0.409 -0.817,-1.899 1.276,1.009 0.286,2.533 -2.187,-0.785 -2.799,2.869 1.8,-0.006 -1.104,1.169 1.706,0.813 0.359,-1.626 0.04,2.558 1.493,0.765 -0.293,-1.669 1.445,2.683 0.998,-5.11 -0.343,7.274 1.926,0.665 0.906,-2.786 0.276,3.269 1.766,-0.956 0.024,1.54 -2.287,0.117 1.994,2.171 5.218,0.647 2.054,-2.4 -1.306,-6.766 2.11,-1.071 -2.786,-4.334 7.249,6.331 0.638,-1.187 1.796,2.532 -1.002,-2.434 2.177,3.229 7.063,3.021 0.117,2.13 4.482,3.616 2.842,-2.5 -2.243,-4.431 2.64,-1.67 -4.187,-7.59 -5.025,-3.915 0.936,-0.915 -2.051,0.598 1.675,-2.851 -1.531,-1.947 2.14,1.139 -0.813,-3.338 -1.675,0.468 0.161,-3.051 -5.615,-1.681 -1.657,1.002 -9.752,-10.25 1.735,0.279 -1.254,-7.872 -1.901,-3.845 -4.803,-2.715 1.32,-0.222 -2.745,-2.035 1.836,-0.148 -1.559,-1.681 2.482,-2.583 5.124,1.479 5.594,14.85 7.125,3.945 3.655,4.084 3.381,-0.343 0.051,-1.601 2.373,2.524 2.647,-13.703 1.895,1.446 3.832,-1.736 -1.655,4.711 1.682,1.747 -4.028,3.046 -0.803,5.66 4.448,3.025 1.316,-1.469 4.778,4.611 0.183,2.561 -5.193,-1.27 -0.508,2.48 3.554,5.651 7.391,6.088 -1.271,1.426 -2.422,-4.38 1.961,3.735 -0.381,1.943 1.123,1.291 0.748,-1.2 0.113,4.028 -0.893,-2.816 -0.688,3.412 -3.645,-0.5 -3.003,9.734 1.414,2.217 -6.668,-0.954 -2.825,6.115 -1.111,-2.481 -1.963,2.084 -3.582,-1.171 -3.043,-4.422 0.193,-5.809 -2.852,0.139 -2.935,-5.631 -1.974,6.192 8.24,11.848 0.3,-1.19 2.42,1.213 -0.34,1.65 5.819,1.527 -4.085,0.282 1.549,2.842 -2.607,-0.75 -1.63,2.133 2.137,1.213 -4.502,1.784 -0.271,2.516 3.027,1.603 -0.595,2.387 -3.617,-2.438 1.47,6.31 2.562,0.193 -2.713,2.98 2.85,-0.46 -5.938,6.956 2.4,3.478 -2.366,7.288 -7.146,0.971 4.962,4.968 -3.848,2.871 -2.327,-1.499 -4.532,4.663 2.736,0.467 -1.662,0.542 2.139,2.291 7.343,-1.545 4.679,4.581 2.829,-0.239 1.269,3.635 0.837,0.481 3.96,12.573 -19.729,8.761 -3.086,-0.783 -4.484,6.611 4.216,3.011 3.899,13.056 -0.207,8.783 1.846,-2.098 0.01,3.811 2.445,-0.925 -0.88,0.496 2.053,8.069 8.253,-5.088 7.745,5.168 3.318,-6.241 8.956,-4.374 0.844,-5.566 2.498,-2.076 -0.941,-4.458 1.728,-3.695 -2.707,-1.233 -1.288,-3.489 0.79,-9.371 5.229,-9.042 -3.479,-4.578 -0.048,-3.191 1.612,-2.946 8.082,-1.377 3.381,-12.702 5.586,-0.673 7.643,5.994 20.187,1.105 5.224,4.53 1.057,5.701 1.454,-0.63 -1.372,-5.847 0.877,-2.616 -4.233,-1.814 -1.165,-4.354 2.906,-1.704 2.855,1.178 -0.745,-2.131 -10.836,-0.146 -1.025,-2.691 -3.971,2.608 -8.117,-4.81 -5.47,-0.491 -4.692,-5.364 2.199,-5.095 4.514,4.275 -0.205,-4.082 9.755,5.585 2.661,-1.707 4.047,0.687 -2.37,0.944 5.991,-1.785 4.32,1.188 4.098,7.515 8.342,3.373 0.606,-1.474 -0.146,2.123 2.459,1.336 5.363,-4.935 0.024,1.966 -4.377,2.807 0.598,2.495 4.765,3.396 0.289,-2.19 2.87,2.089 -1.004,-2.446 2.46,0.208 -4.753,-4.077 2.181,-1.592 -2.626,-0.689 0.583,-2.249 2.422,0.467 -1.633,-2.587 -5.698,0.958 0.61,-2.195 -1.44,-1.301 1.482,-0.304 -6.094,-4.012 0.127,-1.715 4.594,0.551 -1.914,-1.378 2.07,-0.866 -3.492,-0.996 1.865,-4.958 4.483,-2.854 1.034,4.493 -0.982,-7.932 2.422,-4.136 -7.445,-2.852 -0.62,1.227 -2.1,-8.28 -5.39,-7.123 1.293,0.827 0.265,-2.323 -3.931,-4.206 1.076,0.656 -0.667,-2.271 0.713,2.408 -0.925,-4.015 -1.761,-0.435 1.746,0.408 -1.574,-2.684 0.212,-4.538 2.283,0.466 -1.603,2.033 1.277,-0.751 0.404,1.323 2.753,-4.232 1.459,1.064 0.363,4.995 0.685,-2.131 3.793,3.068 1.514,-0.812 -1.182,-11.147 -0.915,3.453 -4.282,-1.647 4.36,1.726 -0.868,0.994 -2.904,-0.876 -1.813,-4.328 1.712,2.298 -1.49,-4.719 0.35,-11.057 2.093,4.007 -0.948,2.211 3.653,0.167 -1.224,-0.004 3.104,5.372 -0.108,3.24 14.264,-3.862 3.864,2.454 1.617,2.894 0.899,5.396 -1.491,5.278 -3.293,4.312 -4.934,0.431 -1.781,4.992 0.611,9.942 -3.654,5.164 1.723,1.615 1.414,-1.535 -1.273,3.024 1.069,1.244 -4.101,5.98 0.651,3.893 1.441,2.263 1.307,-2.868 2.82,4.847 1.56,-0.333 -0.463,2.03 -1.776,-0.979 1.083,2.449 2.947,-1.564 0.627,2.193 2.617,0.068 0.239,2.409 1.667,-3.529 -0.386,4.52 1.209,-4.083 4.686,-0.167 0.979,-2.458 -1.871,-3.67 0.874,-1.56 5.309,-1.174 0.98,-4.416 -1.117,-4.595 1.838,-1.023 -0.114,-3.755 3.852,6.779 3.906,3.74 7.961,19.893 -2.355,8.206 -1.749,-1.663 -1.683,2.505 -1.186,9.853 -5.89,3.536 -3.999,5.061 -1.788,-1.5 -4.277,4.084 -1.903,-1.735 -4.225,2.589 -1.846,8.425 3.573,6.798 -1.305,6.015 -4.854,-0.03 -7.294,3.519 -4.193,-3.593 -6.834,2.208 -3.217,3.176 -9.17,0.291 -1.66,-1.574 0.888,-8.271 -4.72,-3.109 -0.918,-6.39 -0.809,3.449 -3.945,-1.694 -4.514,7.03 -5.581,2.114 -2.476,4.813 -5.773,1.658 -9.088,8.344 -2.538,5.838 -3.321,2.541 -2.532,5.684 -3.526,1.524 -1.303,-1.588 -6.386,4.563 -4.634,-2.606 -1.643,1.551 -0.243,11.643 -8.097,12.79 -0.617,7.56 2.917,7.32 -1.394,5.331 -4.664,8.002 -6.17,4.219 -1.931,8.634 -3.454,3.917 -0.491,9.353 -4.202,6.566 0.902,-1.279 -4.517,14.269 0.182,5.628 0.745,-2.112 4.551,4.246 -1.143,5.268 3.949,8.356 -1.408,12.113 -4.596,6.636 6.066,3.167 0.336,2.784 4.971,-2.278 -4.082,2.647 -2.097,-0.581 0.232,4.841 2.949,-1.035 -2.932,1.938 4.198,-0.844 -1.716,1.85 2.775,-0.22 -0.425,1.531 5.396,-2.974 -2.99,1.979 2.661,0.01 -2.4,2.426 1.632,1.313 1.161,-1.352 -0.271,1.516 1.993,-1.456 1.728,4.16 5.159,0.594 -0.875,1.83 2.341,0.167 1.04,3.924 1.805,-0.745 -2.403,1.52 4.766,1.873 -0.207,2.066 7.11,0.645 13.833,4.998 6.508,-0.355 6.738,-6.046 10.429,-6.012 10.052,-2.305 15.036,-15.253 10.865,-8.83 -1.739,2.252 4.523,-2.562 2.998,1.157 1.206,-1.854 -1.116,2.037 2.02,-0.797 -1.544,1.271 0.867,0.36 1.296,-1.629 -1.204,2.744 2.951,2.432 3.024,-2.183 -0.019,-1.389 0.689,0.824 -0.477,-1.251 1.047,0.79 0.161,-1.98 1.198,0.676 3.805,-3.172 -0.319,-1.791 1.458,1.245 1.009,-2.1 1.814,2.781 1.983,-2.287 0.509,1.08 -1.147,0.86 1.909,2.236 -2.167,10.968 1.405,-0.593 -0.088,3.048 -1.408,0.775 2.689,-0.431 -1.915,2.026 -0.602,-0.994 -0.897,5.666 -1.724,1.06 3.454,5.29 7.568,2.846 1.105,4.32 1.731,-0.313 -1.547,1.808 2.713,6.288 -1.957,4.219 1.467,5.371 -1.945,5.687 -5.304,8.222 -5.803,11.838 -2.792,7.919 1.559,8.35 -6.358,11.245 -3.685,7.013 -1.985,2.07 -2.116,2.162 -2.541,2.546 1.689,-1.687 1.363,-1.38 9.078,-9.585 5.345,-5.998 7.068,-8.38 12.646,-16.45 7.146,-10.271 4.434,-6.79 6.635,-10.854 -0.713,1.209 0.058,-0.098 9.572,-17.275 3.885,-7.737 1.597,-3.323 1.654,-3.544 0.039,-0.085 4.035,-9.114 2.535,-6.112 6.399,-17.13 3.467,-10.626 1.988,-6.675 0.494,-1.737 1.418,-5.192 1.03,-3.989 -0.255,0.644 1.169,-6.125 0.616,-2.904 -0.288,1.049 1.021,-5.067 -0.229,-1.423 1.268,-7.94 1.829,-12.788 0.924,-5.294 -0.134,-0.709 0.508,-1.969 1.98,-21.236 1.074,-17.623 -0.126,-17.237 -3.468,-34.127 -0.943,-4.397 -0.204,-2.572 0.075,1.622 -1.697,-7.5 -0.139,1.199 0.816,8.241 -0.145,8.483 0.262,6.039 -0.468,1.588 -0.066,7.025 -2.343,-0.345 -0.359,2.823 0.048,-5.416 -0.661,-2.089 -4.754,-1.956 -1.436,2.148 -1.225,-1.374 0.484,2.546 -6.349,-9.656 -2.924,0.343 -5.157,-9.895 0.582,-0.043 -2.721,-3.159 -3.649,0.192 -2.592,-3.956 0.5,-0.987 -2.381,-0.552 -10.944,-10.29 -4.641,-2.085 -2.996,-4.005 5.147,3.964 3.817,0.504 -4.014,-10.821 3.486,8.027 1.022,-1.968 10.219,6.274 2.271,3.113 2.633,-0.888 3.985,3.905 2.994,5.897 4.432,0.48 7.243,6.774 2.438,7.387 4.358,8.632 0.839,-6.365 -0.521,-5.116 -0.116,-14.774 -0.836,-5.161 -1.771,-15.182 -1.47,-4.788 -1.956,-11.994 -1.703,-5.083 -0.738,-3.869 -1.876,-5.212 -1.264,-4.922 -2.521,-5.254 -1.063,-2.831 0.153,-0.346 -5.136,-12.131 -2.094,-1.528 0.221,3.928 -0.993,-0.254 -2.731,-3.395 -2.086,-3.766 7.037,17.661 0.3,5.049 0.83,2.947 -0.831,1.275 -4.237,-7.791 -0.112,1.781 3.339,6.119 -3.303,-2.648 -1.759,-3.29 -2.749,0.57 -5.204,-4.713 -0.143,1.27 -0.425,-2.372 -1.634,-1.376 0.323,-2.896 -1.148,-1.675 1.225,-0.568 -0.536,-2.56 6.601,4.69 0.603,-2.458 2.252,-0.671 0.126,-2.904 -2.959,-9.383 3.408,3.417 -2.057,-12.47 -7.87,-18.509 1.645,2.268 -0.891,-1.957 1.762,2.622 -1.613,-3.158 1.101,1.828 -1.718,-3.068 1.545,2.701 0.135,-0.075 -2.687,-4.765 1.483,2.551 2.858,5.137 -0.092,-0.236 -3.609,-6.36 -2.926,-4.939 -1.093,-1.799 1.481,2.445 0.65,1.085 -0.817,-1.364 1.518,2.545 0.55,0.934 2.6,4.511 6.636,12.281 5.964,12.158 3.278,7.235 0.076,0.173 -1.398,-3.145 -1.585,-3.466 -2.018,-4.275 0.045,0.093 -2.271,-4.645 -1.093,-2.174 -2.77,-5.348 -4.718,-8.628 -3.635,-6.277 -1.854,-3.09 -1.444,-2.36 -2.095,-3.347 -2.803,-4.354 -1.23,-1.867 -7.277,-10.543 -5.002,-6.795 -4.662,-6.039 -3.864,-4.806 -1.411,-1.713 -3.227,-3.835 -2.094,-2.43 1.404,1.624 -2.511,-2.89 0.471,0.537 -1.477,-1.677 0.548,0.62 -1.782,-2.006 0.15,0.168 -2.041,-2.262 1.066,1.177 -3.334,-3.645 1.645,1.785 -1.004,-1.092 -1.522,-1.639 -1.958,-2.079 4.782,5.137 -2.021,-2.197 1.634,1.772 -1.162,-1.263 1.091,1.185 1.364,1.498 0.537,0.595 -2.032,-2.235 4.587,5.101 5.891,6.858 -1.819,-2.157 1.863,2.209 -1.383,-1.643 0.394,0.465 -1.593,-1.875 0.485,0.568 -2.239,-2.601 -1.954,-2.229 -0.761,-0.857 0.244,0.274 -2.106,-2.349 -2.24,-2.453 2.213,2.423 -1.088,-1.197 5.504,6.171 3.578,4.174 -1.587,-1.867 2.743,3.246 3.377,4.107 -0.118,-0.145 4.105,5.165 2.052,2.658 -1.521,-1.975 7.49,10.021 -1.29,-1.779 2.979,4.148 5.949,8.685 3.105,4.767 1.196,1.884 -1.788,-2.805 0.374,0.583 -3.102,-4.751 -5.252,-7.678 -1.977,-2.779 -1.963,-2.705 1.041,1.427 -5.597,-7.504 1.305,1.711 -3.296,-4.284 -7.752,-9.565 -3.58,-4.194 -2.861,-3.258 3.179,3.624 -2.163,-2.478 0.055,0.062 3.528,4.069 -1.879,-2.182 2.179,2.533 -1.202,-1.404 0.074,0.086 4.701,5.581 -0.732,-0.885 -3.853,-4.56 -1.498,-1.732 0.305,0.351 -1.596,-1.825 0.465,0.529 -0.86,-0.978 -0.398,-0.45 -0.173,-0.195 -0.53,-0.595 -0.999,-1.115 -0.261,-0.289 -6.938,-7.47 -5.167,-5.291 -0.597,-0.597 -8.996,-8.66 -2.193,-2.02 -0.131,-0.119 -4.435,-3.977 -4.473,-3.876 -3.124,-2.63 -1.814,-1.499 -0.302,-0.248 -0.915,-0.746 -1.692,-1.368 -3.155,-2.503 -1.883,-1.465 -1.635,-1.257 0.596,0.456 -2.542,-1.932 0.265,0.199 2.974,2.268 2.276,1.771 -0.893,-0.697 -5.052,-3.863 0.756,0.569 -4.202,-3.123 -1.281,-0.932 -1.211,-0.874 -1.281,-0.915 -0.674,-0.479 -2.873,-2.012 1.452,1.012 -1.681,-1.169 0.16,0.11 -3.581,-2.446 1.523,1.033 -1.009,-0.686 -2.649,-1.775 1.06,0.705 -2.587,-1.713 0.498,0.327 -3.351,-2.178 -1.957,-1.248 -0.261,-0.165 -2.488,-1.558 -1.821,-1.122 0.549,0.337 -3.766,-2.28 -0.317,-0.19 -2.184,-1.29 -1.452,-0.846 -0.817,-0.472 -1.459,-0.835 -0.562,-0.319 -2.197,-1.235 0.5,0.279 -3.089,-1.708 -2.436,-1.318 0.63,0.338 -0.695,-0.374 -1.065,-0.568 -0.476,-0.252 -7.664,-3.938 -0.415,-0.207 -3.168,-1.554 -1.499,-0.722 -2.033,-0.964 -0.354,-0.166 -1.572,-0.733 -1.851,-0.851 1.895,0.871 -3.692,-1.684 -0.036,-0.017 3.401,1.55 -7.919,-3.54 -1.573,-0.676 1.368,0.587 -3.65,-1.551 -1.485,-0.617 -6.289,-2.524 1.396,0.548 -1.446,-0.568 -7.5,-2.827 -0.526,-0.191 -1.426,-0.513 -2.382,-0.841 -5.283,-1.797 -1.014,-0.334 -2.846,-0.92 4.002,1.301 7.761,2.676 -3.36,-1.184 3.022,1.063 -2.889,-1.017 -4.617,-1.566 -12.911,-4.005 -3.887,-1.1 1.023,0.285 7.731,2.261 -2.283,-0.688 5.384,1.649 -12.912,-3.797 -4.636,-1.233 4.858,1.294 -0.294,-0.08 2.074,0.573 3.027,0.861 -1.498,-0.43 1.513,0.434 -1.313,-0.377 -1,-0.283 -1.047,-0.294 3.997,1.14 -0.47,-0.137 2.395,0.704 1.078,0.323 -1.595,-0.477 2.742,0.824 -1.004,-0.304 6.751,2.111 1.576,0.515 0.94,0.311 0.983,0.328 -4.087,-1.343 1.504,0.488 -2.682,-0.865 0.942,0.301 -1.959,-0.623 -0.249,-0.078 -2.709,-0.838 -0.173,-0.053 -6.121,-1.803 -5.204,-1.438 -5.89,-1.524 -0.055,-0.014 -2.858,-0.7 -11.167,-2.492 -4.633,-0.922 -5.078,-0.937 -1.738,-0.303 -0.873,-0.148 -5.217,-0.841 0.15,0.023 -8.792,-1.24 -20.233,-1.996 -17.772,-0.78 -8.152,-0.028 -4.102,0.266 3.482,0.239 -2.113,-0.027 -0.775,0.111 6.121,0.366 3.883,0.031 0.295,-0.126 4.651,-0.079 -1.686,0.285 3.544,-0.133 -0.419,0.385 3.872,0.121 1.679,0.262 -10.753,0.522 -13.685,2.355 -9.958,0.68 -1.256,-0.205 -1.235,0.414 -7.653,0.429 -1.092,0.669 -9.322,0.581 3.606,-0.604 -1.013,-0.147 -11.372,2.075 1.067,0.172 2.502,-0.462 0.239,0.438 -4.721,2.919 -9.445,2.656 0.379,-1.13 -0.616,-0.29 -1.611,0.527 -0.207,-0.575 -3.873,2.52 -2.517,0.68 2.007,0.805 -3.105,1.157 -2.268,0.32 2.535,-1.079 -2.203,-1.613 4.265,-1.729 6.227,-4.381 4.267,-1.049 1.107,-1.228 -0.662,-1.019 -9.761,-0.127 -4.697,1.413 1.532,-0.009 -5.512,1.283 2.013,0.156 -6.096,1.927 2.73,0.409 -3.814,1.113 4.406,-0.05 -1.155,0.74 4.783,-1.002 -0.974,2.766 -2.144,0.758 -1.676,0.05 -2.373,1.724 -1.559,-0.476 -0.566,1.072 -5.442,2.185 -4.585,0.584 0.714,0.541 -3.711,3.864 -5.858,4.313 -5.396,2.134 0.486,0.78 8.799,-0.41 -0.937,-0.185 3.482,-0.323 2.043,-1.694 0.607,0.307 2.258,-0.978 -8.833,4.509 0.262,1.83 3.088,0.533 -1.571,0.998 -3.32,-0.686 -3.377,2.195 -4.936,0.756 -5.021,1.933 0.565,0.525 -1.808,0.065 -0.981,1.204 3.173,-1.066 -0.73,1.461 1.744,0.23 2.457,-1 -4.281,2.254 2.18,-0.322 -2.369,0.977 0.799,1.301 6.592,-1.971 3.884,-2.105 1.385,-1.139 -4.794,0.164 8.265,-0.378 13,-3.345 0.024,-0.009 m -43.586,639.285 1.355,0.512 -0.11,-0.041 4.8,1.762 0.923,0.33 -1.976,-0.71 0.272,0.099 -2.094,-0.765 4.208,1.521 1.051,0.37 5.605,1.912 3.123,1.021 -2.56,-0.833 -2.222,-0.742 2.234,0.745 -2.061,-0.687 3.01,0.998 -1.802,-0.594 1.823,0.601 1.435,0.466 0.09,0.028 5.032,1.576 -1.179,-0.362 -4.339,-1.37 -5.023,-1.679 0.999,0.245 4.881,1.478 -1.577,-0.878 2.932,0.572 -3.303,-1.135 2.156,0.566 1.849,0.722 1.646,0.331 -1.64,-0.771 -2.298,-0.452 -3.029,-1.113 -2.123,-1.5 5.859,2.026 5.564,1.339 -2.116,-1.922 1.468,0.463 -2.359,-1.205 5.764,1.706 11.071,2.087 3.855,0.319 2.74,-0.933 -0.869,-0.893 -3.446,-1.174 0.156,-0.906 -7.493,-2.867 -0.838,-2.323 0.967,1.581 3.351,1.569 8.601,2.383 9.494,1.25 6.406,-1.658 0.714,-2.198 5.141,-2.043 -1.298,-0.91 4.077,1.438 -6.702,2.396 5.931,-1.151 4.68,-3.202 4.586,-1.18 0.99,-3.082 -2.216,-2.219 2.223,-1.607 -2.216,-0.714 2.92,0.521 3.227,-1.734 6.352,-1.558 5.354,0.156 5.408,-2.106 4.817,0.587 2.61,-1.013 0.221,0.853 5.826,0.207 0.257,-1.296 5.49,-1.412 -0.512,-1.454 7.188,-5.66 0.646,-3.878 3.275,-2.229 1.853,-16.918 0.93,-0.938 1.291,1.567 2.413,-1.331 19.036,-17.485 0.963,-4.987 -2.72,-6.901 -2.144,-1.478 -9.309,-0.217 -8.04,-5.356 -9.433,-3.771 -13.653,-0.074 -7.082,-2.598 -8.476,4.201 0.398,-3.261 2.361,-1.17 -3.814,0.303 3.064,-1.634 -2.139,-3.015 -2.464,1.856 -0.541,-2.469 -1.183,0.817 0.643,-0.971 -1.697,0.534 -1.782,-1.89 -0.968,1.126 -0.304,-1.936 -0.913,0.973 -5.727,-2.831 -0.459,1.04 -4.156,-1.146 -2.654,3.449 2.585,0.642 -2.29,0.504 -1.25,-1.549 -4.993,3.98 1.202,-2.846 -6.97,0.266 9.28,-1.048 3.07,-5.276 -11.766,-2.179 -2.759,3.942 -0.21,-2.191 -2.476,1.745 -0.247,-2.258 -2.462,1.9 2.322,-3.936 8.496,-5.004 -1.443,-0.219 1.251,-2.257 -4.995,-2.465 -3.061,-10.896 -1.461,-1.068 -0.682,1.735 -3.685,-4.927 -10.996,-6.378 -17.41,-2.897 -6.709,-6.771 -2.119,2.158 1.43,-4.588 -3.076,-3.91 -6.525,-5.075 -3.688,-0.613 0.407,-4.375 -4.214,-3.528 -3.952,-0.573 -2.823,-3.736 5.833,-0.452 -13.256,-3.202 3.312,1.887 h -7.926 l -6.106,-5.063 -10.207,-2.477 -1.029,-4.15 -6.262,-3.805 -1.603,-4.601 -1.473,2.576 2.276,0.509 -0.084,1.429 -1.725,-1.408 -7.945,1.191 2.293,6.754 -0.455,2 -3.412,0.051 -1.754,-4.794 3.332,-3.509 -1.437,-5.246 4.681,-0.882 -2.556,-3.295 -8.889,2.856 -4.307,-2.117 -0.891,1.479 -2.724,-1.82 -2.244,0.673 -2.596,2.426 -0.016,3.775 -6.914,1.552 0.466,3.656 -4.634,-8.715 -4.909,-4.937 -3.012,-1.867 -7.212,0.46 -3.431,-4.018 0.317,1.519 -2.008,-1.463 -5.497,-16.041 5.778,-13.965 0.18,-5.337 -6.057,-8.191 -12.99,-6.973 -2.814,-3.325 4.169,-3.541 2.412,-6.997 -1.145,-0.97 2.031,-1.561 -0.138,4.113 3.703,-6.256 -1.154,-1.318 6.329,-6.306 -4.702,-5.157 -8.945,-2.888 -4.345,7.638 -4.458,2.404 -2.449,-3.56 -8.119,-2.993 -1.533,-5.735 -2.204,-2.045 -0.023,-23.132 0.677,-3.049 4.06,-9.801 1.763,-3.586 1.549,0.344 -1.247,1.749 3.23,-3.709 2.181,-7.511 -1.004,-1.155 1.214,0.86 2.628,-3.686 2.993,0.886 -0.096,-2.188 1.894,2.306 -1.137,0.167 4.71,0.125 1.987,-2.979 1.216,2.271 -1.414,0.176 3.66,0.925 0.7,-1.681 -0.644,1.625 4.435,4.967 2.331,-0.249 1.478,6.522 2,-0.291 0.644,1.979 0.708,-2.488 1.261,1.6 -0.052,3.903 2.041,-0.324 -1.596,-3.867 2.368,-0.513 -3.23,-4.766 8.046,5.312 1.549,-2.149 -0.129,2.712 -1.248,0.184 4.444,0.434 -1.168,1.03 3.907,1.615 -1.383,-0.214 3.24,2.703 -0.573,4.065 5.338,0.159 1.548,2.415 1.939,8.245 -2.871,4.964 1.931,0.639 -2.058,1.909 0.286,3.857 1.561,0.504 -0.842,6.483 2.307,3.555 -1.033,2.31 2.335,0.963 -0.418,1.147 5.435,-8.992 2.18,-27.886 5.775,-3.518 -0.015,-1.902 0.303,1.793 10.463,-4.546 12.132,-1.452 -2.351,-1.888 2.592,-0.499 -1.645,-2.26 3.032,2.493 2.34,-0.893 0.242,-2.204 -1.426,1.499 0.627,-1.99 -2.828,-0.944 2.877,-1.078 1.165,2.064 0.743,-3.966 -0.323,6.114 0.598,-7.333 -3.178,-3.642 1.912,1.929 -0.581,-3.227 0.555,2.182 1.496,-1.399 -1.502,-3.548 1.354,3.164 1.114,-1.362 -3.208,-4.589 1.118,-1.59 2.082,5.195 1.596,-7.443 3.513,-0.214 -3.487,2.966 0.901,6.279 -3.071,4.28 6.323,-5.686 1.066,-8.324 0.842,5.645 4.788,-3.361 0.895,-4.537 3.882,-1.863 8.848,1.545 1.274,-2.517 0.048,2.42 5.28,0.74 0.403,-2.422 -1.775,1.506 -1.445,-4.877 5.931,-6.535 1.888,0.531 0.693,-2.005 1.886,1.709 2.991,-3.693 -0.732,2.051 2.789,-0.814 0.198,1.714 5.245,-1.369 -0.111,-2.67 2.475,1.881 9.74,-2.271 -3.354,2.512 6.191,1.59 -3.488,1.287 -0.943,-2.398 -7.864,2.957 -1.541,3.987 2.148,2.906 6.63,-5.133 2.382,1.538 0.451,-1.744 10.157,-0.23 1.613,-0.427 -2.881,-4.25 -5.689,-0.417 -4.45,-5.122 1.081,-4.51 -2.352,-0.681 3.697,-3.559 -3.605,0.205 0.01,-1.965 -3.383,-1.567 5.749,1.649 4.201,-1.333 0.268,-4.309 -5.47,-2.277 -8.388,0.891 -14.818,6.398 6.774,-3.667 0.813,-2.872 11.561,-2.774 5.241,-4.354 23.496,6.498 5.992,-4.823 6.528,0.351 5.489,-3.027 -1.525,-2.484 2.225,0.439 -3.049,-1.53 2.748,0.573 -1.205,-1.672 2.065,-2.678 -1.758,-3.081 -3.601,1.505 1.595,-2.813 -3.129,-2.452 -10.475,3.696 9.761,-3.784 -4.41,0.188 8.49,-1.49 -2.622,-1.557 1.104,-0.874 -3.597,-0.144 0.351,-1.916 -1.55,0.784 1.136,-1.393 -3.268,2.271 2.411,-1.97 -1.965,-0.142 1.075,-1.141 -3.609,1.275 2.606,-4.204 -1.525,1.029 0.709,-1.436 -3.421,-1.784 1.854,-1.116 -2.224,-0.581 1.511,0.044 -1.66,-1.585 1.921,0.084 -2.349,-1.937 2.434,1.473 1.863,-2.46 -2.834,-3.104 2.221,-0.29 -1.79,-2.276 1.169,-1.171 -3.107,0.398 3.399,-2.185 -3.477,0.194 3.055,-1.648 -0.108,-2.177 -2.703,-0.543 2.367,-0.417 -2.011,-5.604 1.405,-0.934 -1.044,-1.074 -3.312,2.822 0.648,2.412 -2.32,-0.016 0.713,1.598 -2.706,0.561 -0.917,3.079 0.178,-3.538 -5.682,3.347 0.438,-3.405 -3.35,2.48 2.88,-3.869 -5.276,-1.876 1.857,-1.091 0.172,1.64 2.165,-2.438 -1.423,-0.508 1.804,-3.38 -2.84,-1.564 3.38,1.107 2.91,-5.146 -1.724,1.038 -3.418,-3.527 1.464,-2.336 -1.889,-0.485 -0.756,-6.062 -3.107,1.039 -5.134,-5.468 -2.799,0.754 -0.769,4.371 -4.189,2.863 1.872,0.561 -1.816,4.371 -7.862,5.173 1.957,5.364 -3.793,9.128 -6.372,4.258 -7.843,0.343 0.54,3.47 -4.139,11.1 -3.292,1.521 -1.223,3.418 0.143,-3.302 -2.927,2.112 -2.123,-2.11 1.513,-2.162 -0.954,-9.25 7.362,-11.245 -6.965,-4.888 -4.813,-19.038 -5.769,-1.491 2.554,-1.335 4.259,-7.463 -1.704,-1.911 -1.723,1.592 1.474,-4.04 6.661,-5.931 7.869,-2.924 0.292,-1.497 5.746,-0.046 0.201,-1.928 1.494,1.685 2.919,-0.584 0.377,-3.752 -1.968,-0.315 1.381,-0.641 -2.032,-3.102 1.539,-1.029 1.878,7.567 4.177,-2.199 3.189,2.487 6.177,-2.889 -3.382,-8.282 2.035,1.079 1.329,5.898 5.951,-1.939 -0.003,-2.699 3.533,5.063 0.632,-4.9 2.189,1.339 -1.229,3.154 8.024,-2.761 1.238,-5.827 3.103,0.457 -0.416,-1.829 2.379,-0.729 -1.777,-3.277 1.741,-0.05 -3.903,-3.51 -3.325,5.631 -1.385,-0.957 -7.137,5.058 -2.527,-0.126 6.496,-8.391 -0.19,-2.497 -5.912,3.297 3.526,-5.993 1.909,0.755 -2.306,-3.622 3.184,-1.573 0.813,1.126 4.802,-9.818 -7.918,2.026 0.436,1.294 -4.571,2.643 1.223,4.995 -1.426,-0.814 -3.097,1.765 2.235,-0.094 -1.514,2.099 -5.026,-0.386 -3.949,3.648 -0.113,-2.581 4.648,-2.47 -2.381,0.155 1.861,-0.813 -0.263,-1.826 -2.16,-1.289 -1.595,2.523 1.217,0.949 -2.177,1.477 1.273,-3.739 -2.404,1.117 -3.941,-4.223 1.288,-3.242 -1.615,-2.108 3,-4.11 -5.813,-1.355 0.532,2 3.856,1.058 -6.314,-0.471 -2.441,3.396 -1.674,1.002 0.101,-1.451 -2.667,2.786 2.507,-4.207 1.658,0.111 2.112,-5.13 -3.209,-1.55 -1.398,-4.986 2.027,-1.251 1.962,1.339 1.941,-2.771 -1.07,-2.892 3.378,-8.726 -3.371,-2.395 4.901,-1.912 -5.25,0.455 6.945,-5.758 -2.461,1.529 -4.888,-3.27 5.431,0.127 -4.967,-3.173 -0.476,-1.482 2.676,-1.029 -2.565,-1.396 -3.365,1.739 11.077,-12.417 6.139,-10.183 2.105,-1.748 1.307,0.371 1.145,-2.278 2.636,-1.027 -1.19,-1.094 1.77,0.531 1.969,-1.009 -1.483,-1.6 1.417,-2.098 -2.239,-0.347 1.767,-0.238 0.353,-2.131 -3.93,-2.81 2.352,-2.679 -1.645,-0.964 -6.842,2.954 -3.05,0.476 -3.026,2.622 -2.583,0.196 -1.921,1.718 1.641,-1.846 3.567,-1.138 -5.768,1.806 3.303,-3.587 3.298,-0.769 1.369,-4.946 -5.059,2.577 0.99,-1.214 -3.754,0.924 -5.387,4.233 1.139,0.028 -2.012,0.512 0.97,1.431 -1.901,1.393 -0.4,-1.029 -3.685,1.3 -1.148,-0.521 1.864,-1.752 -0.995,-1.366 2.662,-1.684 -4.809,-2.246 -2.73,0.955 -1.097,1.193 -0.39,-0.472 -3.707,2.772 1.036,-1.649 -3.766,0.878 -1.807,3.022 -5.813,1.746 -1.066,-0.757 -0.962,2.819 -5.39,3.104 2.909,0.007 -2.964,1.062 -0.003,2.06 -1.95,-0.688 -4.393,1.115 -0.615,-4.355 -2.437,0.66 3.293,-3.046 -1.692,-1.921 0.175,0.521 -1.099,0.865 1.635,-0.5 -2.108,1.48 1.5,0.232 -1.761,0.908 -0.313,2.213 -1.653,0.718 3.881,5.271 -0.308,2.28 2.187,1.019 1.917,-1.866 1.708,-0.325 5.66,4.372 -0.696,2.369 -0.835,-1.266 -2.86,2.385 2.59,-2.813 -0.51,-1.49 -4.222,0.202 -0.9,1.69 -2.194,-0.782 0.155,3.173 1.561,-0.352 -1.443,0.669 1.981,-0.323 -1.861,2.07 2,0.292 2.493,-1.849 1.569,1.209 -2.156,0.267 1.354,0.244 -1.564,0.596 0.426,1.614 -0.801,-0.48 -1.002,1.367 -0.209,-0.926 0.053,0.979 -1.83,0.642 -0.838,1.992 -2.699,1.816 -1.327,5.241 -2.957,2.883 1.475,0.91 -1.613,1.672 -1.076,-0.363 2.342,-1.174 -2.184,0.117 -8.299,8.943 0.671,0.963 3.905,-3.44 -1.939,2.275 1.63,-0.547 -3.657,1.963 -0.979,2.003 6.53,-3.144 -5.826,3.446 -1.15,1.729 1.649,0.143 -2.393,0.357 -1.211,2.363 -0.399,-0.73 -1.541,2.095 1.268,-2.121 -1.951,2.1 -0.795,-0.684 -5.137,6.776 -3.197,0.102 2.48,1.245 -1.769,1.607 -4.938,2.222 2.774,0.158 3.125,-1.182 -4.405,1.785 -0.475,1.406 -1.616,-0.896 -1.747,1.985 1.72,-1.984 -1.414,0.673 -0.712,2.526 -1.346,-0.529 -2.833,3.465 3.123,-0.308 -2.225,1.083 -0.211,1.674 0.184,-2.178 -3.834,5.064 -2.228,-0.069 1.178,0.247 -1.569,1.317 2.418,0.68 -4.235,0.394 -1.677,1.617 1.122,0.386 -1.808,-0.214 0.267,1.676 -1.025,-1.2 0.369,2.673 -1.033,-1.59 -0.032,3.507 -0.563,-0.66 -0.636,1.383 1.609,0.744 -1.931,-0.73 -0.83,2.146 1.481,-0.377 -1.318,0.564 0.053,1.259 2.458,-0.885 -2.935,1.314 1.122,1.251 -2.492,0.455 -1.046,2.253 2.125,-0.357 -1.99,2.35 -1.078,-0.478 1.188,1.413 -3.104,2.322 -0.874,2.63 -5.458,5.13 -2.427,-0.234 2.288,-0.556 1.87,-1.808 -2.918,0.616 3.755,-1.721 0.196,-5.942 -6.313,6.459 0.357,0.825 -3.22,1.708 0.186,1.867 -0.336,-1.548 -14.688,10.719 -5.461,6.664 -4.156,2.776 -5.567,7.915 -3.107,5.822 0.72,2.084 -2.047,3.167 0.97,-2.838 -2.214,2.688 -6.065,14.026 -1.981,2.43 0.134,8.958 -1.417,6.905 -8.764,21.274 -1.398,11.387 -1.898,1.836 -0.203,2.215 -1.315,-3.972 -0.693,9.451 1.438,0.261 -0.86,7.392 -3.068,6.232 0.338,12.267 -0.905,4.308 1.756,0.383 1.265,-5.412 -0.904,-4.318 3.999,-12.856 1.16,-10.015 1.664,-3.685 1.922,-12.913 5.131,-9.759 0.57,9.021 -5.069,13.395 -1.042,8.354 0.894,2.3 -1.581,2.673 0.095,9.518 -2.109,1.902 1.22,7.446 -0.904,2.213 0.417,15.347 -1.147,9.611 -2.213,2.257 0.33,1.911 -1.401,-0.646 -0.309,2.459 1.874,15.281 3.554,6.935 1.312,6.381 11.271,22.729 8.161,4.45 7.976,20.353 9.989,12.351 -0.87,-1.265 5.379,2.94 -0.1,2.826 -1.58,-1.017 6.581,15.146 -1.318,0.079 1.124,1.401 -0.732,4.408 2.121,3.326 1.254,-0.718 -1.454,-3.381 2.074,3.002 4.183,7.733 -0.152,3.18 1.248,1.053 -0.229,-2.085 1.717,4.887 0.948,-1.019 4.217,3.072 0.825,3.176 2.202,0.143 0.386,3.991 2.088,0.971 2.209,-0.266 -1.836,-4.813 6.906,-0.673 2.739,5.148 1.761,0.48 -1.897,1.713 4.654,9.52 -1.962,11.085 2.385,2.604 -0.596,1.12 -3.277,3.201 -3.851,-0.858 0.06,3.311 -2.41,-0.613 0.446,2.977 -5.495,-1.541 0.647,3.207 -2.571,1.23 1.057,1.863 -2.926,0.156 0.208,5.891 3.091,3.516 1.639,-1.438 0.827,2.136 -1.2,2.786 -5.547,0.822 2.331,7.134 -1.245,0.636 5.74,6.305 5.397,8.672 8.238,15.768 8.595,11.568 -0.504,1.5 2.97,3.886 4.403,4.479 19.735,14.308 6.939,6.171 2.507,5.526 1.876,4.663 -0.35,5.206 3.25,5.655 0.098,7.394 2.663,2.856 -0.882,0.839 5.603,6.795 0.147,3.982 -1.709,-0.534 6.375,4.28 0.437,1.015 3.066,1.541 -0.656,-0.216 2.494,0.952 1.68,0.741 0.72,0.212 -1.175,-0.275 2.608,1.166 0.225,0.201 -1.818,-0.814 2.027,0.932 -1.478,-0.639 1.098,0.677 2.229,0.987 -1.274,-0.495 3.545,1.503 -1.945,-0.798 3.172,1.321 -2.498,-1.037 0.438,0.184 1.272,0.529 0.094,0.039 -1.662,-0.692 -2.015,-0.853 1.579,0.669 -1.267,-0.536 0.215,0.092 -0.745,-0.317 -1.575,-0.678 -1.152,-0.502 2.247,0.974 -0.36,-0.154 -2.021,-0.879 1.593,0.694 -1.261,-0.549 1.771,0.768 0.825,0.354 2.189,0.927 1.934,0.804 -1.668,-0.692 2.257,0.936 -2.554,-1.06 3.433,1.419 2.519,1.014 -1.801,-0.723 1.683,0.676 -5.029,-2.05 3.589,1.472 -1.67,-0.679 1.457,0.593 -0.299,-0.121 1.039,0.419 2.142,0.853 -2.502,-0.998 2.488,0.992 -3.084,-1.232 2.816,1.126 0.285,0.113 1.12,0.438 1.17,0.455 -2.918,-1.143 2.225,0.873 -0.451,-0.176 2.23,0.861 -0.379,-0.145 1.136,0.433 -1.065,-0.406 2.845,1.076 -3.148,-1.192 1.442,0.551 -0.403,-0.153 2.56,0.963 -1.048,-0.392 0.163,0.062 -0.478,-0.18 -0.23,-0.087 -2.606,-0.996 0.643,0.248 2.621,0.995 -1.34,-0.506 h -0.005 m 109.893,-447.266 1.921,-1.96 2.856,1.73 -3.098,-2.886 4.038,0.197 -1.885,-1.586 2.515,-1.306 -2.707,-0.486 2.909,0.323 -1.734,-1.433 2.515,-0.84 -1.941,-0.638 2.485,-0.537 -1.839,-0.413 2.251,-1.289 -2.396,-2.977 2.367,0.831 -2.743,-2.156 3.853,-0.309 -0.839,-2.427 2.182,1.13 -1.635,-2.332 2.134,0.993 -1.236,-1.087 2.338,-0.497 -2.041,-1.585 2.689,0.993 -0.184,-2.356 -2.602,-0.835 3.25,-0.48 -1.996,-4.412 2.347,0.857 0.74,-3.208 4.379,-0.322 0.645,-4.426 1.778,0.551 -1.499,2.471 1.545,0.634 -0.233,-1.95 0.711,1.319 3.405,-1.583 -0.873,-1.749 2.73,0.534 2.894,-7.64 2.524,-1.586 -1.748,-3.684 2.593,2.821 3.438,-0.664 -0.106,-1.605 1.485,1.009 6.124,-3.302 6.643,-9.024 -6.806,-0.46 -3.634,3.09 -2.622,-0.472 3.72,-2.487 -5.435,0.814 1.792,-3.938 2.472,0.802 2.161,-2.144 -6.094,-0.528 1.901,-1.11 -2.262,-1.232 7.839,2.244 3.849,4.091 1.023,-2.426 0.826,2.017 1.696,-0.655 -2.555,-2.361 0.292,-2.446 -1.464,0.456 0.724,-1.622 -2.068,1.007 0.619,-1.708 -4.556,-1.804 -1.141,1.833 0.051,-1.492 -1.92,0.352 2.974,-1.002 -1.671,-1.384 -2.04,1.787 -1.87,-1.367 3.808,-1.792 -4.604,0.411 2.201,-0.904 -2.006,-1.058 2.61,0.956 1.816,-1.706 -2.438,-1.903 2.745,1.681 0.123,-1.443 3.472,0.349 -3.18,0.288 3.539,1.567 2.872,-1.84 -0.56,-1.898 -2.677,-0.487 0.609,2.094 -1.812,-1.808 -0.387,-2.79 4.527,0.926 0.526,-1.443 -3.527,-0.047 -0.134,-2.08 -2.941,-10e-4 2.772,-0.674 -3.505,-1.106 5.041,1.065 -0.866,-2.896 -4.034,-0.361 2.518,-1.573 -2.924,0.394 -2.11,-2.069 5.642,-1.877 -1.286,-2.327 -3.788,-0.156 1.98,-1.446 -2.646,-0.82 -0.696,1.858 -0.679,-2.173 0.72,-9.443 -2.285,1.731 -0.915,-1.516 3.419,-2.875 -4.947,0.981 5.189,-2.944 -0.684,-4.064 -3.535,0.155 -0.187,2.464 -2.586,-0.137 -1.493,5.349 -0.944,-7.125 -3.116,3.669 0.624,-2.829 -6.7,1.547 0.988,-1.784 5.758,-0.617 2.21,-2.564 -3.982,0.046 -0.053,-1.802 -7.48,2.767 1.331,-2.096 5.52,-1.366 -8.482,-0.15 -0.58,3.519 -3.256,-2.454 -1.383,1.472 3.524,1.065 0.196,1.618 -4.301,-2.05 2.319,2.591 -1.92,-0.212 -0.027,2.291 -4.628,-3.911 0.089,4.21 -2.416,-2.093 -1.46,1.532 0.815,-3.256 -4.464,0.533 1.097,3.532 -1.148,-2.742 -1.839,-0.109 -1.732,3.407 -0.987,-1.285 -0.789,2.084 0.054,-1.862 -5.015,2.33 -0.388,1.388 3.241,0.513 -4.763,3.832 -3.33,-0.708 -6.816,2.035 1.94,4.619 4.04,0.652 -0.906,1.572 -3.461,-1.288 2.847,1.849 -6.115,-1.916 3.036,3.181 -2.871,0.438 0.431,1.95 2.199,1.712 0.073,-1.81 1.613,1.751 3.569,-0.873 2.854,1.88 3.948,9.185 -2.59,1.866 2.256,-0.491 -1.332,6.149 1.63,3.283 -2.465,-0.225 1.538,0.7 -1.671,2.057 2.024,-1.329 -3.536,2.34 3.301,1.855 1.879,-4.55 -0.33,3.357 2.978,0.276 -2.853,1.292 3.186,0.115 -2.619,1.327 2.13,-0.438 -1.594,0.797 2.396,0.815 -2.002,-0.296 2.007,3.959 -4.199,-2.9 -3.47,0.077 3.708,3.813 4.315,0.541 -2.799,4.208 2.493,0.438 -1.145,1.405 -1.319,-1.461 0.286,3.447 -3.316,-1.203 -3.098,1.391 6.101,-0.214 -1.761,1.505 2.204,1.723 -6.397,-2.327 2.525,1.651 -2.448,-0.78 -1.81,2.765 5.31,-1.968 -1.69,0.752 4.608,0.3 -8.597,1.257 5.315,1.146 -5.827,0.166 3.437,2.257 -3.208,0.613 2.392,1.032 -2.797,-0.395 0.989,1.189 -1.74,0.988 7.493,-3.723 1.313,0.869 -8.423,3.356 4.224,0.362 -3.908,1.234 1.296,2.289 3.599,-1.954 1.75,1.007 -5.646,1.29 1.512,0.193 -1.2,2.728 2.617,-0.752 -2.641,1.39 -0.145,2.775 4.076,-2.555 -0.372,-2.751 2.584,5.232 -2.947,-1.891 1.587,1.19 -4.314,0.964 4.301,0.773 -4.055,0.034 1.715,0.843 -1.977,1.181 2.769,0.432 -2.198,0.989 2.844,0.647 -2.591,-0.053 2.734,0.98 -1.272,2.378 2.091,-1.341 -2.243,2.949 2.694,1.563 -1.498,1.568 2.577,-0.351 -2.101,1.305 2.026,-0.816 -1.246,1.513 1.617,0.535 -1.993,0.366 2.893,0.315 -2.491,0.571 3.333,0.705 0.393,2.987 7.435,-1.708 -3.265,2.41 2.625,-1.333 -1.988,2.367 2.409,-0.987 -0.154,2.112 1.875,-1.712 -1.909,3.229 2.314,-2.225 -0.925,3.088 m -57.795,-21.505 -2.859,-11.892 2.095,3.078 0.477,-2.265 4.685,8.347 1.673,-6.514 0.677,3.56 1.435,-3.947 -1.792,-2.481 1.809,-0.207 -0.541,-2.642 -2.048,0.775 0.222,-2.502 -0.923,1.617 1.043,-5.292 -2.674,0.516 1.413,-3.374 2.569,1.193 -0.164,-3.707 2.496,1.044 0.434,3.026 1.793,-1.08 -1.945,1.994 4.367,-1.094 -4.018,2.4 2.57,5.833 2.354,-5.497 1.191,2.393 0.609,-3.154 1.977,1.373 -1.448,-2.314 3.039,0.887 -0.862,-1.925 2.145,0.249 -0.839,-2.42 -2.417,1.638 0.438,-1.676 -2.496,0.25 2.692,-2.29 -2.482,1.795 1.439,-1.528 -3.167,0.404 2.25,-0.844 -1.56,-1.044 1.747,0.661 -0.146,-2.74 -1.871,0.415 1.866,-1.382 -2.231,1.58 -0.022,-2.235 -1.406,1.748 1.272,-2.135 -1.555,1.047 1.018,-1.75 -1.373,0.678 0.472,-2.169 -1.893,-0.271 2.883,-0.081 -4.387,-3.655 3.085,1.256 0.159,-2.082 -2.033,0.307 2.447,-0.58 -1.445,-1.293 3.972,2.438 -0.25,-1.795 -5.109,-2.23 5.813,1.019 0.568,-1.278 -0.731,-2.24 -5.351,2.147 4.11,-1.936 -3.21,-0.144 4.789,-1.145 -1.309,-2.021 -3.021,0.844 2.516,-1.547 -5.436,2.958 2.22,-2.202 -1.784,0.042 4.269,-2.09 -4.69,0.758 4.394,-2.123 -1.116,-2.721 -4.071,1.92 2.761,-3.169 -4.281,1.72 2.279,-1.879 -1.098,-0.642 3.054,-0.896 -4.062,-0.633 4.044,-1.94 -2.624,-2.883 -2.565,0.701 1.194,2.456 -2.417,-1.816 -0.051,3 -0.251,-4.853 -4.007,1.745 4.266,-3.061 2.02,-5.122 -5.86,-1.104 0.253,2.412 -2.236,-1.59 0.856,2.45 -1.59,-2.067 -1.669,4.945 -0.372,-1.977 -2.085,0.294 0.507,2.922 -3.27,2.664 0.79,-1.333 -6.551,-3.762 -1.618,3.072 0.166,1.961 3.276,0.248 -1.346,2.687 5.601,4.357 -0.243,-3.045 0.975,4.458 0.356,-2.565 3.717,3.682 0.469,-2.846 2.185,-0.967 -1.215,5.419 1.895,-0.571 -1.528,1.419 1.796,0.67 -0.41,2.509 -3.691,1.63 3.204,-0.565 0.602,3.394 1.517,-0.233 -1.389,7.915 -3.201,1.692 1.612,1.326 -1.925,-1.1 -4.542,1.492 -0.185,4.394 -5.563,-1.125 -2.432,-2.68 -4.871,4.342 7.454,3.792 1.307,-2.694 0.414,3.882 1.696,-1.45 -1.006,4.674 2.578,2.593 -2.571,-0.074 0.229,2.017 10.84,11.063 -0.005,-0.011 m 46.872,-103.146 -4.802,-0.024 -1.359,2.916 -1.069,-3.244 -2.178,0.31 0.023,1.982 -0.974,-2.178 -4.333,-0.189 1.196,1.152 -1.746,0.443 2.498,0.99 -3.724,0.48 4.479,1.292 -4.734,-0.855 -0.055,1.866 5.909,0.342 -3.78,-0.041 -1.558,0.691 3.315,0.183 0.966,0.711 -2.129,0.404 2.077,0.523 6.049,-1.424 -3.701,1.381 1.912,0.974 -7.275,-0.72 -1.017,4.021 0.248,-4.004 -1.758,-1.456 -2.844,6.008 -1.27,-0.577 2.888,1.503 -2.395,-0.102 -0.328,1.512 -0.887,-2.758 -2.25,-0.313 -3.228,1.825 2.565,0.02 -0.896,1.248 2.834,-1.328 -4.691,3.865 4.621,-0.675 -5.26,1.712 -1.009,-4.333 -1.507,3.427 -5.519,0.178 0.225,1.361 1.815,-1.223 -1.15,2.131 1.361,-1.015 -0.424,1.62 1.366,-1.059 -0.191,2.26 2.52,-0.834 0.154,1.641 1.214,-1.469 -0.312,2.13 1.236,-1.971 -0.969,3.754 4.214,0.274 2.389,-1.965 -3.275,-2.865 1.866,-2.062 1.831,3.232 3.007,-2.357 2.298,1.207 -0.129,-1.525 2.286,0.419 -0.922,-1.553 2.244,0.677 -2.356,-3.857 3.997,2.106 -2.192,-2.852 4.984,1.374 0.283,-1.903 1.996,1.714 2.063,-1.164 -1.303,-1.188 1.911,0.902 0.524,-1.753 0.573,1.2 7.053,-2.948 -5.371,-0.147 4.005,-0.828 -1.559,-1.514 2.486,1.275 3.666,-0.801 1.783,-1.286 -0.697,-2.463 -4.047,-0.239 2.395,-0.755 -6.086,-3.411 -0.066,-0.008 m 167.491,145.922 2.936,-4.169 -0.662,-1.304 -3.606,1.494 1.568,-1.733 -0.473,-5.947 -2.754,-1.624 -3.44,2.155 -0.063,0.118 -2.05,-3.445 -0.962,-0.222 -1.695,0.588 1.961,-1.51 -1.344,-1.732 -4.575,-0.747 -6.681,-5.656 -5.282,1.209 2.956,-2.422 -2.461,0.435 1.688,-2.061 -1.396,-6.316 -6.481,3.954 0.14,-7.712 -5.049,2.458 2.225,4.288 -2.092,0.691 3.329,3.41 -1.222,3.031 3.428,-1.42 1.801,8.466 -0.17,-3.535 0.546,-2.587 1.794,1.188 -1.39,0.375 2.392,6.104 1.476,0.816 -0.683,-1.264 4.786,-2.997 -0.257,3.299 2.728,1.695 0.473,-1.432 1.179,4.101 1.803,0.41 -4.038,2.882 -0.521,3.023 1.769,-1.667 1.418,1.813 -2.287,5.665 7.25,-0.126 1.99,-3.791 -0.349,4.375 -3.648,1.661 -1.664,8.259 6.195,-3.873 -0.789,-2.784 10.242,-5.88 0.011,-0.007 m -204.82,50.769 5.462,-4.5 0.686,2.812 -2.308,3.43 3.042,-1.96 -0.896,3.409 1.875,0.383 3.086,-5.061 -0.407,-1.809 -2.227,1.279 2.086,-3.522 -3.229,3.52 -1.167,-2.251 1.528,-0.976 -1.197,-1.285 4.123,-1.287 -4.882,0.231 3.701,-4.917 -3.876,-0.453 0.438,-1.851 -4.158,2.527 1.521,-2.82 -3.892,-0.002 3.213,-2.707 -2.832,-0.259 0.486,-1.326 -3.5,3.106 6.315,-8.329 -0.947,-1.824 2.177,0.339 -1.157,-1.788 -6.805,4.381 -2.863,7.099 -2.099,-0.051 0.68,2.848 -1.708,-1.44 -4.271,3.181 3.886,0.559 -5.291,2.672 0.454,2.166 3.637,-0.602 5.373,2.717 4.758,-1.803 -1.969,2.724 5.92,-0.229 -5.995,3.37 3.223,0.301 0.006,-0.002 m -57.71,-179.463 -2.702,1.977 4.455,4.888 6.039,0.791 -1.819,3.767 3.857,3.857 2.038,-2.354 -2.969,0.284 2.737,-2.407 0.082,1.689 3.123,0.053 -0.857,1.482 2.584,-1.803 1.05,-6.794 8.809,-6.332 1.456,-2.915 -1.685,-1.2 -8.133,4.963 6.004,-6.196 -0.57,-0.86 -2.325,2.498 0.219,-1.434 -1.811,0.411 -0.64,-1.154 2.987,-0.21 0.594,-2.443 -3.226,-0.916 4.527,-1.85 -6.631,-2.537 -4.403,0.844 -0.054,1.891 -1.756,0.024 2.221,3.554 -4.244,-2.88 -2.06,1.766 2.392,4.658 -0.607,3.965 -4.97,-6.804 -3.113,2.696 -0.597,5.029 -0.002,0.002 m 180.694,78.376 3.992,-3.785 1.408,-4.44 -1.575,-0.223 1.612,-0.761 -6.332,-4.117 0.814,-1.848 -1.418,1.718 -2.65,-1.451 0.164,2.604 -4.068,0.547 1.603,2.641 -2.825,-2.437 -0.486,2.867 -3.092,-1.402 0.123,5.296 -2.088,-4.4 -4.978,-1.373 2.652,2.856 -3.062,-1.463 1.339,2.683 -2.223,-0.31 1.204,1.32 -1.791,0.505 6.98,-1.098 -1.783,1.905 2.236,0.455 -5.322,1.837 7.541,1.355 -2.429,3.884 3.981,-1.647 6.939,1.574 3.534,-3.292 v 0 m 54.155,56.066 4.322,-4.301 -5.057,-9.501 1.554,-3.774 -4.156,-3.075 -2.817,2.636 0.524,-1.719 -1.755,-0.212 0.418,2.551 -1.755,-1.002 -1.085,3.834 2.223,-0.553 -0.074,2.865 -4.977,1.707 2.842,1.766 -1.017,2.903 4.603,-0.45 -1.757,4.872 3.73,-2.042 -4.32,4.335 2.15,-0.289 -1.351,2.521 2.677,-1.247 -1.337,2.25 2.027,-1.521 -0.347,1.976 4.73,-4.521 v -0.009 m -186.128,-130.199 0.083,3.425 3.19,-0.278 -1.084,2.347 5.071,2.757 1.557,-1.381 0.342,2.974 4.57,-0.097 -0.758,-1.194 2.624,-1.297 -0.979,-2.703 -7.255,-1.628 -0.858,-2.813 -1.307,0.816 1.619,-2.834 -2.066,-0.261 2.069,-0.126 -0.38,-1.752 2.111,1.844 -1.104,-2.392 1.369,-0.336 -3.495,-0.961 2.421,-1.874 -2.121,-2.481 -2.608,3.475 2.586,1.307 -5.563,5.433 -0.034,0.03 m -16.175,-21.211 3.362,0.426 -2.35,1.054 2.624,2.229 -4.868,-1.926 -0.57,2.704 5.51,1.849 1.577,2.671 4.682,-1.678 0.477,-1.575 -2.441,0.871 0.079,-1.395 5.151,-3.558 -3.267,0.017 -4.068,3.524 -1.018,-2.251 4.115,-5.582 -1.69,-0.419 -0.22,1.4 -2.289,-1.382 0.67,1.822 -2.702,-1.63 1.48,1.845 -3.53,-1.615 -0.725,2.593 0.011,0.006 m 33.583,6.377 -0.239,2.936 -1.425,-0.517 -0.591,1.481 1.79,1.792 1.73,-1.883 -1.237,2.266 4.369,-2.541 -1.135,1.541 4.925,-0.747 0.848,-1.675 -1.696,-0.587 3.749,-3.085 -1.973,0.753 2.892,-6.688 -3.886,0.692 -0.445,1.781 -2.49,-1.022 -0.525,2.343 -0.537,-1.778 -1.314,0.808 0.861,1.649 -2.953,1.052 3.173,2.898 -3.88,-1.472 -0.011,0.003 m 119.01,5.537 3.2,0.134 -7.811,-7.024 -0.188,-2.61 -6.401,-0.386 0.966,1.126 -4.351,-1.229 5.928,3.296 -5.524,-1.61 2.122,2.024 -2.659,-0.024 -0.474,-1.754 -0.529,2.799 8.023,3.015 -1.465,-3.541 1.986,1.171 -0.507,-1.534 1.986,0.327 -0.843,3.672 1.906,0.873 1.175,-2.749 -0.271,2.416 1.969,-0.332 -1.973,1.314 3.735,0.626 v 0 m 30.638,-34.101 -3.154,-0.354 0.493,-0.887 -5.767,-2.668 -7.901,-6.773 -4.276,-0.08 5.111,3.314 1.425,3.319 7.607,5.542 2.837,-0.564 2.91,2.303 1.064,-1.156 -0.643,1.318 2.309,1.818 0.543,-2.217 2.017,2.271 0.157,-2.844 -2.811,-0.092 0.371,-1.247 -1.238,0.886 0.397,-1.295 -2.402,0.069 0.951,-0.659 v -0.004 m -284.221,348.573 4.442,-0.024 -6.859,-5.718 0.642,-2.371 -5.238,-3.575 -10.577,-15.368 -5.306,-4.813 -12.728,-4.395 -2.185,3.209 -2.928,-1.006 3.761,2.148 6.518,-1.12 3.686,2.32 0.614,1.539 -2.298,-0.724 1.144,2.063 12.417,10.124 1.504,6.192 3.957,2.537 0.172,1.97 -3.49,1.42 12.752,5.592 v 0 m 16.555,18.333 2.806,-1.449 10.003,4.956 1.995,-1.638 -6.135,-4.979 2.607,-0.361 -2.987,-0.969 -0.688,-2.607 -13.74,-7.007 -3.353,0.177 3.393,2.812 -1.044,2.061 1.744,3.713 -8.857,-4.579 -1.55,0.799 2.444,3.466 9.132,2.549 2.478,4.699 1.749,-1.639 h 0.003 m 146.269,-449.31 3.471,-0.24 -2.689,0.183 -2.845,0.217 1.406,-0.11 9.647,-0.601 3.966,-0.169 -3.662,0.155 -3.989,0.212 8.437,-0.266 2.566,0.849 1.594,-0.103 -2.049,-0.199 3.629,-0.218 0.372,-0.328 -2.571,-0.167 -17.272,0.784 -0.011,10e-4 m -66.003,132.783 5.383,-3.02 -0.654,-2.775 5.087,-1.022 -2.972,-3.958 -1.846,1.79 -0.557,-1.45 0.128,2.718 -2.491,0.987 -0.218,-3.054 -2.45,0.775 -3.631,8.046 1.406,0.861 2.28,-1.663 -1.193,0.896 1.705,0.877 0.023,-0.008 m -10.755,52.367 2.985,-0.623 -0.364,-2.525 -2.659,-0.539 2.415,-2.472 -1.526,-7.299 -1.76,0.725 1.542,-3.902 -8.301,7.432 -3.87,1.058 3.322,1.255 -1.461,3.352 8.39,-2.27 -0.946,3.034 2.209,2.773 0.024,0.001 m 217.865,-94.39 -0.596,-4.63 -6.293,1.745 -3.912,-0.616 -3.592,-2.228 -0.316,1.826 0.819,1.942 1.478,-0.177 1.133,1.654 0.303,-1.425 4.888,3.717 2.157,-0.108 -0.655,-2.095 4.567,0.405 0.019,-0.01 m -289.143,-16.689 0.116,0.612 -1.532,0.024 0.893,1.901 1.417,-0.862 -1.244,1.337 1.924,-0.491 2.029,-2.076 -1.506,0.042 1.623,-0.958 -3.107,1.123 2.62,-2.062 -0.979,-0.202 -2.25,1.609 -0.004,0.003 m 230.21,26.319 -3.133,0.375 0.513,1.656 -2.28,-0.857 2.593,1.691 -4.136,0.106 1.889,1.045 -0.944,1.082 2.688,0.594 1.123,-2.048 0.974,1.947 3.336,-1.553 -2.612,-4.038 h -0.011 m -134.78,18.808 1.848,1.664 2.459,-0.607 5.496,-5.045 -1.903,0.458 -0.807,-1.872 -2.479,2.762 1.567,-3.335 -2.621,2.68 -2.339,-1.118 2.675,2.567 -2.598,0.05 -1.335,1.764 0.037,0.032 m -28.104,-13.475 10.701,2.339 3.139,-3.987 -1.974,-1.058 2.6,-3.507 -1.85,-3.077 -3.328,2.05 -10.745,0.483 0.116,1.345 -4.698,3.863 3.05,2.242 2.973,-0.702 0.016,0.009 m -122.337,52.105 1.458,1.32 -2.553,1.076 -0.469,5.654 7.836,-11.828 1.5,-8.851 -1.574,2.007 0.867,1.063 -2.389,0.281 0.29,1.968 -4.963,7.31 h -0.003 m 28.385,-33.872 -1.584,1.708 2.857,-1.421 0.588,-1.91 0.473,1.051 4.744,-5.428 -3.808,2.267 -0.026,1.011 -1.64,0.151 -1.608,2.568 0.004,0.003 m -10.506,6.554 1.061,0.232 0.674,-1.94 4.595,-0.951 -2.916,-0.316 2.182,-0.475 0.974,-2.531 -5.503,4.063 -4.642,6.185 3.555,-4.255 0.02,-0.012 m 214.293,-99.042 -8.911,0.204 2.091,2.128 -1.746,-1.753 -2.902,1.316 6.25,1.587 1.148,-1.562 2.639,1.628 2.805,-1.581 -1.374,-1.963 v -0.004 m -85.748,271.714 -1.249,-2.446 -2.927,3.155 -1.516,-0.276 3.879,-2.707 1.163,-4.391 -6.063,4.771 0.251,3.157 6.456,-1.24 0.006,-0.023 m 8.376,-204.834 -1.352,-1.628 -8.804,-0.705 1.978,1.155 -1.697,1.619 6.085,-0.014 -2.795,1.688 6.391,-0.5 0.202,-1.618 -0.008,0.003 m -5.257,47.812 1.406,-3.815 2.805,-3.068 6.139,-2.971 -1.579,-1.8 -5.94,0.458 -8.682,5.878 2.872,3.785 2.975,1.53 0.004,0.003 m 237.453,62.845 -0.721,-4.084 -2.952,-1.844 1.439,2.606 -1.945,-0.99 -1.039,2.658 7.065,3.627 -1.844,-1.976 v 0.003 M 946.5,605.9 l -3.223,-2.156 -3.538,1.822 0.032,1.166 1.791,0.039 -1.313,0.649 6.254,1.174 10e-4,-2.691 -0.004,-0.003 m -109.359,56.223 3.958,-3.608 -0.003,-4.698 -2.715,1.667 0.543,1.321 -3.128,0.432 1.61,0.836 -0.267,4.059 0.002,-0.009 m -124.226,1.114 2.609,-2.869 -1.428,2.222 1.334,-0.338 1.389,-3.293 -4.463,2.854 1.96,-0.82 -1.397,2.238 -0.004,0.006 m 98.408,21.717 3.855,-0.153 0.663,-1.999 2.223,2.166 7.454,-2.67 -4.853,-4.686 -9.369,7.332 0.027,0.01 m 156.106,-25.694 -4.02,-0.859 -0.453,1.823 3.546,1.896 0.081,-1.695 2.115,0.904 -1.267,-2.074 -0.002,0.005 m -193.558,115.357 2.5,0.261 -0.763,1.001 2.635,-2.312 -1.787,1.44 1.737,-3.092 -4.332,2.704 0.01,-0.002 m 100.713,-48.962 -1.864,-3.793 -3.02,-0.552 -0.88,3.196 2.993,0.606 -1.48,1.5 4.24,-0.948 0.011,-0.009 m 284.724,99.196 2.897,-4.089 -0.671,-2.002 -0.361,2.462 -6.357,3.93 1.23,1.932 3.259,-2.235 v 0.002 m -531.492,221.218 1.051,-0.288 -2.247,-6.075 -0.89,0.102 2.01,4.425 h -1.659 l 1.733,1.836 h 0.002 m 129.935,173.648 1.355,0.542 -3.304,-1.772 -1.927,-0.829 0.54,0.375 1.439,0.84 1.891,0.842 h 0.006 m -54.219,-545.027 -1.928,0.413 -0.266,0.944 1.243,-0.422 -1.863,0.726 0.493,0.77 2.321,-2.431 m 242.95,-72.952 -6.899,-1.433 -0.818,2.213 2.61,-0.147 -2.207,1.305 7.331,-1.938 h -0.017 m -2.542,7.229 -3.622,-1.266 -2.413,0.511 -0.823,2.381 7.304,-0.042 -0.449,-1.583 0.003,-10e-4 m -235.026,334.149 0.746,1.264 1.834,-3.568 -1.842,-3.252 1.347,3.102 -2.085,2.436 v 0.018 m 394.662,-95.863 2.801,-4.297 -3.083,-6.876 -4.026,-2.449 -2.235,4.024 6.551,9.611 -0.01,-0.013 m -298.155,3.877 4.362,-1.72 -7.665,-2.193 0.905,-3.468 -2.286,2.148 4.677,5.212 0.007,0.021 m -105.919,137.751 3.888,1.421 -2.766,-4.28 -6.709,-2.991 2.179,4.117 3.407,1.73 10e-4,0.003 m 34.154,-384.917 0.427,0.914 1.516,-1.361 -1.813,0.706 1.105,-1.701 -1.233,1.437 -0.002,0.005 m 441.962,198.088 0.26,-5.107 -1.277,-0.787 -0.568,-4.06 -1.274,9.731 2.858,0.229 10e-4,-0.006 m -399.096,257.528 0.624,-3.637 -4.145,-0.334 1.015,2.484 -2.743,0.614 5.249,0.859 v 0.014 m -71.278,-105.626 -1.231,-0.702 1.079,-1.267 -1.373,0.337 0.688,2.465 0.846,-0.829 -0.009,-0.004 m 128.799,-260.053 0.131,1.7 5.126,1.796 0.505,-3.942 -3.796,-3.222 -1.961,3.665 -0.005,0.003 m 192.916,-42.312 -2.107,-2.503 -2.316,0.814 2.325,2.126 2.099,-0.43 v -0.007 m -212.841,182.475 1.029,-1.226 -2.571,-2.844 -6.173,-3.127 7.708,7.2 0.007,-0.003 m 334.924,-32.475 0.558,-1.006 -1.74,-0.968 -0.546,1.991 1.727,-0.018 10e-4,10e-4 m -436.163,149.753 -0.562,2.191 0.923,-2.835 -2.115,-3.718 1.759,4.358 -0.005,0.004 m 64.568,-355.263 -0.181,1.203 7.376,-3.981 -1.727,-0.101 -5.476,2.879 h 0.008 m -67.624,70.572 -2.93,2.009 0.046,1.031 2.312,-0.84 0.59,-2.223 -0.018,0.023 m 44.241,342.94 2.335,-1.664 -8.607,-2.594 0.013,2.52 6.255,1.74 h 0.004 m 297.65,-248.823 1.516,1.967 1.964,-1.021 -2.436,-2.4 -1.04,1.446 v 0.008 m 97.009,50.797 -2.727,-2.434 -3.092,0.475 -0.419,2.095 6.232,-0.128 0.01,-0.008 m -147.592,-38.739 0.743,1.195 0.762,-1.688 -1.086,-3.271 -0.415,3.762 v 0.002 m 4.846,-74.227 -0.498,-3.922 0.222,2.03 -1.964,-1.305 2.231,3.195 0.01,0.002 m -302.339,252.534 1.647,-1.496 -1.203,-3.89 -2.034,2.833 1.586,2.552 0.004,0.001 m 225.428,-241.624 3.837,0.949 -2.955,-3.06 -2.393,0.403 1.502,1.709 0.009,-10e-4 m -241.139,-20.395 0.713,0.122 -1.964,1.851 4.235,-3.823 -2.983,1.847 v 0.003 m -10.067,265.903 2.128,0.595 -0.198,-2.096 -1.193,-1.052 -0.765,2.536 0.028,0.017 m 317.074,-334.985 -1.919,-0.284 0.953,1.298 2.138,0.089 -1.166,-1.093 -0.006,-0.01 m -187.736,51.34 3.575,-1.205 -0.851,-2.402 -1.586,0.206 -1.166,3.384 0.028,0.017 m 81.535,-88.123 -3.197,-0.382 -2.648,1.329 7.277,0.492 -1.431,-1.436 -10e-4,-0.003 m 5.977,-4.842 -0.83,0.66 2.619,1.013 3.864,-1.277 -5.645,-0.396 h -0.008 m 189.96,279.008 0.583,-3.158 -1.564,-0.794 -2.008,3.783 2.989,0.172 v -0.003 m 13.246,-24.39 -0.347,-4.583 -3.188,-4.38 -0.584,5.313 4.119,3.65 v 0 m -305.838,-141.513 0.677,4.674 3.702,0.066 1.607,-7.029 -5.993,2.285 0.007,0.004 m -80.111,-25.868 3.871,-2.051 1.51,-2.158 -7.271,3.807 1.889,0.406 10e-4,-0.004 m 417.901,177.588 -3.003,-9.633 -8.141,9.196 1.845,1.919 9.294,-1.478 0.01,-0.004 M 757.801,602.26 l 2.805,-0.944 1.4,-1.982 -4.293,2.14 0.085,0.787 0.003,-10e-4 m -25.748,6.292 -1.478,1.591 2.806,-1.613 0.213,-1.677 -1.538,1.696 -0.003,0.003 m 92.515,111.858 -1.995,-2.588 -4.004,4.44 3.416,0.932 2.546,-2.761 0.037,-0.023 m -33.461,16.082 -3.389,0.644 -0.762,1.829 6.703,-1.382 -2.545,-1.092 -0.007,10e-4 m -14.939,290.692 2.512,-0.784 -1.43,-1.89 -1.968,0.633 0.885,2.045 h 10e-4 m 55.021,-373.253 -1.25,-2.481 -2.302,0.82 0.289,2.135 3.25,-0.482 0.013,0.008 m 114.651,-45.175 -1.608,0.026 1.387,1.674 1.521,-0.793 -1.295,-0.9 -0.005,-0.007 m -106.733,55.518 3.29,-0.831 -0.04,-3.44 -3.744,2.576 0.467,1.682 0.027,0.013 m 403.03,304.999 0.072,-0.934 -0.399,2.438 0.16,0.182 0.166,-1.683 10e-4,-0.003 m -222.637,-334.3 -1.398,-0.808 -2.206,1.73 2.435,0.528 1.169,-1.45 m 40.401,88.74 -0.338,1.088 1.714,0.104 0.216,-1.601 -1.592,0.409 m -301.639,-119.402 1.576,-0.824 -0.024,-1.065 -1.408,0.68 -0.144,1.209 m 249.538,174.625 -0.017,2.058 1.506,-1.445 -1.484,-0.614 v 0.001 m -175.793,-128.105 2.669,2.394 0.958,-1.709 -3.63,-0.698 0.003,0.013 m 97.772,55.222 -3.271,-1.166 -1.595,1.508 4.86,-0.341 0.006,-10e-4 m 281.12,52.359 -0.798,-1.901 1.636,5.098 -0.835,-3.182 v -0.015 m 21.105,107.123 0.485,-1.408 -1.003,0.229 0.514,1.194 v -0.015 m -127.604,-61.565 -1.283,-0.247 2.637,0.855 -1.352,-0.608 v 0 m -496.342,25.208 -0.257,1.909 1.188,-2.176 -0.928,0.264 -0.003,0.003 m 397.758,-53.915 -2.686,-0.991 3.381,2.373 -0.692,-1.381 v -10e-4 m 53.696,-33.004 2.694,4.236 -3.662,-6.396 0.967,2.153 10e-4,0.007 m -54.807,-44.73 -1.843,-1.849 0.556,2.183 1.281,-0.335 0.01,10e-4 m -50.587,-32.115 2.405,0.331 -4.521,-1.306 2.111,0.973 0.005,0.002 m 184.936,156.336 1.408,-0.888 -1.815,-1.115 0.402,1.962 0.01,0.041 m -374.238,401.088 -1.02,-0.447 -1.098,-0.449 2.115,0.895 h 0.003 m -45.697,-252.81 0.004,0.01 0.968,-1.341 -2.704,2.28 1.732,-0.949 m 13.876,-335.816 1.684,0.019 -2.326,-0.715 0.635,0.699 0.007,-0.003 m 226.672,3.629 -2.185,-2.955 -2.419,-0.188 4.604,3.146 v -0.003 m -260.991,36.214 -0.842,1.138 2.691,-2.256 -1.841,1.107 -0.008,0.011 m 365.362,54.775 -0.527,-4.515 -2.26,2.576 2.765,1.94 0.022,-10e-4 M 729.103,626.29 l 0.6,1.282 1.391,-1.784 -1.982,0.498 -0.009,0.004 m 98.532,-36.968 -3.799,3.547 4.611,-1.459 -0.812,-2.089 v 10e-4 m 194.64,367.244 2.082,-4.163 -3.583,2.362 1.493,1.795 0.01,0.006 m -18.083,-265.771 -1.326,0.065 1.801,2.791 -0.474,-2.853 v -0.003 m -164.969,431.045 2.097,-1.696 -4.486,0.104 2.379,1.592 h 0.01 m -10.028,-359.639 1.349,-1.14 -1.993,-0.522 0.64,1.661 0.004,10e-4 m 11.562,-182.143 0.003,0.765 2.708,-0.643 -2.708,-0.124 -0.003,0.002 m -89.146,286.52 5.512,1.653 2.343,-1.422 -7.851,-0.234 -0.004,0.003 m 72.733,-193.519 1.312,3.739 3.576,-4.069 -4.874,0.331 -0.014,-10e-4 m -116.28,-5.657 1.524,-1.247 -4.785,2.482 3.263,-1.239 -0.002,0.004 m 0.8,-2.403 -3.122,2.104 7.367,-4.819 -4.246,2.709 10e-4,0.006 m 101.92,-100.225 2.708,-0.588 -4.263,0.815 1.549,-0.226 0.006,-10e-4 m 430.317,262.668 -0.544,-3.118 0.525,4.797 0.02,-1.673 -10e-4,-0.006 m -205.912,124.031 -0.125,-3.354 -2.12,4.933 2.241,-1.578 v -0.001 M 804.34,709.075 l -0.685,1.449 2.251,-2.546 -1.552,1.075 -0.014,0.022 m -4.176,12.907 1.317,1.144 -0.601,-3.365 -0.719,2.206 0.003,0.015 m -41.213,64.45 2.707,3.732 0.448,-3.304 -3.156,-0.431 10e-4,0.003 m -79.842,110.463 h -0.002 l -1.142,-0.602 2.969,1.614 -1.825,-1.012 m 483.275,-86.051 -0.98,-3.049 0.021,2.984 0.96,0.071 -10e-4,-0.006 m -346.819,-159.142 2.458,-0.47 -3.533,-0.657 1.075,1.124 v 0.003 m 22.92,-96.138 0.317,0.013 2.179,-0.507 -2.471,0.49 -0.025,0.004 m 322.873,477.795 1.083,-0.052 0.815,-3.302 -1.899,3.346 10e-4,0.01 m -228.576,-338.047 2.02,-0.67 -1.896,-1.652 -0.125,2.321 0.001,10e-4 m 24.909,-64.254 1.973,-0.451 -1.563,-1.019 -0.42,1.478 0.01,-0.008 m -282.904,454.79 0.955,-0.657 -1.493,-0.809 0.53,1.469 h 0.008 m 46.543,-106.069 1.029,-1.631 -3.655,0.4 2.622,1.233 0.004,-0.002 m 38.745,70.784 -2.073,-0.479 3.482,0.856 -1.378,-0.393 -0.031,0.016 m 184.239,-462.301 -0.514,-1.012 -1.781,0.351 2.28,0.657 0.015,0.004 m 92.376,357.825 -0.268,-1.405 -1.432,2.826 1.701,-1.416 -10e-4,-0.005 M 802.547,741.05 l 1.804,-1.124 -1.893,-1.015 0.085,2.135 0.004,0.004 m 192.182,298.177 1.632,-0.287 -1.93,-1.547 0.31,1.821 -0.012,0.013 m -101.337,-376.609 1.853,2.731 0.146,-2.065 -1.958,-0.698 -0.041,0.032 m -173.758,329.092 -1.439,-0.795 2.142,2.236 -0.695,-1.438 -0.008,-0.003 m 242.937,-331.861 -1.734,-1.619 -0.209,1.417 1.934,0.202 h 0.009 m -141.08,49.034 1.732,-0.56 -2.586,-0.727 0.854,1.31 v -0.023 m -28.055,36.622 2.54,-0.605 0.728,-2.288 -3.262,2.875 -0.006,0.018 m -59.277,290.036 h 0.002 l 1.279,1.421 -1.969,-2.63 0.688,1.206 m 294.626,-80.828 -1.734,-0.538 -0.409,1.711 2.14,-1.167 v -0.006 m -121.753,-403.374 1.215,0.213 1.489,-0.189 -2.707,-0.025 0.003,10e-4 m -104.393,35.284 -0.141,0.082 -1.147,0.873 2.722,-1.721 -1.434,0.766 m 28.204,72.444 1.417,-1.668 -2.84,2.66 1.436,-0.98 -0.013,-0.012 m 126.648,-29.925 -3.112,-1.303 0.836,1.457 2.3,-0.138 -0.024,-0.016 m -194.596,-47.809 -1.775,0.794 3.318,-1.449 -1.528,0.647 -0.015,0.008 m 77.001,84.734 -2.426,-1.153 1.305,2.441 1.116,-1.273 0.005,-0.015 m -12.858,55.392 -1.835,-0.839 1.807,2.286 0.037,-1.433 -0.009,-0.014 m 326.672,332.394 0.253,0.859 1.005,-1.981 -1.258,1.118 v 0 m -224.373,-353.85 3.121,-0.324 -2.048,-0.885 -1.07,1.205 -0.003,0.004 m -87.166,-30.613 -0.922,-0.907 -0.966,1.882 1.891,-0.958 -0.003,-0.017 m 222.594,90.686 -1.29,-1.276 -0.13,1.847 1.42,-0.571 m -237.725,-196.528 -2.384,1.42 2.829,-0.87 -0.445,-0.55 m 97.671,157.23 4.72,-1.668 -1.458,-2.096 -3.262,3.764 m 3.608,-13.476 4.043,0.2 -1.584,-1.218 -2.459,1.018 m -173.408,-121.34 -0.644,0.547 1.811,-0.982 -1.167,0.435 m 307.104,153.772 -2.669,-5.405 0.158,3.257 2.511,2.148 m -369.543,-55.63 -2.082,2.355 3.454,-3.606 -1.372,1.251 m 6.817,276.918 1.006,1.234 -1.002,-1.249 -0.004,0.015 m 304.033,-265.603 -0.715,-1.997 0.708,1.989 0.01,0.008 m -212.6,-6.134 -1.186,1.363 1.194,-1.363 h -0.008 m 218.086,95.026 0.458,-1.802 -0.473,1.775 0.015,0.027 m -401.025,38.97 -0.744,3.793 0.75,-3.795 -0.006,0.002 m 359.738,84.413 3.435,-0.029 -3.435,0.024 v 0.005 m 144.591,-101.064 1.217,-1.161 -1.223,1.153 0.01,0.008 m -400.623,152.782 1.313,1.654 -1.309,-1.657 -0.004,0.003 m 42.549,-372.963 -1.162,0.952 1.169,-0.954 -0.007,0.002 m 234.454,163.683 1.568,1.12 -1.564,-1.121 -0.004,10e-4 m 15.755,-73.748 -1.262,0.453 1.26,-0.45 v -0.003 m -49.05,-49.145 -3.322,-1.112 3.318,1.116 0.004,-0.004 M 601.282,823.835 v 0 l 0.953,-0.814 -0.953,0.814 m 355.74,-185.118 -0.207,-2.483 0.206,2.486 0.001,-0.003 m -120.428,480.443 0.086,1.357 -0.086,-1.376 v 0.019 m -9.331,-351.586 1.081,1.107 -1.077,-1.117 -0.004,0.01 m 8.223,-16.717 0.371,2.086 -0.369,-2.09 -0.002,0.004 m 167.838,-63.941 -0.641,1.395 0.644,-1.394 v -10e-4 m -274.257,-73.079 -1.44,0.86 1.444,-0.861 -0.004,10e-4 m 102.711,142.729 1.628,0.335 -1.623,-0.348 -0.005,0.013 m 254.673,95.467 -0.01,0.005 1.246,-0.432 -1.238,0.427 m -401.807,-158.347 -0.004,-0.001 -1.029,0.252 1.033,-0.251 m 133.928,71.855 0.111,-1.752 -0.115,1.75 0.004,0.002 m 187.117,-67.194 v 0.002 l -0.121,1.679 0.123,-1.681 m -336.58,332.825 v 0.01 l 0.451,1.508 -0.451,-1.517 m 136.621,-290.524 0.104,-1.678 -0.111,1.682 0.007,-0.004 m 202.631,22.147 1.156,1.188 -1.164,-1.202 0.01,0.014 m -179.635,29.075 1.502,0.688 -1.499,-0.69 -0.003,0.002 m 66.111,-31.193 2.107,1.462 -2.107,-1.466 v 0.004 m -116.673,279.622 0.554,-1.856 -0.581,1.844 0.027,0.012 m 336.586,-233.414 0.01,-0.01 -0.945,0.85 0.935,-0.84 m 109.879,-31.38 -1.159,-2.848 1.145,2.82 0.014,0.028 M 954.832,602.43 l -1.427,-0.06 1.431,0.063 -0.004,-0.003 m 99.933,117.327 -0.292,-2.032 0.265,2.009 0.027,0.023 m -99.857,-87.603 0.002,0.012 0.762,-1.717 -0.764,1.705 m -2.869,-1.351 1.254,0.904 -1.254,-0.907 v 0.003 m -71.97,144.269 1.596,-0.777 -1.595,0.772 -0.001,0.005 m 127.709,-23.331 0.393,1.252 -0.385,-1.256 -0.01,0.004 m -154.013,469.999 0.735,-0.812 -0.735,0.812 v 0 m -196.959,-248.585 -0.006,-0.004 -1.145,-0.044 1.151,0.048 m -27.058,72.72 1.484,0.905 -1.481,-0.907 h -0.003 m 364.685,-432.328 -0.002,-0.003 -1.716,-1.375 1.718,1.378 m -18.506,-3.239 -1.765,0.195 1.761,-0.187 0.004,-0.008 m -301.101,98.655 -0.976,2.146 0.983,-2.152 -0.007,0.006 m 459.398,107.781 -2.116,-1.087 2.108,1.084 0.01,0.003 m -474.08,133.379 1.313,-0.1 -1.309,0.097 -0.004,0.003 m 478.151,-130.733 -0.537,-1.88 0.534,1.876 v 0.004 m -91.561,-94.641 1.265,0.438 -1.267,-0.445 v 0.007 m -56.696,26.87 -1.975,-1.119 1.975,1.119 v 0 m 19.435,30.455 v -0.003 l 0.396,-1.199 -0.398,1.202 m -188.908,-69.971 3.063,-0.845 -3.056,0.833 -0.007,0.012 m 208.946,-90.212 -1.467,-0.831 1.455,0.839 0.012,-0.008 m -377.72,342.48 1.021,-1.022 -1.017,1.005 -0.004,0.017 m -2.146,-82.35 -0.007,0.004 1.239,-0.123 -1.232,0.119 m 84.483,-246.869 -0.225,0.941 0.232,-0.938 -0.007,-0.003 m -23.799,27.671 1.764,-0.736 -1.768,0.734 0.004,0.002 m 30.34,216.819 1.473,-1.504 -1.477,1.5 0.004,0.004 m 35.802,150.253 0.997,1.882 -0.994,-1.913 -0.003,0.031 m -58.489,-62.734 1.465,1.316 -1.462,-1.331 -0.003,0.015 m 55.914,-376.078 0.01,-0.007 -2.278,1.122 2.268,-1.115 m 216.682,162.659 1.486,0.885 -1.486,-0.885 v 0 m -59.48,-63.268 0.003,10e-4 -2.446,-3.168 2.443,3.167 m 58.893,340.476 2.391,-0.095 -2.392,0.081 0.001,0.014 m 64.336,-266.935 -1.557,-0.426 1.553,0.429 v -0.003 m -283.06,16.541 2.16,0.426 -2.148,-0.429 -0.012,0.003 m -66.848,-107.672 -0.004,0.006 1.78,-1.557 -1.776,1.551 m 510.154,107.419 -0.622,-0.431 0.629,0.441 -0.01,-0.01 m -599.998,3.503 -0.067,-1.381 0.065,1.369 0.002,0.012 m 390.345,-101.919 -0.93,-1.58 0.925,1.585 v -0.005 m 96.343,121.108 1.6,1.752 -1.598,-1.754 v 0.002 m -88.695,-92.057 -0.499,-1.221 0.484,1.208 0.015,0.013 m 127.132,93.942 1.058,-0.627 -1.063,0.625 0.01,0.002 m 11.041,6.053 -1.288,-0.029 1.302,0.048 -0.014,-0.019 m -219.253,-113.929 -1.207,-1.309 1.206,1.312 10e-4,-0.003 M 641.4,882.424 l 2.132,-0.42 -2.13,0.416 -0.002,0.004 m 116.945,337.632 1.226,0.54 -1.228,-0.54 h 0.002 m -33.479,-593.335 0.289,0.576 -0.289,-0.578 v 0.002 m 415.899,195.86 1.413,-0.224 -1.416,0.22 v 0.004 m -441.443,-145.8 h -10e-4 l 1.436,-0.675 -1.435,0.675 m 79.257,359.158 0.017,0.01 -0.994,-1.987 0.977,1.981 m -147.668,-137.788 1.357,-1.92 -1.351,1.903 -0.006,0.017 m 328.283,-188.062 0.823,-2.243 -0.845,2.251 0.022,-0.008 m -179.776,344.212 -0.047,-0.011 -1.583,0.143 1.63,-0.132 m 58.607,64.366 -0.525,1.115 0.55,-1.112 h -0.025 m -122.478,-153.635 -0.982,-4.645 0.981,4.642 10e-4,0.003 m 516.443,-112.018 -0.564,-0.071 0.565,0.078 -10e-4,-0.007 m -634.813,-1.097 -0.044,2.094 0.046,-2.091 -0.002,-0.003 m 554.248,-45.592 -1.535,-2.124 1.524,2.12 0.011,0.004 m -343.98,-240.589 -2.76,0.633 2.766,-0.632 -0.006,-10e-4 m 193.177,209.604 1.231,-0.771 -1.233,0.766 v 0.005 m -242.037,92.188 2.161,0.391 -2.165,-0.392 0.004,10e-4 m 80.476,-158.069 1.683,-0.514 -1.683,0.514 v 0 m -141.193,249.922 1.75,1.586 -1.749,-1.591 -10e-4,0.005 m 317.964,-233.262 0.728,-1.276 -0.734,1.269 0.01,0.007 m -172.778,395.86 -2.818,0.144 2.823,-0.143 -0.005,-10e-4 m 237.472,-259.913 -0.946,1.411 0.949,-1.413 v 0.002 m -50.525,-240.118 -0.01,-0.007 0.272,0.975 -0.267,-0.968 m -300.81,4.115 0.914,-0.901 -0.914,0.901 v 0 m 289.235,164.76 0.239,-2.477 -0.247,2.463 0.01,0.014 m -3.509,162.947 1.189,1.672 -1.184,-1.681 v 0.009 m 192.382,-122.596 0.692,-0.438 -0.703,0.419 0.011,0.019 m 11.4,-53.889 -0.166,-1.316 0.16,1.306 0.01,0.01 m -492.3,-161.719 0.797,0.211 -0.79,-0.213 -0.007,0.002 m -51.784,87.35 -1.107,1.531 1.108,-1.527 -10e-4,-0.004 m 70.738,-110.487 10e-4,-0.002 -2.722,1.839 2.721,-1.837 m -10.362,299.347 -2.077,2.947 2.095,-2.938 -0.018,-0.009 m 249.808,137.97 1.941,-0.982 -1.942,0.973 10e-4,0.01 m -174.672,-282.29 0.009,0.003 -1.336,-0.842 1.327,0.839 m 23.093,373.871 2.342,0.316 -2.34,-0.317 -0.002,10e-4 m 409.806,-157.786 -0.196,1.95 0.198,-1.962 v 0.012 m -571.488,-249.23 -0.975,1.083 0.982,-1.089 -0.007,0.006 m 200.796,423.687 0.234,-1.202 -0.239,1.205 h 0.005 m -99.368,-89.389 1.045,-0.974 -1.045,0.968 v 0.01 m -112.751,-160.658 0.878,1.014 -0.873,-1.015 -0.005,10e-4 m 357.073,-162.652 v 0.002 l -0.743,1.668 0.746,-1.67 m -316.028,-50.142 -1.267,0.94 1.271,-0.942 -0.004,0.002 m 127.181,-23.948 1.942,-1.005 -1.944,0.988 0.002,0.017 m 301.649,197.506 1.138,0.146 -1.143,-0.154 v 0.008 m -254.657,363.026 1.604,0.049 -1.605,-0.064 10e-4,0.015 m 84.365,-577.911 -1.468,-0.364 1.469,0.371 -10e-4,-0.007 m -118.202,203.002 1.536,-0.281 -1.534,0.267 -0.002,0.014 m -42.067,-116.936 -1.49,2.246 1.494,-2.241 -0.004,-0.005 m -94.158,-47.043 1.573,-1.585 -1.585,1.592 0.012,-0.007 m 452.763,137.143 v 0.004 l 0.242,-1.605 -0.244,1.601 m -3.242,-4.436 -0.012,0.01 -0.898,1.113 0.91,-1.123 m -285.356,407.782 1.267,-0.227 -1.268,0.225 h 10e-4 m 1.693,-482.956 -0.004,0.004 2.052,-0.339 -2.048,0.335 m 284.518,81.886 v 0.002 l -0.186,1.19 0.188,-1.192 M 962.81,653.278 l 0.342,-1.362 -0.36,1.393 0.018,-0.031 m -227.026,-52.497 -0.214,1.666 0.217,-1.666 h -0.003 m 162.53,-20.559 1.188,0.63 -1.186,-0.631 -0.002,10e-4 m 263.76,235.031 -0.429,-1.614 0.423,1.606 0.01,0.008 m -272.827,-35.163 -1.763,-0.99 1.762,1.014 10e-4,-0.024 m -128.228,441.133 1.418,0.609 -1.432,-0.615 0.014,0.01 m 69.715,-98.579 1.783,-1.187 -1.783,1.121 v 0.066 m -123.203,-184.879 -3.67,-0.526 3.677,0.53 -0.007,-0.004 m 313.72,-143.044 1.541,-0.922 -1.546,0.914 v 0.008 m 38.085,-35.852 -0.525,1.219 0.525,-1.219 v 0 m -60.53,273.959 1.083,-1.385 -1.091,1.38 h 0.008 m -151.727,-298.566 1.208,-0.815 -1.213,0.818 0.005,-0.003 m -90.704,275.319 1.653,0.312 -1.651,-0.325 -0.002,0.013 m -118.558,-124.353 2.464,-2.264 -2.462,2.26 -0.002,0.004 m 68.916,-215.141 -0.838,1.119 0.842,-1.117 -0.004,-0.002 m 199.421,-86.113 0.06,1.211 -0.038,-1.219 -0.022,0.008 m 247.467,225.34 0.118,-1.865 -0.121,1.876 v -0.011 M 910.53,551.464 l -0.755,0.081 0.761,-0.081 h -0.006 m -282.046,491.74 1.261,1.231 -1.261,-1.255 v 0.024 m 409.36,-238.826 1.483,-0.934 -1.485,0.93 v 0.004 m -32.555,-122.262 -0.974,0.561 0.978,-0.561 v 0 m -177.84,-20.291 -1.574,1.411 1.574,-1.381 v -0.03 m 303.02,92.862 0.01,-0.002 -1.422,0.455 1.416,-0.453 m -173.664,149.647 -1.557,-0.368 1.57,0.382 -0.013,-0.014 m 36.605,-287.601 -0.783,-0.836 0.774,0.836 h 0.009 m -33.766,286.779 1.604,-0.023 -1.62,-0.087 0.016,0.11 m -211.906,-312.76 -1.479,1.485 1.498,-1.494 -0.019,0.009 m -39.15,78.494 -1.155,1.464 1.193,-1.481 -0.038,0.017 m -48.286,274.197 1.249,0.211 -1.253,-0.229 0.004,0.018 m 53.812,10.523 1.334,3.973 -1.328,-3.995 -0.006,0.022 m -25.922,-263.693 -1.057,1.027 1.085,-1.044 -0.028,0.017 m 379.74,69.208 v 0.003 l -0.339,1.438 0.343,-1.441 m -281.439,286.359 -0.96,-1.463 0.956,1.466 h 0.004 m 56.011,-491.083 -0.886,0.162 0.886,-0.162 v 0 m -18.259,108.752 2.112,0.485 -2.119,-0.49 0.007,0.005 m -131.572,19.525 -0.542,1.074 0.554,-1.081 -0.012,0.007 m 44.55,353.363 0.843,1.563 -0.841,-1.575 -0.002,0.012 m -96.608,-153.644 0.977,-0.532 -1.021,0.551 0.044,-0.019 m 94.002,-249.845 1.26,0.041 -1.239,-0.045 -0.021,0.004 m 92.897,38.901 -1.545,-0.268 1.528,0.268 h 0.017 M 686.83,689.758 v 0.002 l 1.71,-1.689 -1.71,1.687 m 41.611,206.661 1.646,-0.984 -1.639,0.965 -0.007,0.019 m 232.885,-261.073 -0.359,0.808 0.36,-0.8 -10e-4,-0.008 m -209.469,-47.208 -0.172,-0.43 0.168,0.433 0.004,-0.003 m 121.437,547.969 2.16,-0.18 -2.16,0.176 v 0 m 141.628,-207.393 1.64,0.083 -1.636,-0.084 v 0.001 m 226.008,48.625 0.596,-2.619 -0.594,2.611 v 0.008 m -627.114,-188.166 -0.246,1.702 0.251,-1.709 -0.005,0.007 m 292.589,-208.779 1.14,0.639 -1.142,-0.641 0.002,0.002 m -29.741,145.558 -0.048,-2.048 0.043,2.052 0.005,-0.004 m -78.655,-33.906 -0.457,1.306 0.473,-1.289 -0.016,-0.017 m 346.381,105.012 -0.538,1.049 0.54,-1.048 v -10e-4 m -139.529,-97.136 0.246,1.384 -0.244,-1.386 v 0.002 m -304.02,264.357 -0.273,-2.092 0.265,2.124 0.008,-0.032 m 349.63,-136.057 1.242,-0.088 -1.244,0.083 v 0.005 m 81.992,-75.429 v -10e-4 l -0.786,0.933 0.791,-0.932 m -349.869,-179.877 -1.01,0.526 1.012,-0.526 h -0.002 m -120.92,318.23 0.487,1.192 -0.482,-1.195 -0.005,0.003 m 184.821,-234.298 1.759,-1.637 -1.758,1.63 -10e-4,0.007 m -86.918,356.148 1.856,0.107 -1.855,-0.117 -10e-4,0.01 m 197.783,-365.117 0.003,0.004 -0.325,-1.32 0.322,1.316 m -323.979,402.1 1.529,0.219 -1.529,-0.222 v 0 m 608.449,-214.715 -0.034,-1.12 0.033,1.117 10e-4,0.003 M 671.812,714.13 l -0.507,1.177 0.509,-1.179 -0.002,0.002 m 392.638,40.264 -1.688,-0.954 1.676,0.955 0.012,-10e-4 m -61.741,-72.156 0.321,-2.421 -0.328,2.421 h 0.01 m -175.723,34.998 -0.799,1.819 0.809,-1.796 -0.01,-0.023 m 170.988,311.174 0.717,1.106 -0.718,-1.111 10e-4,0.01 m -323.607,58.726 0.889,-0.139 -0.889,0.131 v 0.01 M 652.498,960.811 h 0.002 l 0.945,-1.135 -0.947,1.135 m 116.181,-381.905 0.674,-0.453 -0.708,0.465 0.034,-0.012 m -65.481,356.878 -0.003,-0.002 0.805,1.442 -0.802,-1.44 m 96.025,-252.351 -0.002,0.002 -0.77,1.205 0.772,-1.207 m 13.975,17.63 -0.847,-1.319 0.84,1.324 0.007,-0.005 m 5.206,-25.687 -1.938,-1.275 1.9,1.278 0.038,-0.003 m -192.931,365.669 1.059,1.471 -1.059,-1.51 v 0.039 m 83.127,-103.967 1.183,0.844 -1.18,-0.846 -0.003,0.002 m 245.461,-307.988 -0.005,-0.015 -1.003,-0.993 1.008,1.008 m -276.083,72.16 0.212,1.117 -0.209,-1.119 -0.003,0.002 m -77.718,159.994 0.313,-1.594 -0.318,1.587 0.005,0.007 m 237.991,-305.577 -0.937,0.211 0.942,-0.211 h -0.005 m -27.222,288.945 2.926,-1.521 -2.913,1.509 -0.013,0.012 m 94.111,-96.011 1.823,-0.651 -1.811,0.637 -0.012,0.014 m -39.905,381.569 0.49,-1.088 -0.49,1.077 v 0.011 m -23.025,-280.993 -0.002,-0.006 -0.991,0.982 0.993,-0.976 m -89.207,18.766 1.39,0.182 -1.386,-0.191 -0.004,0.009 m -148.382,-12.585 0.296,1.171 -0.29,-1.184 -0.006,0.013 m 181.503,-283.387 -2.618,0.94 2.615,-0.938 0.003,-0.002 m 316.016,232.702 1.255,0.611 -1.257,-0.623 v 0.012 m -268.92,318.878 0.962,-0.868 -0.975,0.86 0.013,0.01 m 179.028,-340.225 1.357,0.455 -1.391,-0.517 0.034,0.062 m 39.473,45.931 1.062,0.801 -1.062,-0.807 v 0.006 m 0.011,-105.402 -2.519,-1.121 2.516,1.12 v 10e-4 m -176.873,-7.934 0.386,1.208 -0.381,-1.212 -0.005,0.004 m -104.67,301.88 1.186,1.146 -1.184,-1.155 -0.002,0.01 m 76.097,-335.186 0.004,0.01 0.935,-0.945 -0.939,0.935 m -56.32,-90.166 -0.751,0.758 0.753,-0.747 -0.002,-0.011 m -67.274,393.91 -1.614,-1.059 1.61,1.076 0.004,-0.017 m 463.689,-168.859 0.271,-1.047 -0.272,1.05 10e-4,-0.003 m -23.2,292.66 -0.012,0.644 0.035,-0.709 -0.023,0.065 m -37.274,-241.901 -0.492,1.314 0.498,-1.309 -0.01,-0.005 m -242.281,-89.294 0.852,-1.125 -0.85,1.106 -0.002,0.019 m 170.736,-15.853 1.226,0.009 -1.225,-0.016 -10e-4,0.007 m -324.017,-122.906 -0.028,-0.018 -0.702,-0.435 0.73,0.453 m 197.659,42.42 -0.271,-1.213 0.269,1.217 0.002,-0.004 m 169.112,141.244 0.718,-1.176 -0.736,1.146 0.018,0.03 m -263.898,298.375 -0.833,1.038 0.84,-1.031 -0.007,-0.01 m -15.565,-372.682 1.267,2.068 -1.269,-2.072 0.002,0.004 m 1.202,-83.166 1.94,-1.317 -1.957,1.284 0.017,0.033 m 14.701,454.494 1.35,0.06 -1.346,-0.065 -0.004,0.01 m -58.748,-347.775 -0.005,0.008 2.35,-1.133 -2.345,1.125 m 50.481,-63.134 -2.286,0.413 2.293,-0.381 -0.007,-0.032 m 9.934,-48.946 -0.542,-1.288 0.53,1.313 0.012,-0.025 m -140.935,20.528 -0.017,0.001 -0.247,1.127 0.264,-1.128 m 129.435,-28.645 -1.079,-0.436 1.083,0.439 -0.004,-0.003 m -142.166,317.297 1.396,1.079 -1.39,-1.102 -0.006,0.023 m 224.219,-395.73 -1.887,-0.049 1.885,0.07 0.002,-0.021 m 145.417,183.195 0.998,0.965 -0.992,-0.964 -0.01,-10e-4 m 92.671,41.611 -0.192,1.845 0.198,-1.837 -0.01,-0.008 m -88.074,-37.528 0.622,1.67 -0.615,-1.669 -0.01,-10e-4 m -183.204,-51.551 -1.542,0.831 1.543,-0.828 -10e-4,-0.003 m -10.765,-29.364 -1.248,-0.746 1.245,0.761 0.003,-0.015 m 92.581,224.846 2.475,0.168 -2.477,-0.178 0.002,0.01 M 824.91,665.583 l -1.866,-0.668 1.835,0.668 h 0.031 m -41.166,19.798 0.41,0.915 -0.388,-0.93 -0.022,0.015 m 205.779,-73.66 0.955,-0.69 -0.975,0.684 0.02,0.006 m 58.557,167.815 0.782,-1.128 -0.802,1.099 0.02,0.029 m 103.743,44.802 -0.887,-1.022 0.882,1.029 0.01,-0.007 m -314.549,-151.213 1.693,-1.283 -1.709,1.227 0.016,0.056 m -113.503,299.038 0.009,0.019 1.191,0.976 -1.2,-0.995 m 173.976,-219.551 1.773,2.701 -1.773,-2.71 v 0.009 m -73.468,-87.904 -0.646,-0.807 0.636,0.8 0.01,0.007 m -45.454,109.524 -1.516,0.836 1.506,-0.813 0.01,-0.023 m 20.684,-167.516 0.385,0.551 -0.365,-0.549 -0.02,-0.002 M 960,631.861 l -1.75,-0.781 1.75,0.784 v -0.003 m -87.17,101.522 1.763,0.099 -1.751,-0.101 -0.012,0.002 m -173.59,-53.38 -1.146,0.035 1.143,-0.029 0.003,-0.006 m 126.727,32.139 -0.84,1.503 0.847,-1.49 -0.007,-0.013 m 196.959,34.176 v -0.004 l -0.953,-1.118 0.955,1.122 m -323.944,186.694 -0.426,1.23 0.43,-1.232 -0.004,0.002 m 130.931,-260.684 1.099,-0.845 -1.121,0.822 0.022,0.023 m 59.92,-7.068 -1.134,-1.668 1.095,1.686 0.039,-0.018 m -17.241,51.719 0.961,-0.906 -0.963,0.903 0.002,0.003 m 136.725,38.684 -2.054,-3.254 2.045,3.241 0.01,0.013 M 900,660.756 l -1.146,-1.074 1.146,1.074 v 0 m -0.907,0.607 -0.899,-0.903 0.848,0.894 0.051,0.009"
+           inkscape:connector-curvature="0"
+           style="fill:#ffffff;fill-opacity:1" />
+      </g>
+      <g
+         id="layer2-9-2">
+        <radialGradient
+           id="radialGradient8499-8"
+           cx="7553.0029"
+           cy="-7131.8633"
+           r="16567.537"
+           gradientTransform="matrix(0.0194,0,0,-0.0205,772.9011,743.9232)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="0"
+             style="stop-color:#0101FF"
+             id="stop8495-8" />
+          <stop
+             offset="1"
+             style="stop-color:#000080"
+             id="stop8497-9" />
+        </radialGradient>
+        <path
+           id="polygon8-2"
+           d="m 816.922,1128.468 -2.089,0.699 -5.204,-0.451 -2.362,4.688 0.97,-5.429 2.884,0.622 -5.426,-1.635 3.239,0.474 -3.058,-1.649 -6.19,1.688 -5.01,-1.841 -6.294,2.965 -6.267,-2.248 -11.858,0.622 -3.277,-2.11 -6.255,1.726 -0.569,-1.853 1.598,0.088 -7.674,-5.048 -0.526,0.8 -2.801,-4.449 -3.987,-2.45 -7.489,-2.149 -4.075,2.791 -5.911,-2.265 -1.703,1.517 1.218,1.064 -2.811,0.313 -2.108,-3.021 -6.138,-2.91 -1.946,-3.2 -6.128,-1.319 1.733,-0.028 -1.185,-0.936 2.405,1.475 3.112,0.641 2.031,3.274 6.162,2.694 2.52,3.262 2.175,-0.292 -1.289,-1.043 1.813,-1.662 6.354,1.978 3.777,-2.467 10.746,2.95 6.032,6.645 7.135,4.453 3.775,-0.669 2.707,1.815 5.35,-0.098 0.69,-1.761 5.245,1.398 -3.826,-1.624 -6.06,-8.591 -11.351,-7.879 -15.051,-4.549 2.716,0.103 11.982,3.801 11.855,8.408 9.226,10.047 9.08,2.047 4.876,-2.362 5.275,1.784 3.654,-2.137 6.841,1.397 2.06,0.954 -0.222,1.303 1.885,0.172 9.143,-2.311 -6.124,1.778 m -101.765,-297.499 -4.463,4.921 -3.234,-0.215 3.309,-9.46 6.579,-6.841 -2.142,-1.029 6.784,-4.172 0.031,2.345 4.798,-0.432 4.49,3.809 0.2,-3.138 -1.968,-1.74 1.124,-1.407 -7.829,-3.232 -0.031,-2.944 -2.321,-0.624 1.117,-2.722 -7.132,-0.304 -1.221,-1.218 1.493,-1.642 -3.937,-1.635 13.742,-2.491 0.637,1.367 2.39,-1.944 -1.669,1.985 1.558,-0.201 1.199,-2.075 4.214,4.58 -0.994,5.152 2.803,2.061 -3.659,8.309 9.943,9.658 0.666,7.809 -2.488,1.511 -2.447,-2.215 -0.56,-5.02 -0.442,4.248 -5.17,6.012 -3.14,0.502 1.632,-6.14 -4.538,-0.688 3.723,-2.039 2.62,-5.148 -3.418,-5.673 -4.716,4.209 1.29,-2.397 -3.735,1.295 -5.089,8.974 0.001,0.039 m 243.432,-268.732 6.997,0.843 2.506,1.658 4.415,1.678 10.577,1.257 -10.588,-1.241 -4.588,-1.726 -2.76,-1.652 -9.97,-1.143 -8.12,-1.725 -16.184,-0.911 -2.219,1.706 6.809,2.68 3.711,-0.222 3.805,1.056 13.046,1.814 -13.047,-1.796 -3.78,-1.001 -2.91,0.154 3.329,1.975 -0.442,4.404 -10.363,4.353 -4,0.163 -0.265,1.33 0.133,-1.347 3.96,-0.19 9.489,-4.065 1.122,-4.408 -7.984,-3.768 -12.756,-1.885 0.023,-0.455 -6.067,-0.94 2.252,-2.71 1.685,0.181 -1.432,-0.09 -0.818,0.863 -1.573,1.743 6.04,0.928 -0.031,0.446 10.024,1.139 -0.558,-1.737 4.832,-0.762 14.195,1.332 7.987,1.695 2.069,0.173 -0.678,-0.61 2.104,0.813 h 0.023 m 212.155,169.835 -3.231,-3.417 -0.862,-3.395 -1.164,1.438 -8.193,-1.766 -5.172,-4.227 1.495,2.112 -5.022,-2.058 -4.6,-5.62 -0.193,-4.153 -3.267,-3.859 -2.399,-6.763 0.427,-4.116 1.335,0.152 4.927,4.688 0.835,-0.753 0.088,4.906 2.303,2.974 1.436,-0.585 -0.531,3.032 1.219,1.183 0.749,-1.11 4.352,2.259 1.611,-2.755 2.626,3.04 4.06,2.141 -3.703,-3.332 -0.882,-2.64 4.096,0.414 2.036,4.439 -1.638,0.873 3.271,3.452 2.006,0.793 -1.033,-0.542 v -1.854 l 1.722,1.084 -0.421,0.924 1.868,1.968 -0.797,-1.843 1.568,0.255 7.807,7.233 1.42,7.647 -3.521,4.659 -4.888,-3.596 -1.767,-3.276 0.024,-0.006 m -122.113,-99.839 4.864,2.299 5.618,-4.231 -5.788,-10.162 -1.659,-5.761 3.069,-1.365 -1.17,-3.012 1.546,-3.659 1.492,-0.665 4.443,1.452 -4.372,-1.385 -1.595,1.906 -0.229,5.45 -2.602,1.177 1.047,4.731 6.54,10.472 1.439,-0.708 4.101,0.87 2.976,2.417 7.022,3.051 -7.048,-3.003 -2.971,-2.427 -3.981,-0.802 -7.898,5.762 -5.525,-2.335 -5.616,-0.322 -5.979,-1.739 -3.368,-1.754 -2.633,-3.74 2.378,1.546 0.453,2.209 3.016,1.541 6.045,1.844 6.367,0.344 0.018,-0.001 m -105.051,-79.509 -10.35,-1.143 4.597,0.469 -4.875,-0.496 -15.951,-1.142 -2.821,-0.126 0.873,0.037 -2.125,-0.085 -1.005,-0.019 -12.577,-0.023 -0.881,0.113 2.684,0.166 -3.577,0.047 3.296,-0.059 -2.703,-0.165 1.697,-0.151 -1.221,0.073 0.5,-0.069 h -2.039 l 6.584,-0.04 6.738,0.065 -0.413,-0.032 1.253,0.042 7.08,0.293 11.521,0.795 6.547,0.623 7.145,0.821 0.023,0.006 m 77.907,46.088 3.371,0.453 1.291,-2.486 -1.277,2.558 -11.363,-0.647 -2.149,0.803 0.838,1.66 -12.836,1.318 1.054,2.449 -1.993,-1.57 0.727,-1.036 12.932,-1.315 -0.868,-1.569 1.885,-0.627 -2.342,-1.349 -0.236,-1.327 2.903,-0.865 -1.083,-2.208 1.286,2.262 -2.927,0.815 0.544,1.563 1.883,0.939 8.348,0.187 0.012,-0.008 m 210.433,381.676 0.983,-10.801 1.169,-3.964 0.596,-0.284 0.67,-3.338 0.227,0.984 0.852,-2.294 0.481,2.006 0.757,-3.154 0.159,0.642 -1.288,4.138 -0.275,4.859 -1.373,5.196 1.031,-1.479 -0.784,3.074 -0.866,1.276 0.072,1.72 -0.523,1.624 0.281,-2.6 -1.066,1.093 -0.948,4.273 -0.151,-2.979 v 0.008 m -129.547,-296.871 1.535,1.843 1.842,0.223 -0.775,-2.592 2.816,3.314 0.713,-1.617 0.805,3.042 -0.612,-1.255 -4.044,-0.264 -4.682,-4.759 -1.646,-0.358 1.139,0.1 -1.552,-1.104 1.089,-0.469 -1.124,-3.724 -1.527,-1.148 1.31,0.603 -0.649,-1.42 4.093,8.549 1.231,0.998 0.038,0.038 m -348.437,-16.224 3.85,0.704 0.797,-1.462 1.161,2.188 0.371,-3.215 -2.39,-2.031 2.172,-1.175 5.767,6.238 -0.575,1.719 -3.388,-1.056 0.585,3.052 2.363,0.565 -5.297,2.208 -0.542,-3.162 -2.483,1.566 -3.529,-1.463 4.561,-0.714 -4.183,-1.031 0.745,-2.922 0.015,-0.009 m 265.271,-89.137 -2.28,-1.08 1.043,-0.265 3.955,-0.171 -0.024,0.298 0.652,0.083 0.092,-0.635 2.718,0.695 -1.611,-0.095 1.249,0.698 -1.236,-0.607 -5.97,0.146 2.79,1.331 2.709,-0.081 -0.238,0.418 -1.146,-0.349 0.771,1.059 -3.466,-1.447 -0.01,0.002 m -283.704,115.788 0.3,-6.184 0.477,3.564 3.297,-1.023 1.241,1.327 3.846,-5.242 -2.117,7.132 7.064,1.48 1.129,3.455 -3.225,-3.657 -1.652,0.41 2.795,1.096 0.626,1.288 -1.681,-1.429 0.957,1.516 -2.037,-1.492 -9.377,-0.277 -1.678,-1.956 0.035,-0.008 m 408.174,-14.484 3.613,4.015 1.378,0.311 1.993,4.22 -1.491,-0.458 0.979,3.393 -4.55,-2.829 -4.529,-4.172 -0.465,-2.158 -2.109,-1.207 0.604,-0.647 -2.955,-2.615 0.354,-1.63 -1.658,-2.35 3.449,3.871 1.975,1.17 1.662,-1.16 1.75,2.244 v 0.002 m -327.174,119.544 0.679,4.569 2.202,1.11 -3.698,-0.06 -1.37,-2.101 -2.877,1.398 0.521,2.184 -1.425,-0.616 1.299,-2.399 -2.244,-5.062 -0.801,2.086 1.282,-4.825 1.746,7.379 1.938,0.013 -0.161,-3.792 0.209,3.143 2.331,0.664 0.369,-3.691 m 307.643,243.435 -0.256,-1.704 -3.89,0.12 3.288,-0.619 0.498,-3.622 -0.731,-0.874 -1.184,0.563 1.156,-0.882 -3.12,1.833 2.635,-2.572 -3.364,0.028 -1.179,-2.332 -3.6,1.906 3.256,-2.028 -0.834,-1.845 6.412,3.833 0.117,-6.47 0.796,14.665 m -67.732,-336.407 -3.208,-0.877 1.819,-0.722 -0.855,-2.577 -4.925,0.519 -1.713,-2.263 -4.353,-1.087 8.246,0.726 -2.966,0.41 2.521,1.784 1.976,-1.996 -2.343,-1.487 1.497,-0.575 2.913,2.465 0.857,4.125 1.282,-0.533 -0.711,2.059 -0.037,0.029 m -316.864,363.383 2.169,-4.114 4.373,-1.359 4.386,-0.01 3.922,2.496 14.527,-0.725 0.396,-1.444 -0.616,-4.706 1.082,5.761 2.552,1.12 -13.785,-0.01 -4.309,0.166 -3.963,-2.465 -4.088,-0.01 -6.619,5.331 -0.027,-0.034 m 305.046,-367.095 3.545,2.345 -2.072,-2.235 1.729,0.112 -1.922,-0.583 1.516,-0.701 2.447,5.593 3.186,2.669 0.345,-1.917 2.098,2.267 -3.709,-0.322 -3.302,-4.462 -2.816,-2.019 -1.404,0.42 0.343,-1.185 0.016,0.018 m 171.524,290.916 -6.208,0.809 -9.034,13.669 -2.812,6.055 0.188,3.926 -7.477,17.135 -0.386,4.405 -0.036,-3.687 5.483,-13.354 1.425,-15.287 -1.14,14.895 2.106,-9.132 5.328,-10.428 6.604,-8.625 5.947,-0.394 0.012,0.013 m -495.398,-236.797 -0.293,-2.827 2.888,-1.801 1.199,2.801 2.74,-3.402 -0.847,1.996 -8.727,15.985 -4.079,2.946 4.668,-5.711 -1.813,-0.295 2.365,-3.657 -1.844,-0.251 2.04,-5.847 1.327,0.102 0.376,-0.039 m 28.809,-89.563 2.299,-1.836 3.797,-7.296 3.545,-1.208 5.827,-5.229 -0.506,-2.849 2.82,-2.922 5.858,-1.459 -6.747,2.516 -1.421,5.403 -5.299,4.415 -3.74,1.243 -4.051,7.612 -2.372,1.612 -0.01,-0.002 m 65.964,548.695 -15.764,-3.07 -1.77,3.832 1.188,2.604 -4.043,1.447 2.524,2.685 -2.952,-2.924 4.016,-1.068 -1.166,-3.23 0.701,-0.363 1.206,-3.054 2.567,0.017 13.479,3.117 0.014,0.01 m 262.337,-558.625 -3.475,-1.54 5.522,1.479 1.48,1.72 1.711,0.175 0.084,-1.365 0.346,1.059 2.304,0.478 -3.799,-0.155 -0.26,1.371 -1.438,-2.188 -0.796,0.87 -1.674,-1.898 v -0.006 m -121.187,-63.329 2.009,0.051 1.005,1.303 1.756,-1.203 -1.177,0.883 1.303,1.286 -2.501,-0.677 -1.431,1.298 0.337,-1.777 -4.193,-1.476 -1.214,0.632 -1.059,-1.494 5.158,1.169 0.007,0.005 m -188.065,18.826 -6.755,-2.43 -4.274,0.257 1.038,-2.854 2.78,-1.037 2.666,-2.133 3.911,-1.024 -3.578,0.96 -3.589,2.754 -2.107,0.52 0.257,2.654 2.28,-0.39 7.379,2.711 -0.008,0.012 m 231.504,-43.25 -1.292,-0.543 5.077,0.33 4.799,1.259 -0.97,-0.518 10.85,3.526 2.931,0.746 4.338,1.708 2.589,1.372 -5.272,-2.192 -6.363,-2.049 -8.184,-2.234 -8.504,-1.404 h 10e-4 m 53.869,119.291 3.059,-0.807 7.019,2.709 1.277,2.097 -1.603,1.411 v -1.964 l -4.582,0.346 -4.015,-1.634 3.292,0.275 -3.182,-1.303 3.308,0.648 -0.642,-1.545 -3.933,-0.233 m -325.522,154.33 5.467,2.589 -0.982,-1.092 6.513,0.532 -2.146,2.173 -11.754,0.999 -5.223,-4.671 5.177,-3.759 0.197,2.269 -2.294,-0.532 -0.54,1.69 5.583,-0.203 0.002,0.005 m 366.258,-226.398 0.849,1.896 -6.146,-3.889 -0.074,1.06 -1.803,-1.491 1.668,1.028 -0.575,-1.267 3.925,2.602 0.229,-0.384 1.528,1.175 -1.166,-1.787 1.56,1.053 0.01,0.004 m 29.06,121.854 -0.043,-1.768 5.305,4.577 -1.284,3.273 2.038,3.113 -0.435,3.571 0.264,-3.24 -2.62,-3.719 1.184,-2.732 -2.784,-3.111 -11.313,2.95 9.688,-2.914 m -79.074,-93.582 -4.917,-0.05 5.248,4.407 0.402,3.571 -12.021,-3.705 -3.483,-3.847 3.55,3.811 11.807,3.568 -0.396,-3.462 -5.234,-4.428 5.013,0.124 0.031,0.011 m 145.696,61.714 4.199,6.792 2.278,3.479 2.458,3.01 4.885,7.959 -0.028,-0.21 0.682,1.34 -5.517,-9.043 -2.487,-3.053 -2.282,-3.494 -4.129,-6.679 -0.059,-0.101 m -64.532,6.015 1.775,-0.079 2.152,2.294 4.121,5.225 0.241,2.968 -2.126,-1.804 0.901,-1.039 -2.958,-2.679 0.583,-0.804 -2.129,-3.218 -2.522,-0.865 h -0.038 m 62.499,56.638 0.683,-0.808 2.975,3.181 1.966,-1.421 0.753,-3.087 1.651,1.287 -1.619,-1.207 -0.134,2.922 -2.586,1.571 -3.029,-3.206 -0.642,0.755 -0.018,0.013 m -319.818,437.614 -2.343,-1.028 -1.325,0.471 1.25,-0.729 -2.162,-1.632 4.405,0.012 -0.255,0.578 2.295,1.208 -3.695,-1.595 -1.788,0.335 3.641,2.389 -0.023,-0.01 m 357.409,-206.394 0.941,-5.379 0.22,8.932 -0.756,2.837 1.293,0.051 -0.199,5.715 -1.193,1.531 0.307,-4.27 -1.215,-1.911 1.126,-9.378 -0.524,1.872 m 5.584,6.189 0.401,-1.382 0.266,0.456 -0.939,4.965 -1.57,5.104 -1.859,6.507 -0.614,1.222 1.575,-5.924 1.275,-3.857 1.452,-7.053 0.013,-0.038 m -111.456,-364.358 -3.223,-3.009 -4.562,-7.05 -2.705,-2.606 3.168,2.672 4.069,6.345 4.993,4.48 4.216,2.418 -2.104,-0.006 -3.857,-3.248 0.01,0.004 m -366.122,199.982 -2.906,1.208 -0.748,3.314 -3.495,0.522 -9.759,-5.203 3.749,-1.723 6.864,3.262 1.681,-0.968 -2.529,-1.202 7.137,0.789 0.006,10e-4 m 309.779,-169.954 -6.854,2.779 -3.844,-0.597 -2.58,-2.049 -2.148,1.394 2.062,-1.475 2.707,2.061 3.773,0.538 6.85,-2.65 0.034,-0.001 m 67.072,41.018 -8.382,-9.454 -4.33,-2.835 -2.287,-4.677 2.062,3.93 3.011,2.401 2.675,0.386 0.462,2.328 6.791,7.916 v 0.005 m -39.688,-23.055 3.479,-0.981 -1.095,-5.011 1.312,-2.358 3.502,-0.717 -3.318,0.979 -1.417,2.149 1.043,5.097 -3.485,0.84 -0.021,0.002 M 854.59,573.504 l 5.076,-0.72 3,-2.889 5.168,-1.189 -4.851,1.2 0.618,0.467 -2.598,1.173 -1.098,1.337 -5.204,0.653 -0.111,-0.032 m 222.148,120.694 2.812,-0.527 2.104,2.839 -4.364,0.547 1.52,-1.469 -3.743,-0.987 0.476,-1.925 0.216,1.797 0.978,-0.281 10e-4,0.006 m -384.634,74.08 -0.742,2.613 1.297,0.087 -1.368,1.615 1.967,2.855 -2.76,-2.941 1.234,-3.239 -1.571,-2.429 1.94,1.437 0.003,0.002 m 55.527,-43.836 3.835,-2.503 2.946,0.738 -3.856,0.899 -0.249,1.549 -0.342,-1.454 -2.497,2.876 0.149,-2.112 0.014,0.007 m -31.033,54.208 -1.516,4.505 -1.468,-2.04 1.245,2.434 -3.994,-1.265 4.282,-2.129 -1.319,-1.138 2.777,-0.385 -0.007,0.018 m 58.799,57.822 -21.381,5.852 8.614,-2.542 -8.182,-3.786 -2.593,-6.212 2.656,6.141 8.106,3.632 12.799,-3.168 -0.019,0.083 m -41.646,323.475 5.513,4.732 -1.155,0.739 -1.276,-2.061 -1.142,0.19 -4.161,-2.953 0.269,-1.671 1.901,0.976 0.051,0.048 m -7.292,-426.847 2.975,-2.033 -1.857,1.627 2.25,-0.177 2.475,-3.433 4.993,-0.695 -5.612,4.426 -5.239,0.3 0.015,-0.015 m 453.438,231.57 -3.43,6.452 -4.286,-4.603 1.289,-1.901 1.562,2.66 1.062,-1.947 0.444,1.648 3.352,-2.319 0.01,0.01 m -486.94,-274.983 1.06,2.262 -1.052,4.486 -1.222,-1.056 2.012,-3.543 -2.309,-0.536 1.896,0.117 -0.385,-1.73 m 29.739,58.164 -1.923,2.012 1.833,0.174 -2.855,0.271 -0.875,4.26 -1.082,-4.837 1.771,0.662 3.131,-2.542 m 331.847,275.194 -9.376,-5.476 -9.398,3.277 -1.348,1.879 1.228,-1.915 9.554,-3.308 4.879,1.271 4.461,4.272 m -337.12,-270.982 0.384,2.631 -5.733,5.689 4.566,-6.027 -1.463,-2.29 1.082,-1.269 1.166,1.236 -0.002,0.03 m 488.178,99.46 2.802,4.458 -1.206,4.658 0.739,9.12 -1.346,-7.669 1.175,-3.823 -2.163,-6.736 -10e-4,-0.008 m -161.102,-93.308 -1.008,-3.261 2.215,-1.135 -1.088,1.842 1.897,1.452 -1.697,-0.746 -0.279,1.894 -0.04,-0.046 m -173.995,441.086 -1.886,-0.221 1.169,-1.458 -1.82,0.257 1.333,-1.33 2.597,2.189 -1.373,0.574 -0.02,-0.011 m -142.098,-541.238 -4.908,2.973 -1.102,-0.726 3.805,-1.172 -0.251,-1.567 0.462,1.341 2.011,-0.877 -0.017,0.028 m 102.607,473.234 -1.413,-2.621 5.572,0.768 -1.845,1.634 0.929,1.397 -2.63,-3.441 -0.624,2.226 0.011,0.037 m 221.681,-535.278 -6.309,-2.915 0.337,-0.241 4.211,2.289 1.231,-0.326 2.88,0.801 -2.319,0.407 -0.031,-0.015 m -423.36,193.085 -1.202,1.891 0.582,0.444 -1.002,3.042 0.779,-2.747 -1.59,-1.851 2.453,-0.821 -0.02,0.042 m 415.31,-52.3 2.056,3.012 -1.453,4.002 -2.194,-2.811 1.786,-1.087 -2.097,-1.902 1.885,-1.231 0.017,0.017 m -323.218,-16.516 -1.017,2.909 -4.957,2.175 1.945,-3.27 -0.451,2.112 2.031,-0.486 2.451,-3.473 -0.002,0.033 m 374.945,325.465 -0.787,3.892 0.778,0.855 1.188,-1.799 -0.221,2.754 -2.387,-1.01 1.414,-4.697 h 0.015 M 769.232,820.27 l 0.462,3.316 -2.262,-2.611 -1.552,1.47 1.415,-1.552 -1.778,0.325 3.715,-0.948 m 381.247,192.805 2.157,3.171 9.152,-6.847 -9.083,6.878 -0.056,12.584 -0.145,-12.699 -2.025,-3.087 m -11.51,-7.648 3.009,0.738 0.13,5.859 -1.533,-2.063 1.231,-3.589 -2.838,-0.938 10e-4,-0.01 M 708.69,687.163 l -3.128,3.693 0.734,3.901 -0.755,-3.447 -4.064,4.04 7.227,-8.202 -0.014,0.015 m -27.699,71.337 3.99,3.707 -1.493,1.199 0.868,-1.64 -4.122,-1.734 0.706,-1.597 0.051,0.065 m 46.771,-50.076 6.356,0.166 2.495,7.657 -4.552,-5.591 -4.954,-0.578 0.656,-1.645 -0.001,-0.009 m 39.01,-27.94 -2.883,1.418 0.723,-1.701 -0.463,1.514 1.964,-2.043 0.681,0.771 -0.022,0.041 m 64.992,550.056 -0.833,-1.045 4.139,-0.93 0.146,1.218 -2.018,-0.364 -1.409,1.134 -0.025,-0.013 m 127.617,-641.267 7.207,0.772 0.17,-1.263 0.148,1.268 5.34,1.289 -12.894,-2.018 0.029,-0.048 m 88.233,118.218 1.543,1.274 -0.705,2.095 2.539,2.063 -4.736,-3.665 1.359,-1.767 m -321.071,73.707 -2.144,1.837 -2.001,-1.008 -0.146,-3.601 1.023,3.186 3.268,-0.414 m 470.559,249.829 -0.242,-3.979 1.509,-2.229 -0.817,2.516 0.989,-0.325 -1.439,4.017 m 9.398,35.254 3.691,-7.317 2.926,-5.058 -2.282,4.065 -4.337,8.315 v -0.01 m -455.01,-363.87 1.688,0.467 -1.524,0.013 -0.95,2.912 0.756,-3.392 h 0.03 m 297.11,-16.5 3.105,-0.428 -0.89,0.949 3.145,1.761 -5.434,-2.251 0.074,-0.031 m -311.33,38.871 -3.892,2.458 -1.027,-1.139 3.315,-2.101 1.632,0.76 -0.028,0.022 m -38.607,21.572 -0.664,2.027 -3.758,-2.295 2.445,1.355 1.995,-1.104 -0.018,0.017 m 340.143,-58.935 2.565,-0.545 -1.734,0.493 0.246,1.629 -1.16,-1.549 0.083,-0.028 m 181.945,338.915 0.446,-1.989 2.108,-4.91 -1.591,5.111 -0.965,1.794 v -0.01 m -422.14,-224.564 2.011,-1.699 -0.737,-1.806 1.098,2.087 -2.361,1.473 -0.011,-0.055 m 280.02,-180.501 -1.278,-1.567 2.37,1.393 0.898,1.609 -1.993,-1.433 v -0.002 m -28.695,88.003 1.464,3.182 1.556,0.096 -2.363,-0.067 -0.676,-3.196 0.019,-0.015 m -331.498,16.502 -3.404,2.662 1.536,-2.517 -0.126,1.341 2.006,-1.504 -0.012,0.018 m 455.575,22.463 3.401,1.727 0.816,2.435 -4.037,-2.57 -0.197,-1.6 0.017,0.008 m -441.171,40.961 -0.179,2.365 -3.2,2.209 -0.393,-3.278 3.762,-1.305 0.01,0.009 m 53.318,30.868 0.703,3.875 -1.048,-2.441 -3.239,0.769 3.601,-2.239 -0.017,0.036 m -177.383,97.247 -1.342,-1.965 -0.493,1.588 0.232,-4.044 1.593,4.229 0.01,0.192 m 613.787,118.407 0.596,-1.31 -0.762,1.822 0.701,-1.677 -0.543,1.185 0.01,-0.02 m 11.249,-74.957 1.623,-4.599 -0.675,2.162 0.347,0.737 -1.293,1.706 v -0.006 m -418.793,265.646 6.125,0.342 -3.046,0.046 0.999,0.52 -3.957,-0.86 -0.121,-0.048 M 690.63,780.486 l -7.928,11.16 -0.721,-3.292 2.39,-0.029 6.26,-7.882 -10e-4,0.043 m 436.413,-139.987 -0.136,-0.479 3.232,3.02 1.813,2.832 -4.901,-5.37 -0.01,-0.003 m -332.91,133.19 -2.25,0.669 0.649,1.136 -3.13,-1.225 4.759,-0.592 -0.028,0.012 m -50.23,-58.203 3.31,-2.91 -1.458,1.337 1.576,0.576 -3.472,1.034 0.044,-0.037 m 347.265,-48.629 -3.304,-4.304 -2.518,-0.558 3.219,0.709 2.609,4.157 -0.01,-0.004 m -377.103,93.89 -4.404,9.115 2.901,-6.176 -0.34,-2.52 1.866,-0.451 -0.023,0.032 m 166.307,-185.946 4.253,-2.524 -0.846,-2.504 1.029,2.676 -4.377,2.374 -0.059,-0.022 m 49.771,3.618 4.095,-1.712 -3.862,1.645 3.883,2.923 -4.116,-2.856 m -279.892,193.151 -1.724,5.292 0.197,-1.299 -1.626,1.368 3.153,-5.361 m 86.764,-33.173 4.029,-1.391 -2.62,2.174 -4.116,-1.243 2.707,0.46 m 374.625,-90.877 -2.57,-2.791 1.736,1.809 0.465,-0.157 0.369,1.139 m -49.245,-52.026 0.107,-0.513 3.155,1.762 -0.56,0.252 -2.702,-1.501 m -5.71,103.156 7.323,-0.041 2.364,5.392 -8.218,-1.585 -1.469,-3.766 m 173.25,271.586 -0.129,-2.22 1.758,-7.825 -0.204,3.976 -1.425,6.069 m -160.076,-253.432 2.994,0.783 -6.049,-1.321 0.273,-1.952 2.782,2.49 m 26.634,286.8 2.087,1.188 -1.173,0.942 -1,-2.122 0.086,-0.01 M 736.9,679.817 l 1.399,-5.176 3.659,-1.371 -3.581,1.509 -1.477,5.038 m -104.248,275.17 1.799,4.812 -2.419,-2.919 0.629,-1.921 -0.009,0.028 m 66.533,-29.826 -0.01,-0.054 0.314,-2.518 -0.372,7.825 0.068,-5.253 M 815.8,791.213 l -0.33,1.678 -1.434,-1.338 1.765,-0.369 -0.001,0.029 m -54.694,-110.594 -0.747,4.783 -1.498,0.706 2.253,-5.511 -0.008,0.022 m 20.555,128.173 -8.025,5.152 3.339,-4.741 4.699,-0.448 -0.013,0.037 m -126.869,188.384 3.261,8.054 -3.792,-4.048 0.529,-4.01 0.002,0.004 M 791.76,809.59 l -1.198,1.589 -0.018,-2.355 1.229,0.723 -0.013,0.043 m 4.861,-14.589 2.593,-1.298 -0.267,1.701 -2.308,-0.358 -0.018,-0.045 m -13.471,-92.837 -1.138,1.723 -1.376,-0.77 2.539,-0.978 -0.025,0.025 m -19.993,14.043 2.527,-0.312 -1.81,2.58 -0.749,-2.262 0.032,-0.006 m -12.866,461.228 -2.243,-2.306 0.311,-1.719 1.943,4.025 h -0.011 m 21.468,-367.859 1.14,1.318 -2.17,1.253 1.001,-2.583 0.029,0.012 m -118.717,184.254 0.366,2.073 -1.817,-2.236 1.451,0.161 v 0.002 m 510.449,-259.977 1.263,-0.48 -0.753,1.945 -0.526,-1.477 0.016,0.012 m -431.341,25.875 0.356,2.187 -1.736,-1.445 1.365,-0.766 0.015,0.024 m 5.246,-1.772 -3.939,-0.389 2.408,-1.382 1.542,1.782 -0.011,-0.011 m 302.629,-61.112 -1.841,-0.893 3.671,-0.728 -1.809,1.627 -0.021,-0.006 m -294.34,-13.645 0.933,-3.107 1.038,0.532 -1.958,2.591 -0.013,-0.016 m 52.751,119.848 3.745,-1.736 -1.914,2.584 -1.846,-0.804 0.015,-0.044 m 427.012,212.47 -1.729,4.237 0.956,-3.017 0.8,-1.283 -0.027,0.063 m -495.217,-276.313 -1.277,2.84 -0.759,-1.793 2.051,-1.068 -0.015,0.021 m 15.568,86.2 0.568,1.452 -3.375,-2.343 2.797,0.863 0.01,0.028 m 480.308,167.266 0.673,-4.906 0.573,0.945 -1.245,3.97 -10e-4,-0.009 m 8.35,-98.38 -1.07,-1.37 0.443,-2.418 0.63,3.781 v 0.007 m -487.855,-184.835 4.086,-1.301 -0.91,1.602 -3.194,-0.291 0.018,-0.01 m 286.65,-25.584 2.206,0.838 -1.476,0.529 -0.736,-1.367 h 0.01 m -288.183,36.921 0.419,-2.095 2.575,-1.221 -3.01,3.339 0.016,-0.023 m 370.644,269.703 0.029,-0.011 0.315,0.22 1.767,1.343 -2.111,-1.552 m -349.682,79.002 -1.018,4.585 -0.911,-4.337 1.906,-0.255 0.023,0.01 m 11.505,-245.429 0.208,2.027 -1.518,-1.767 1.313,-0.279 -0.003,0.019 m 445.314,202.305 -0.443,1.795 -0.859,1.78 1.219,-3.416 0.083,-0.159 m -508.504,-295.937 -0.325,1.426 -1.188,-0.488 1.5,-0.955 0.013,0.017 m 524.395,201.427 1.462,8.933 -1.521,-2.838 0.055,-6.119 v 0.024 M 771.1,712.596 l -1.582,0.396 0.212,-1.766 1.401,1.366 -0.031,0.004 m -13.951,110.029 0.625,1.453 -1.554,0.162 0.939,-1.656 -0.01,0.041 m -1.507,-131.627 -0.962,-2.246 1.604,0.147 -0.61,2.096 -0.032,0.003 m 34.658,88.815 0.057,2.387 -1.812,-1.683 1.739,-0.727 0.016,0.023 m -61.426,-58.141 -1.271,1.593 -2.194,-1.208 3.471,-0.411 -0.006,0.026 m -24.774,161.876 -0.552,1.401 -0.707,-2.043 1.256,0.614 0.003,0.028 m 467.398,-126.835 -0.948,-5.907 2.116,4.076 -1.155,1.833 -0.013,-0.002 m -360.26,54.722 0.658,-2.008 0.811,2.978 -1.462,-0.935 -0.007,-0.035 m 255.791,-214.649 -1.625,-1.392 1.704,0.97 -0.073,0.425 -0.01,-0.003 m -408.821,255.734 -0.786,1.292 -1.021,-1.643 1.813,0.331 -0.006,0.02 m 125.769,363.303 -1.638,-0.916 3.597,0.806 -1.924,0.122 -0.035,-0.012 m 378.759,-432.724 -1.421,0.104 -1.283,-2.412 2.722,2.311 -0.018,-0.003 m -110.48,-75.323 -1.167,-1.381 1.582,0.226 -0.397,1.156 -0.018,-0.001 m -316.715,-59.742 -3.374,1.453 2.42,-1.842 0.979,0.374 -0.025,0.015 m 8.597,52.586 4.13,-0.113 -5.145,1.707 1,-1.596 0.015,0.002 m 65.796,392.749 0.499,2.02 -2.894,-0.108 2.376,-1.928 0.019,0.016 m -35.138,-369.616 -1.61,-0.724 0.978,-1.512 0.685,2.181 -0.053,0.055 m -135,71.252 -2.843,2.326 -2.229,-1.293 5.078,-1.039 -0.006,0.006 M 792,816.828 l -1.341,6.071 -0.954,-3.501 2.277,-2.608 0.018,0.038 m 315.251,-191.219 -2.256,-1.67 1.795,0.49 0.469,1.179 -0.01,0.001 m -348.997,72.169 -1.908,-4.549 3.118,0.613 -1.18,3.939 -0.03,-0.003 m 241.227,-100.507 0.408,1.01 -4.85,-3.414 4.42,2.397 0.022,0.007 m -220.814,105.343 -3.106,-0.592 -1.305,-3.441 4.481,3.992 -0.07,0.041 m -63.002,83.532 -0.179,4.77 -1.205,-3.331 1.385,-1.452 -10e-4,0.013 m 355.991,-187.367 -0.438,-0.532 3.454,1.927 -3.013,-1.394 v -10e-4 m -312.196,92.49 -2.564,-0.887 0.875,-1.434 1.701,2.329 -0.012,-0.008 m 352.565,-24.285 1.774,0.149 0.732,1.578 -2.566,-1.748 0.06,0.021 m -352.143,156.435 -1.432,3.835 -0.481,-2.456 1.915,-1.393 -0.002,0.014 m -0.16,-114.668 4.404,0.225 -4.698,2.616 0.265,-2.82 0.029,-0.021 m 279.075,-126.528 0.402,-0.247 3.504,1.256 -3.901,-1.009 v 0 m -278.273,637.728 2.864,1.316 -1.887,-0.714 -1.006,-0.616 0.029,0.014 m 25.046,-443.652 0.056,2.676 -1.798,-1.041 1.746,-1.684 -0.004,0.049 m 7.116,-159.056 1.759,-0.852 -1.527,1.583 -0.236,-0.726 0.004,-0.005 m -18.045,92.431 -3.793,-0.545 -1.9,-4.241 5.701,4.759 -0.008,0.027 m 298.75,-0.507 2.005,0.331 -1.274,1.531 -0.739,-1.86 0.01,-0.002 m -332.466,6.834 2.629,-1.038 -1.648,2.316 -1.02,-1.254 0.039,-0.024 m -133.097,186.991 0.23,1.498 -1.728,-2.889 1.48,1.356 0.018,0.035 m 414.239,-218.901 -2.924,0.82 2.112,-2.228 0.917,1.448 -0.105,-0.04 m 84.927,-64.701 0.086,-0.101 2.037,1.74 -2.123,-1.638 v -10e-4 m -410.243,309.739 -0.903,2.75 -0.911,-2.362 1.82,-0.413 -0.006,0.025 m 67.461,-121.457 -0.55,2.537 -2.702,0.059 3.232,-2.613 0.02,0.017 m 251.766,-126.288 -1.328,-3.876 2.729,2.341 -1.395,1.55 -0.01,-0.015 m -279.93,6.351 -1.334,-4.274 2.176,2.604 -0.839,1.694 -0.003,-0.024 m 313.88,0.629 2.012,0.102 -0.973,1.164 -1.049,-1.269 0.01,0.003 m -55.886,-87.656 2.776,-0.44 -1.035,1.053 -1.737,-0.61 -0.004,-0.003 m -235.732,115.269 -0.246,-1.584 2.443,-1.299 -2.178,2.9 -0.019,-0.017 m 65.685,25.221 -2.95,-1.749 2.394,-3.729 0.556,5.472 v 0.006 m -23.838,21.649 1.545,2.643 -3.041,-2.489 1.489,-0.213 0.007,0.059 m 20.141,29.204 -0.756,1.537 -1.028,-1.665 1.818,0.09 -0.034,0.038 m -116.043,96.152 0.126,1.921 -1.54,-0.753 1.411,-1.171 0.003,0.003 m 319.447,-213.463 4.351,2.093 0.243,1.551 -4.603,-3.649 0.01,0.005 m -225.957,137.364 -4.373,5.477 0.496,-7.016 3.874,1.517 0.003,0.022 m 271.756,-121.649 1.317,0.455 -0.879,1.304 -0.438,-1.759 m 16.974,-1.559 -0.7,-2.411 5.509,4.674 -4.809,-2.263 m -287.024,432.663 4.143,1.36 0.728,1.706 -4.871,-3.066 m 431.076,-116.863 -1.015,1.69 0.307,-1.857 0.708,0.167 m -616.468,-166.052 -1.271,0.362 0.992,-2.565 0.279,2.203 m 150.735,-154.072 -2.5,5.488 -1.926,0.53 4.426,-6.018 m -82.959,118.153 -0.295,-3.863 1.722,-2.391 -1.427,6.254 m 487.278,245.457 -1.155,1.765 0.065,-1.605 1.09,-0.16 m -320.794,161.635 3.522,0.363 -0.115,0.786 -3.407,-1.149 m 143.902,-613.319 4.156,2.897 -2.52,-0.938 -1.636,-1.959 m -236.905,115.944 1.898,-1.37 0.603,1.086 -2.501,0.284 m 231.419,-151.414 -0.896,-0.27 4.454,1.127 -3.558,-0.857 m -388.928,288.522 0.97,-1.603 -1.159,2.813 0.189,-1.21 m 207.026,-89.956 -3.416,-2.91 4.09,0.965 -0.674,1.945 m -47.698,459.262 -0.554,-0.395 1.695,0.818 -1.141,-0.423 m 9.426,-414.815 2.157,1.298 -2.583,0.721 0.426,-2.019 m 461.279,175.534 0.855,-1.61 -1.144,4.322 0.289,-2.712 M 1188.197,806.501 V 806.5 l 1.875,3.501 -1.877,-3.5 m -166.082,-101.988 0.035,0.031 -4.852,-1.372 4.817,1.341 m -344.005,323.062 1.39,0.779 -1.438,-0.562 0.048,-0.217 m 423.248,-31.594 0.011,-0.026 8.275,-6.901 -8.286,6.927 m -25.166,-381.374 -7.274,-4.745 7.31,4.745 h -0.036 m 142.026,429.079 3.632,-7.134 -3.63,7.132 v 0 m -524.045,-87.792 10e-4,-0.004 1.196,1.758 -1.197,-1.754 m 390.062,67.761 0.015,-0.021 12.847,-12.132 -12.862,12.153 M 744.68,686.04 l 2.415,-0.196 -2.42,0.198 0.005,-0.002 m 8.074,4.433 4.036,2.174 -4.057,-2.135 0.021,-0.039 m 325.015,344.027 4.441,-7.929 -4.438,7.935 v -0.01 m -26.921,-328.6 2.492,0.456 -2.466,-0.437 -0.026,-0.019 M 723.467,895.781 v -0.002 l 1.66,-0.481 -1.66,0.483 m 52.59,-103.594 -2.702,2.048 2.713,-2.057 -0.011,0.009 m -75.018,-104.968 0.011,-0.011 -3.649,5.56 3.638,-5.549 m 88.287,100.475 4.718,0.39 -4.768,-0.378 0.05,-0.012 m -37.347,23.355 0.004,-0.021 1.179,3.926 -1.183,-3.905 m 266.109,-113.653 0.064,0.009 -7.145,0.592 7.081,-0.601 M 1233.26,960.67 v 0.003 l 1.3,-3.982 -1.297,3.979 m -41.961,-185.914 2.138,1.777 -2.15,-1.781 0.012,0.004 m -452.364,-152.313 0.56,-3.2 -0.542,3.208 -0.018,-0.008 m 53.355,179.491 -0.059,3.012 0.053,-3.036 0.006,0.024 m 223.127,-108.648 0.029,0.002 -5.882,0.323 5.853,-0.325 m -276.715,20.264 3.022,-0.157 -3.045,0.177 0.023,-0.02 m -46.985,-18.521 -0.002,0.021 -0.807,-3.171 0.809,3.15 m 57.36,23.281 3.788,-0.825 -3.809,0.84 0.021,-0.015 m -49.266,191.446 -1.948,4.1 1.955,-4.124 -0.007,0.024 m 91.507,-130.412 -0.033,-0.036 3.422,0.147 -3.389,-0.111 m -4.685,34.019 0.737,2.528 -0.75,-2.542 0.013,0.014 m -10.694,-97.046 -2.472,-3.599 2.569,3.546 -0.097,0.053 m 86.429,487.222 0.007,0.018 -2.77,-1.262 2.763,1.244 m -104.426,-479.077 2.128,-4.159 -2.133,4.176 0.005,-0.017 m 35.406,40.938 -0.008,-0.02 1.622,2.466 -1.614,-2.446 m 394.326,57.558 v -0.006 l 1.003,0.548 -1,-0.542 m -139.456,-124.696 -0.015,-0.018 2.64,1.063 -2.625,-1.045 m -363.334,19.779 -2.751,0.913 2.789,-0.932 -0.038,0.019 m 363.427,19.484 -0.01,-0.029 2.978,5.878 -2.968,-5.849 m -323.148,-29.451 2.542,-1.76 -2.57,1.79 0.028,-0.03 m 37.614,18.76 1.47,-3.06 -1.464,3.097 -0.006,-0.037 m -39.728,9.912 h 0.015 l -1.525,2.738 1.51,-2.738 m 131.147,472.32 0.028,0.017 -2.219,-0.88 2.191,0.863 m -89.155,-485.915 2.529,-0.467 -2.554,0.485 0.025,-0.018 m 341.651,14.834 2.776,2.457 -2.78,-2.439 v -0.018 m -386.659,-3.381 -2.628,0.108 2.648,-0.126 -0.02,0.018 m 335.364,-26.32 0.018,0.018 -3.07,-2.006 3.052,1.988 M 756.7,675.263 l 0.017,-0.003 -2.712,2.002 2.695,-1.999 m 345.066,112.942 0.996,-3.416 -0.98,3.436 -0.016,-0.02 m -369.853,-36.671 -4.24,-1.04 4.273,1.034 -0.033,0.006 m 101.59,85.331 -5.262,3.054 5.248,-3.081 0.014,0.027 M 681.542,726.8 l -4.174,4.403 4.19,-4.422 -0.016,0.019 m 358.296,12.846 -0.021,-0.035 2.486,2.47 -2.465,-2.435 m -408.635,143.631 0.337,-3.417 -0.286,3.398 -0.051,0.019 m 59.201,-173.398 -0.696,-2.82 0.714,2.823 -0.018,-0.003 m 330.596,4.679 7.135,0.913 -7.155,-0.901 0.02,-0.012 m -295.524,-54.234 -4.736,1.857 4.766,-1.869 -0.03,0.012 m 302.017,59.24 2.706,1.867 -2.721,-1.868 0.015,10e-4 m -299.942,-58.952 0.035,-0.026 -4.573,4.004 4.538,-3.978 m 113.637,473.447 -0.007,5.067 -0.045,-5.091 0.052,0.024 m 189.985,-445.065 0.338,-2.336 -0.324,2.32 -0.014,0.016 m -323.399,24.158 -0.005,0.018 0.094,-4.076 -0.089,4.058 m 39.956,-1.973 2.676,-0.543 -2.707,0.556 0.031,-0.013 m 19.263,8.944 2.859,-2.007 -2.853,2.036 -0.006,-0.029 m -36.549,61.263 0.022,0.021 -3.021,-0.92 2.999,0.899 m 319.935,89.95 -0.022,-10e-4 3.055,-1.088 -3.033,1.089 m -314.859,-83.612 -1.509,-1.467 1.521,1.477 -0.012,-0.01 m 74.085,23.166 -0.002,0.014 0.17,-2.185 -0.168,2.171 m 14.573,-107.946 1.367,2.394 -1.374,-2.398 0.007,0.004 m -121.014,-16.067 -3.031,3.45 3.051,-3.475 -0.02,0.025 m 73.811,6.807 0.017,-0.026 -1.138,2.815 1.121,-2.789 m 17.847,74.411 0.016,-0.023 -1.389,2.257 1.373,-2.234 m 12.993,18.029 0.008,-0.03 -0.289,2.39 0.281,-2.36 m 222.697,-51.534 -0.019,-0.013 4.283,1.91 -4.264,-1.897 m -265.454,108.749 -4.125,7.004 4.132,-7.038 -0.007,0.034 m 12.933,-132.225 -1.203,-0.701 1.212,0.704 -0.009,-0.003 M 1069.84,597.335 v 0 l 1.488,0.312 -1.488,-0.312 m 72.715,417.001 6.706,-0.961 -6.717,0.984 0.011,-0.023 m -405.621,-394.972 0.021,-0.016 -2.058,1.688 2.037,-1.672 m 503.339,295.806 -0.202,4.478 0.191,-4.495 0.011,0.017 m -74.57,87.75 -2.621,4.616 2.613,-4.603 0.01,-0.013 m -473.837,-290.46 -2.161,4.132 2.166,-4.191 -0.005,0.059 m -11.458,7.784 0.021,-0.003 -4.056,2.23 4.035,-2.227 m 369.608,-24.165 -4.667,-0.445 4.698,0.437 -0.031,0.008 m 5.289,175.937 -0.365,1.893 0.341,-1.893 h 0.024 M 750.068,822.1 l -0.734,2.476 0.724,-2.508 0.01,0.032 m -29.66,-82.843 -2.135,-0.053 2.177,0.04 -0.042,0.013 m -60.576,130.934 0.003,0.002 -0.813,5.311 0.81,-5.313 m 414.775,-55.987 1.657,-2.536 -1.647,2.573 -0.01,-0.037 m -268.426,-4.062 0.755,-2.851 -0.756,2.864 0.001,-0.013 m -74.175,-60.978 0.034,0.01 -2.428,-0.044 2.394,0.034 m 337.556,102.229 -1.708,1.727 1.687,-1.718 0.021,-0.009 m -273.304,-67.639 -0.211,1.707 0.128,-1.707 h 0.083 m 246.392,-88.352 0.604,-1.996 -0.585,2.009 -0.019,-0.013 m -136.163,457.316 -2.196,0.414 2.196,-0.426 v 0.012 m 227.707,-423.721 -0.03,2.795 v -2.755 l 0.035,-0.04 m -54.448,72.107 0.017,0.013 -2.298,-0.738 2.281,0.725 m -346.627,-33.328 -0.002,0.004 -2.042,-1.255 2.044,1.251 m 405.291,-56.937 v -0.02 l 3.054,0.59 -3.058,-0.57 m -385.756,0.694 -0.029,0.012 2.585,-1.376 -2.556,1.364 m -7.079,5.506 -0.027,10e-4 3.349,-1.183 -3.322,1.182 m 337.611,94.824 -0.727,-2.767 0.744,2.775 -0.017,-0.008 m -329.25,-133.892 -1.935,1.089 1.937,-1.105 -0.002,0.016 m 289.77,15.01 -1.957,-0.929 1.986,0.936 -0.029,-0.007 m -187.836,522.403 -0.009,-10e-4 0.95,-0.352 -0.941,0.353 m -101.365,-517.699 0.762,-2.232 -0.75,2.253 -0.012,-0.021 m 79.195,533.015 2.321,-0.87 -2.271,0.883 -0.05,-0.013 m -108.815,-350.493 0.4,2.553 -0.406,-2.558 0.006,0.005 m 364.445,-71.256 v 0.01 l -0.366,-2.61 0.365,2.6 m -339.405,10.387 -1.185,4.54 1.167,-4.581 0.018,0.041 m -54.97,-124.69 -0.01,0.011 -0.342,-3.532 0.352,3.521 m 324.259,4.622 0.073,-0.015 -3.348,1.132 3.275,-1.117 m -386.198,163.172 -0.006,-0.01 1.153,-0.025 -1.147,0.035 m 101.417,-243.189 0.014,-0.004 -2.758,1.237 2.744,-1.233 m 7.303,3.087 0.003,0.014 -0.497,-1.7 0.494,1.686 m 10.032,76.738 -0.035,-0.047 3.709,-0.446 -3.674,0.493 m 294.252,2.775 -2.206,-1.329 2.253,1.332 -0.047,-0.003 m -290.739,-15.659 -2.344,-1.965 2.377,1.958 -0.033,0.007 m 280.601,-2.415 3.378,0.421 -3.403,-0.417 0.025,-0.004 m 118.541,-23.544 -1.663,-1.993 1.673,2.001 -0.01,-0.008 m 22.28,344.674 v 0 l 1.137,0.131 -1.137,-0.127 m -9.275,-330.27 v 0.002 l -0.297,-0.178 0.295,0.176 m -479.267,196.851 0.003,0.002 1.403,2.969 -1.406,-2.971 m 359.151,-137.193 -0.031,-0.005 1.53,-1.389 -1.499,1.394 m -316.988,4.005 2.306,0.212 -2.312,-0.198 0.006,-0.014 m 298.364,-49.528 -0.035,-1.446 0.066,1.439 -0.031,0.007 m -287.527,86.134 -1.95,-0.555 1.976,0.546 -0.026,0.009 m -6.476,-20.787 -2.111,-0.607 2.129,0.601 -0.018,0.006 m 429.969,-13.795 1.971,-0.309 -1.979,0.343 0.01,-0.034 m -419.505,97.679 -1.651,-0.438 1.68,0.409 -0.029,0.029 m 455.408,169.609 0.011,-0.026 2.263,-3.885 -2.274,3.911 m -40.835,-215.807 v -0.028 l 1.408,1.957 -1.406,-1.929 m -129.144,-110.874 2.848,0.538 -2.854,-0.537 0.01,-10e-4 m -220.627,100.671 -0.467,4.106 0.468,-4.14 -10e-4,0.034 m 241.493,-71.009 1.171,1.382 -1.175,-1.376 v -0.006 m -12.751,-18.94 -1.137,-2.05 1.147,2.035 -0.01,0.015 m 99.665,34.908 2.754,-1.593 -2.759,1.8 v -0.207 m -16.293,78.421 1.777,0.223 -1.789,-0.21 0.012,-0.013 m -379.605,-34.981 -1.805,-1.437 1.844,1.431 -0.039,0.006 m -136.673,111.82 -0.973,4.095 0.965,-4.108 0.008,0.013 m 439.428,-155.529 0.02,2.941 -0.037,-2.969 0.017,0.028 m -46.281,-131.226 -5.998,-1.644 6.015,1.643 -0.017,10e-4 m -323.008,110.961 -2.233,1.228 2.235,-1.244 -0.002,0.016 m 47.213,86.29 -1.435,-0.313 1.444,0.292 -0.009,0.021 m 399.306,-154.693 2.152,2.648 -2.158,-2.653 0.01,0.005 m -355.391,190.613 0.036,-0.001 -1.18,1.346 1.144,-1.345 m -9.731,-6.793 -1.932,1.672 1.956,-1.706 -0.024,0.034 m 479.624,155.263 1.021,-4.08 -0.936,3.943 -0.085,0.137 m -436.494,-182.532 1.878,0.18 -1.85,-0.167 -0.028,-0.013 m 336.98,-66.744 -2.376,0.695 2.39,-0.703 -0.014,0.008 m -333.231,27.697 -0.02,-0.046 2.099,1.639 -2.079,-1.593 m -29.523,-89.866 -2.469,0.453 2.49,-0.471 -0.021,0.018 m -8.23,45.736 1.85,-0.452 -1.865,0.478 0.015,-0.026 m 34.757,42.254 -1.078,1.854 1.08,-1.882 -0.002,0.028 m 245.457,106.694 v -0.021 l -0.066,1.752 0.063,-1.731 m -323.481,-75.578 -1.434,-0.63 1.446,0.604 -0.012,0.026 m 19.194,50.561 -1.961,2.548 1.976,-2.569 -0.015,0.021 m -42.41,47.178 -1.408,1.088 1.405,-1.096 0.003,0.008 m 100.261,-77.896 1.812,-0.205 -1.827,0.257 0.015,-0.052 m 285.65,-112.168 0.992,-2.325 -0.802,2.407 -0.19,-0.082 m -41.102,12.419 -2.53,-1.528 2.562,1.542 -0.032,-0.014 m -327.895,88.632 -1.062,-2.065 1.091,2.03 -0.029,0.035 m -15.015,-43.736 -2.3,3.35 2.305,-3.382 -0.005,0.032 m 7.713,37.327 -2.456,0.3 2.412,-0.332 0.044,0.032 m 82.681,14.184 -1.347,0.386 1.356,-0.437 -0.009,0.051 m 220.351,-100.434 -0.364,-1.72 0.396,1.707 -0.032,0.013 m -223.369,-17.339 -2.008,-2.244 2.038,2.225 -0.03,0.019 m 309.49,317.04 2.445,-3.217 -2.438,3.221 h -0.01 M 741.413,781.44 l -0.442,-1.522 0.453,1.524 -0.011,-0.002 m 282.341,-73.056 -2.733,-0.267 2.739,0.258 -0.01,0.009 m -208.695,2.326 -1.735,0.294 1.743,-0.301 -0.008,0.007 m 207.797,-0.141 -0.021,-0.01 3.315,0.614 -3.294,-0.604 m 174.347,312.89 v 0.01 l -1.046,-0.526 1.048,0.521 M 745.61,613.27 l 0.048,-0.019 -2.089,1.2 2.041,-1.181 m -5.033,202.131 0.027,-0.021 -0.59,1.614 0.563,-1.593 m 8.233,-133.749 -0.038,0.015 1.98,-1.055 -1.942,1.04 m 353.322,-66.927 -0.019,-0.013 1.656,0.999 -1.637,-0.986 m 128.751,290.751 -0.957,-0.961 0.97,0.949 -0.013,0.012 m -103.168,-139.909 1.834,1.538 -1.838,-1.54 v 0.002 m -357.475,-55.123 -1.678,1.554 1.694,-1.576 -0.016,0.022 m 39.37,76.625 0.003,2.506 -0.006,-2.568 0.003,0.062 m -165.581,183.183 2.443,-0.638 -2.438,0.68 -0.005,-0.042 m 152.335,-294.903 -1.646,1.243 1.667,-1.265 -0.021,0.022 m -13.895,554.315 -0.029,-0.01 -1.723,-0.646 1.752,0.656 m 31.808,-442.328 -0.889,3.045 0.892,-3.068 -0.003,0.023 m -130.696,-64.599 0.035,-0.008 -3.119,1.896 3.084,-1.888 m 120.36,38.169 -1.552,-0.313 1.538,0.284 0.014,0.029 m -7.529,9.48 0.002,-0.039 1.713,1.437 -1.715,-1.398 m -173.55,162.951 -10e-4,1.718 -0.003,-1.724 0.004,0.006 m 472.4,65.316 2.645,-2.748 -2.659,2.766 0.014,-0.018 M 698.43,692.079 l -1.053,2.995 1.053,-3.007 v 0.012 m 352.146,5.578 0.027,0.019 -1.988,-0.962 1.961,0.943 m -325.73,77.635 -1.204,1.003 1.209,-1.041 -0.005,0.038 m 35.375,-88.204 -1.589,0.344 1.616,-0.373 -0.027,0.029 m 5.721,123.905 -2.108,1.002 2.141,-1.022 -0.033,0.02 m 30.039,-12.32 0.554,2.469 -0.571,-2.46 0.017,-0.009 m -29.37,-89.802 1.72,-0.355 -1.758,0.367 0.038,-0.012 m -1.496,-50.918 -0.025,0.009 1.594,-1.046 -1.569,1.037 m -96.441,69.107 1.719,-3.078 -1.724,3.09 0.005,-0.012 m 86.616,-24.378 1.487,0.662 -1.513,-0.659 0.026,-0.003 m -63.1,155.761 -0.676,2.818 0.668,-2.832 0.008,0.014 m 43.656,-150.312 0.02,-0.022 -0.282,1.52 0.262,-1.498 m -10.48,33.216 -1.526,0.448 1.538,-0.454 -0.012,0.006 m 12.453,-23.497 -2.75,-0.009 2.749,-0.019 10e-4,0.028 m 259.882,-119.587 -3.38,-2.353 3.375,2.344 0.005,0.009 m -250.839,222.289 -1.26,1.728 1.266,-1.763 -0.006,0.035 m 346.048,-188.43 10e-4,0.002 -0.738,0.238 0.737,-0.24 m 94.014,138.874 2.402,1.649 -2.418,-1.654 0.016,0.005 m -380.62,13.23 0.013,-0.011 -0.449,3.456 0.436,-3.445 m -53.43,374.017 -0.646,-1.224 0.649,1.218 -0.003,0.01 m -23.593,-403.1 -1.096,-1.48 1.183,1.46 -0.087,0.02 m 50.213,88.727 0.021,-0.019 -0.725,2.16 0.704,-2.141 m 39.803,-40.947 -1.667,0.507 1.677,-0.521 -0.01,0.014 m -112.015,-10.867 -1.653,0.529 1.656,-0.538 -0.003,0.009 m 205.514,364.316 -1.361,-0.129 1.361,0.118 v 0.011 m -157.978,-438.218 -0.403,1.356 0.385,-1.352 0.018,-0.004 m 333.788,-107.721 v -0.002 l 1.231,0.526 -1.229,-0.524 m 9.934,385.174 -0.05,2.746 0.037,-2.729 0.013,-0.017 m -358.058,-188.095 -2.061,0.094 2.09,-0.116 -0.029,0.022 m -0.41,-74.297 -2.725,1.143 2.73,-1.16 -0.005,0.017 m 72.208,75.246 -0.007,0.027 0.252,-2.354 -0.245,2.327 m -37.286,0.241 -1.898,1.066 1.897,-1.071 10e-4,0.005 m 270.735,53.108 1.673,-0.165 -1.695,0.191 0.022,-0.026 m -376.565,-3.216 0.004,0.004 -0.937,-0.64 0.933,0.636 m 343.22,-69.351 -0.547,1.449 0.532,-1.47 0.015,0.021 m -283.378,-134.499 -2.591,0.8 2.618,-0.818 -0.027,0.018 m 96.746,472.994 2.323,6.275 -2.438,-6.398 0.115,0.123 m -162.75,-239.905 0.052,1.634 -0.057,-1.644 0.005,0.01 m -32.634,60.027 -0.016,-0.028 1.192,2.097 -1.176,-2.069 m 420.43,-243.861 1.474,0.656 -1.496,-0.663 0.022,0.007 m -242.57,114.688 -0.439,3.456 0.439,-3.477 v 0.021 m -75.61,-122.925 -1.389,-1.233 1.415,1.222 -0.026,0.011 m -49.155,8.433 0.017,-0.007 -2.224,1.946 2.207,-1.939 m 349.333,17.181 1.114,1.334 -1.128,-1.331 0.014,-0.003 m -272.13,107.097 -1.761,0.991 1.799,-1.018 -0.038,0.027 m 250.277,-27.92 v -0.015 l -0.245,1.714 0.241,-1.699 m -270.947,-98.305 2.508,-0.347 -2.541,0.365 0.033,-0.018 m -0.886,44.847 0.013,0.02 -2.149,-0.359 2.136,0.339 m 451,26.839 0.865,0.338 -0.872,-0.338 h 0.01 m -58.983,32.371 0.564,1.45 -0.578,-1.46 0.014,0.01 m -84.868,-107.735 0.04,0.015 -1.291,-0.314 1.251,0.299 m 195.294,254.815 0.358,-1.727 -0.36,1.748 v -0.021 m -197.775,-246.788 -0.01,-0.006 1.853,1.779 -1.848,-1.773 m -325.179,23.081 -1.451,0.397 1.451,-0.401 v 0.004 m -46.177,5.984 1.302,-0.781 -1.329,0.805 0.027,-0.024 m 353.475,-18.627 -2.807,-0.526 2.844,0.52 -0.037,0.006 m 135.259,62.59 -1.324,0.101 1.335,-0.115 -0.011,0.014 m -485.207,-64.255 -1.848,2.319 1.857,-2.335 -0.009,0.016 m 85.949,-2.164 2.437,-0.662 -2.454,0.681 0.017,-0.019 m -93.733,28.816 -2.145,0.046 2.127,-0.069 0.018,0.023 m 125.196,40.237 -1.707,1.5 1.725,-1.519 -0.018,0.019 m 285.992,23.61 0.015,0.02 -1.284,-0.196 1.269,0.176 m -435.563,154.452 0.008,-0.011 0.93,0.515 -0.938,-0.504 m 428.841,-270.89 -0.032,-0.008 2.384,0.038 -2.352,-0.03 m -267.405,77.645 -0.488,2.196 0.493,-2.233 -0.005,0.037 m 227.985,-79.428 1.17,-0.896 -1.195,0.926 0.025,-0.03 m 80.238,299.908 0.011,0.005 1.842,2.215 -1.853,-2.22 m -377.622,-192.292 0.024,-0.012 -3.179,1.604 3.155,-1.592 m 367.971,-144.246 2.45,2.026 -2.465,-2.011 0.015,-0.015 m 3.022,-24.648 -1.138,-1.319 1.14,1.313 v 0.006 m -305.309,69.963 -1.576,1.577 1.563,-1.61 0.013,0.033 m 306.849,355.348 0.554,1.595 -0.56,-1.594 0.01,-10e-4 m -62.478,-347.31 -0.019,1.145 0.01,-1.17 0.013,0.025 m -227.319,101.531 -0.016,-0.011 2.981,0.803 -2.965,-0.792 m -51.867,2.605 -2.152,1.272 2.171,-1.308 -0.019,0.036 m 257.499,-89.349 1.537,1.201 -1.56,-1.202 0.023,0.001 m 215.037,247.341 0.181,-2.35 -0.174,2.345 -0.01,0.005 m -364.431,240.533 -0.85,-0.79 0.875,0.792 h -0.025 m 209.005,-587.531 v 0.002 l -1.31,-0.967 1.308,0.965 m 71.306,41.678 v 0 l -0.406,-0.642 0.406,0.642 m -383.763,54.567 -1.632,-1.48 1.664,1.482 -0.032,-0.002 m 301.28,-111.196 -0.506,0.306 0.507,-0.308 v 0.002 m -319.002,79.223 0.007,0.009 -1.649,-0.128 1.642,0.119 m -20.566,-64.231 -1.235,-0.149 1.271,0.139 -0.036,0.01 m 13.945,-6.502 0.019,-0.01 -1.521,1.666 1.502,-1.656 m 469.445,423.565 0.01,-0.016 -0.128,0.855 0.12,-0.839 m -453.845,86.899 -1.935,-1.709 1.94,1.71 h -0.005 m 286.863,-410.746 v -0.006 l 0.157,2.178 -0.16,-2.172 M 900.063,550.26 l 0.994,-0.064 -0.992,0.064 h -0.002 m -100.423,208.175 -0.485,1.543 0.496,-1.582 -0.011,0.039 m -37.018,-97.977 -0.724,1.441 0.7,-1.442 0.024,10e-4 m 44.449,104.521 h 0.023 l -1.854,1.549 1.831,-1.549 m 220.07,-87.354 -1.051,1.383 1.04,-1.377 0.011,-0.006 m 11.453,51.219 -0.021,-0.016 1.604,0.453 -1.583,-0.437 m -214.134,87.572 0.004,0.034 -1.674,-2.146 1.67,2.112 m -97.596,65.97 0.005,-0.007 1.203,1.403 -1.208,-1.396 m -109.932,-84.978 -1.032,2.67 1.028,-2.693 0.004,0.023 m 148.214,325.584 v 0 l -1.776,-1.322 1.776,1.318 m 259.648,-546.971 -0.366,-0.457 0.371,0.459 v -0.002 m -351.278,166.896 -0.014,10e-4 1.605,-1.397 -1.591,1.396 m 390.994,122.119 1.228,1.072 -1.241,-1.084 0.013,0.012 m -327.879,-92.176 -1.324,-0.606 1.317,0.566 0.007,0.04 m -45.125,85.689 -2.068,6.06 2.069,-6.081 -10e-4,0.021 m 184.689,-196.47 -3.733,-0.007 3.711,-0.01 0.022,0.017 m -133.694,155.299 0.016,-0.024 -1.232,2.146 1.216,-2.122 m 367.546,171.386 2.66,-0.792 -2.647,0.799 -0.013,-0.007 m -78.807,-252.512 2.58,2.141 -2.616,-2.144 0.036,0.003 m -257.488,78.271 -1.763,0.899 1.786,-0.93 -0.023,0.031 m 277.768,-74.086 1.553,0.467 -1.572,-0.47 0.019,0.003 m 45.278,44.324 -0.469,-1.348 0.488,1.369 -0.019,-0.021 m -343.134,-90.991 1.118,0.5 -1.139,-0.498 0.021,-0.002 m 75.971,18.409 -1.68,0.993 1.703,-1.01 -0.023,0.017 m 245.801,326.179 1.354,-2.477 -1.299,2.451 -0.055,0.026 m -410.272,-272.279 -1,0.947 1.022,-0.984 -0.022,0.037 m 49.621,-30.161 -2.142,1.261 2.149,-1.28 -0.007,0.019 m 64.763,69.192 -1.438,1.551 1.441,-1.581 -0.003,0.03 m 220.873,-213.615 -2.466,0.807 2.462,-0.81 v 0.003 m -280.124,192.857 -0.646,-1.327 0.648,1.314 -0.002,0.013 m 303.645,-74.464 0.021,0.008 -2.155,-0.638 2.134,0.63 m 114.828,104.93 1.037,0.21 -1.045,-0.203 0.01,-0.007 m -366.944,-95.06 -1.108,0.828 1.1,-0.867 0.008,0.039 m 341.928,-96.896 1.629,1.275 -1.627,-1.274 v -0.001 m -394.876,160.871 -0.48,-1.292 0.511,1.291 -0.031,0.001 m -1.055,-7.093 -1.159,-0.619 1.177,0.628 -0.018,-0.009 m 49.064,-61.352 1.786,-1.014 -1.797,1.038 0.011,-0.024 m 13.85,126.978 -0.02,2.146 0.019,-2.192 10e-4,0.046 m 11.924,-18.787 0.034,-0.028 -0.978,2.229 0.944,-2.201 M 755.984,710.1 h -0.024 l 1.701,-1.16 -1.677,1.16 m 294.805,-14.321 -0.943,-1.375 0.96,1.394 -0.017,-0.019 m -247.881,66.381 -0.594,1.203 0.582,-1.224 0.012,0.021 m 253.691,-54.56 0.626,-0.989 -0.611,1 -0.015,-0.011 m -222.185,132.671 -2.873,1.042 2.9,-1.057 -0.027,0.015 m 240.336,-31.778 -0.491,1.852 0.47,-1.866 0.021,0.014 m -339.778,-158.195 -2.392,1.593 2.406,-1.604 -0.014,0.011 m 411.947,1.852 -0.275,-0.33 0.28,0.334 v -0.004 m -430.904,110.621 0.005,0.005 -1.794,0.546 1.789,-0.551 m 35.973,-82.538 -1.567,0.065 1.582,-0.073 -0.015,0.008 m -25.318,11.142 0.282,-1.796 -0.264,1.806 -0.018,-0.01 m 405.693,52.688 1.233,1.016 -1.241,-1.02 0.01,0.004 m 17.737,-73.671 0.408,0.899 -0.41,-0.899 v 0 m -378.092,43.498 -0.329,-1.094 0.355,1.098 -0.026,-0.004 m -16.808,-12.078 -0.079,0.002 1.115,-1.162 -1.036,1.16 m 292.709,4.916 1.638,1.294 -1.661,-1.29 0.023,-0.004 m -327.384,83.632 -1.061,-0.463 1.062,0.455 -10e-4,0.008 m -75.556,-48.658 -1.435,1.775 1.461,-1.813 -0.026,0.038 m 100.645,-15.642 -10e-4,-0.006 1.164,0.332 -1.163,-0.326 m -4.035,22.449 -0.565,-1.642 0.597,1.634 -0.032,0.008 m -103.74,-0.95 -0.749,-0.088 0.766,0.063 -0.017,0.025 m 106.904,30.973 0.525,-1.261 -0.518,1.273 -0.007,-0.012 m 2.117,-106.928 1.906,-1.084 -1.891,1.095 -0.015,-0.011 m -5.003,28.334 2.005,-0.957 -2.037,0.979 0.032,-0.022 m 285.799,26.665 2.021,2.174 -2.06,-2.174 h 0.039 m -258.337,-55.655 -1.16,2.037 1.175,-2.071 -0.015,0.034 m -138.093,214.448 -0.8,0.854 0.813,-0.876 -0.013,0.022 m 529.12,-90.275 0.118,1.84 -0.147,-1.878 0.029,0.038 m -134.593,-102.242 -0.736,-1.188 0.759,1.189 -0.023,-10e-4 m -264.497,124.184 -1.617,1.266 1.625,-1.287 -0.008,0.021 m 284.085,-125.385 1.968,0.483 -1.972,-0.476 v -0.007 m -305.935,34.862 -0.088,0.04 1.47,-1.036 -1.382,0.996 m 411.598,-35.652 0.465,1.124 -0.477,-1.135 0.012,0.011 m -420.875,85.102 -1.778,0.427 1.819,-0.439 -0.041,0.012 m 16.58,73.49 0.021,-0.064 -0.325,2.926 0.304,-2.862 m -36.059,44.849 0.946,1.628 -0.94,-1.603 -0.006,-0.025 m 129.668,-53.24 2.601,0.404 -2.619,-0.371 0.018,-0.033 m -86.232,-148.743 0.02,0.008 -2.045,-0.388 2.025,0.38 m 59.17,436.339 h -0.005 l 1.313,-0.15 -1.308,0.153 m 203.536,-418.483 -0.57,-1.533 0.597,1.491 -0.027,0.042 m -53.724,30.675 -0.335,1.768 0.309,-1.756 0.026,-0.012 m -230.53,-50.525 -1.413,-0.58 1.433,0.547 -0.02,0.033 m 494.314,334.769 0.544,-1.482 -0.54,1.472 v 0.01 m -77.031,-358.567 v 10e-4 l 1.455,1.965 -1.457,-1.966 m -471.031,58.737 0.018,-0.005 -1.87,2.145 1.852,-2.14 m 436.096,-31.467 -3.661,-4.222 3.71,4.26 -0.049,-0.038 m -400.428,49.975 -1.505,-0.348 1.52,0.304 -0.015,0.044 m 85.292,67.701 0.019,-0.033 0.052,1.792 -0.071,-1.759 m -91.204,-91.297 -0.307,1.173 0.314,-1.203 -0.007,0.03 m 104.137,54.312 -1.491,1.979 1.511,-2.012 -0.02,0.033 m 284.379,-159.106 1.506,1.043 -1.511,-1.045 v 0.002 m -375.148,131.724 -1.011,-0.951 1.012,0.939 -10e-4,0.012 m 58.247,481.697 h -0.013 l -0.25,-0.117 0.263,0.122 m -44.753,-493.521 0.018,-0.005 -1.526,1.587 1.508,-1.582 m 85.146,55.375 0.04,-0.02 -1.008,1.185 0.968,-1.165 m -69.279,-77.139 1.278,0.281 -1.338,-0.264 0.06,-0.017 m 408.204,74.802 0.289,1.316 -0.305,-1.339 0.016,0.023 m -426.529,-133.47 0.04,-0.013 -2.374,1.149 2.334,-1.136 m 20.964,184.769 0.027,-0.01 -1.699,1.11 1.672,-1.1 m -19.295,-92.256 0.011,0.01 -1.496,-0.246 1.485,0.236 m 482.778,281.05 -10e-4,0.01 -0.703,1.687 0.704,-1.693 m -433.502,-211.607 -0.845,1.895 0.836,-1.936 0.009,0.041 m -130.233,-34.59 -1.546,1.354 1.584,-1.417 -0.038,0.063 m 57.68,-48.576 -1.271,2.004 1.279,-2.022 -0.008,0.018 m -3.189,83.24 0.009,-0.007 -1.36,1.746 1.351,-1.739 m 31.699,-72.133 -1.526,-0.033 1.542,0.015 -0.016,0.018 m 13.541,-36.695 0.037,1.337 -0.051,-1.349 0.014,0.012 m 10.18,14.643 -0.083,1.36 0.068,-1.34 0.015,-0.02 m 155.99,-55.963 0.013,-0.022 -1.146,2.389 1.133,-2.367 m -159.681,553.154 -1.277,-0.549 1.271,0.543 0.006,0.01 m 369.93,-413.588 0.846,1.38 -0.868,-1.359 0.022,-0.021 m -63.952,-94.366 0.339,1.333 -0.341,-1.34 v 0.007 m -353.904,13.418 -1.76,-0.063 1.767,0.036 -0.007,0.027 m 33.805,124.062 -0.881,2.72 0.882,-2.752 -0.001,0.032 m 59.89,-79.274 -1.745,-0.022 1.75,10e-4 -0.005,0.021 m -94.309,-9.366 -0.945,1.898 0.963,-1.954 -0.018,0.056 m 48.543,-74.326 -1.57,0.351 1.613,-0.364 -0.043,0.013 m -65.048,2.252 -1.279,-0.15 1.293,0.137 -0.014,0.013 m 59.28,-25.571 -0.029,0.023 1.553,-1.912 -1.524,1.889 m -32.813,78.9 -1.535,0.762 1.536,-0.774 -0.001,0.012 m 376.918,266.634 0.01,-0.032 0.962,-2.59 -0.968,2.622 M 913.537,550.485 h -0.044 l -1.377,-0.054 1.421,0.054 m 127.267,189.184 1.43,0.818 -1.461,-0.827 0.031,0.009 m -227.945,64.501 1.709,1.698 -1.727,-1.707 0.018,0.009 m 417.757,200.502 v -0.01 l 0.205,0.256 -0.208,-0.248 m -220.592,-231.93 -0.217,1.645 0.201,-1.679 0.016,0.034 m -312.559,141.487 -0.15,1.918 0.145,-1.907 0.005,-0.011 m 17.8,-156.421 -1.464,1.53 1.466,-1.538 -0.002,0.008 m 24.172,-17.586 0.033,0.007 -1.704,0.17 1.671,-0.177 m -3.772,11.301 -1.725,-0.577 1.75,0.561 -0.025,0.016 m 413.435,-90.216 1.155,1.128 -1.163,-1.134 0.01,0.006 m -430.057,70.057 0.019,0.007 -1.262,-0.457 1.243,0.45 m 89.447,59.496 0.257,1.583 -0.264,-1.603 0.007,0.02 m -134.661,-61.521 0.017,-0.007 -2.057,1.458 2.04,-1.451 m 112.926,-52.551 0.173,-1.706 -0.156,1.713 -0.017,-0.007 m 9.297,34.984 0.016,-0.005 -1.844,0.614 1.828,-0.609 m 425.726,318.041 -10e-4,0.01 -0.5,1.513 0.501,-1.522 m -196.327,-293.531 -0.011,-0.008 1.688,-1.15 -1.677,1.158 m 17.455,-48.27 0.08,1.131 -0.104,-1.135 0.024,0.004 M 720.041,788.5 l -1.253,0.028 1.271,-0.059 -0.018,0.031 m 291.608,-96.135 -2.299,0.172 2.299,-0.182 v 0.01 m 24.164,-10.551 v -0.002 l 1.424,1.141 -1.427,-1.139 m -425.627,160.016 -0.772,1.609 0.756,-1.594 0.016,-0.015 m 130.635,-120.642 0.005,0.002 -1.364,1.118 1.359,-1.12 m 18.085,111.605 0.006,-0.005 -1.103,1.67 1.097,-1.665 m 37.601,-119.168 -0.116,-1.297 0.139,1.303 -0.023,-0.006 m 16.593,101.125 -0.012,0.023 -0.042,-1.6 0.054,1.577 m -83.204,-78.137 0.012,10e-4 -1.648,0.772 1.636,-0.773 m 24.364,-36.519 1.52,0.705 -1.555,-0.707 0.035,0.002 m -16.116,-73.01 -1.672,0.958 1.675,-0.974 -0.003,0.016 m 19.174,85.627 1.003,0.817 -1.043,-0.808 0.04,-0.009 m -45.029,107.391 -1.338,2.029 1.313,-2.049 0.025,0.02 m 516.326,167.697 v -0.007 l 0.28,0.268 -0.283,-0.261 m -158.326,-349.95 0.023,-0.005 -0.175,1.15 0.152,-1.145 m 12.72,-21.176 -1.813,-1.105 1.813,1.105 v 0 m -325.361,602.144 1.349,0.6 -1.356,-0.603 h 0.007 m 368.363,-462.792 v -0.007 l 1.189,0.506 -1.184,-0.499 m -69.561,-8.802 1.251,0.619 -1.264,-0.621 0.013,0.002 m -292.515,-88.332 1.527,0.215 -1.565,-0.19 0.038,-0.025 m 256.145,42.701 0.028,0.002 -1.632,0.245 1.604,-0.247 m -297.113,48.814 -1.144,1.374 1.145,-1.39 -10e-4,0.016 m 63.231,96.356 -0.03,-0.044 1.023,1.46 -0.993,-1.416 M 1185,758.263 l 0.469,1.272 -0.478,-1.288 0.01,0.016 m -430.861,-30.577 0.626,-1.432 -0.636,1.461 0.01,-0.029 m 35.525,-50.896 0.415,1.275 -0.435,-1.293 0.02,0.018 m 4.255,170.482 0.035,-0.02 -1.504,0.906 1.469,-0.886 m 226.106,-127.124 0.366,-1.951 -0.357,1.983 -0.01,-0.032 m -263.795,82.724 0.031,-0.045 -0.878,1.433 0.847,-1.388 m -37.904,-24.354 -0.365,-1.163 0.38,1.163 h -0.015 m 123.876,-65.917 0.014,0.007 -2.518,0.474 2.504,-0.481 m -105.448,77.269 -1.104,-0.376 1.114,0.363 -0.01,0.013 m -4.401,-2.957 0.036,10e-4 -1.434,0.576 1.398,-0.577 m 77.897,14.88 0.302,1.66 -0.323,-1.708 0.021,0.048 m 428.236,171.096 0.326,-2.154 -0.322,2.165 v -0.011 M 768.36,853.51 l -0.071,1.548 0.053,-1.575 0.018,0.027 m 257.296,-273.241 -1.308,-0.717 1.334,0.727 -0.026,-0.01 m -268.56,637.987 -0.695,-0.197 0.684,0.191 0.011,0.01 m -23.151,-494.926 -1.24,0.597 1.256,-0.632 -0.016,0.035 m 0.695,28.903 0.009,0.011 -1.508,-0.98 1.499,0.969 m 373.259,-128.148 v -0.001 l 0.331,-0.081 -0.329,0.082 m -119.355,-62.699 1.406,0.371 -1.406,-0.371 v 0 m 79.483,125.665 1.817,0.882 -1.814,-0.875 v -0.007 m -349.066,49.729 -0.893,-1.209 0.9,1.21 -0.007,-10e-4 m -48.36,-0.369 -1.126,1.066 1.132,-1.085 -0.006,0.019 m 360.67,-45.673 0.017,0.005 -1.455,-0.382 1.438,0.377 m 8.935,47.063 1.947,0.852 -1.98,-0.846 0.033,-0.006 m -231.727,60.288 0.002,-0.023 0.086,2.158 -0.088,-2.135 m -46.779,-114.24 -0.261,-0.999 0.295,1.001 -0.034,-0.002 m 341.527,315.133 -1.405,1.313 1.383,-1.314 0.022,10e-4 m -329.89,-151.822 -1.022,1.072 1.027,-1.078 -0.005,0.006 m -18.198,368.057 0.732,0.548 -0.74,-0.549 h 0.008 m 5.655,-365.381 0.042,-0.033 -1.898,1.722 1.856,-1.689 m 478.987,112.825 0.087,-1.269 -0.085,1.247 v 0.022 m -448.034,-196.606 -0.4,1.375 0.355,-1.4 0.045,0.025 m 177.706,-173.135 -0.873,-0.775 0.933,0.786 -0.06,-0.011 m 60.633,150.339 1.337,0.614 -1.343,-0.616 0.01,0.002 m -349.389,-17.456 -1.525,1.152 1.524,-1.161 10e-4,0.009 m 88.088,117.823 -0.911,1.871 0.891,-1.858 0.02,-0.013 m -35.891,-94.354 0.002,0.007 -1.341,-1.24 1.339,1.233 m -4.333,27.906 -1.208,0.323 1.237,-0.338 -0.029,0.015 m -1.637,-25.812 0.029,10e-4 -1.848,0.433 1.819,-0.434 m 47.615,30.841 1.136,1.235 -1.163,-1.249 0.027,0.014 m 313.163,-170.258 0.014,0.02 -1.284,-0.855 1.27,0.835 M 750.611,1157.98 h -0.008 l 0.081,-0.836 -0.073,0.832 m -113.537,-399.623 -1.145,1.443 1.165,-1.473 -0.02,0.03 m 412.908,-172.211 -0.795,-0.504 0.801,0.507 -0.01,-0.003 m -279.669,93.25 -1.387,-0.024 1.429,0.01 -0.042,0.014 m -37.582,68.065 -1.428,0.095 1.452,-0.115 -0.024,0.02 m 455.115,299.136 -0.993,1.314 0.995,-1.32 v 0.01 m -467.01,-299.957 -1.194,0.333 1.189,-0.341 0.005,0.008 m 87.26,28.443 0.055,1.425 -0.06,-1.432 0.005,0.007 m 245.673,-27.755 0.724,1.529 -0.748,-1.553 0.024,0.024 m -15.977,274.194 0.01,-0.01 -0.736,1.429 0.729,-1.419 m 198.254,-66.931 v -0.009 l 0.426,-0.618 -0.428,0.627 m -496.842,-239.598 1.54,-0.616 -1.555,0.64 0.015,-0.024 m -2.554,-94.838 0.051,-0.033 -1.857,1.364 1.806,-1.331 m -14.723,123.672 -0.966,-0.664 0.988,0.653 -0.022,0.011 m 296.462,-41.812 -2.033,-0.395 2.072,0.4 -0.039,-0.005 m 162.999,55.664 -0.018,-0.019 0.837,0.879 -0.819,-0.86 m -154.895,-85.045 1.862,1.266 -1.874,-1.269 0.012,0.003 m -303.695,104.556 0.018,0.006 -1.271,-0.016 1.253,0.01 m 66.293,-100.752 -0.503,-1.277 0.518,1.266 -0.015,0.011 m 201.035,-82.943 -0.601,0.95 0.591,-0.958 0.01,0.008 m -250.452,89.914 0.16,-1.307 -0.14,1.319 -0.02,-0.012 m 33.474,440.009 0.01,0.01 -2.023,-0.276 2.013,0.267 m 290.385,-492.728 -1.747,-1.342 1.758,1.336 -0.011,0.006 m -325.822,124.012 -1.865,0.217 1.894,-0.246 -0.029,0.029 m 24.463,104.325 -0.73,1.18 0.743,-1.241 -0.013,0.061 m 258.887,-182.923 0.01,-0.031 0.84,2.123 -0.847,-2.092 m -321.766,16.072 -0.544,-0.825 0.577,0.822 -0.033,0.003 m 358.329,-6.413 1.548,0.979 -1.586,-0.994 0.038,0.015 m -299.168,0.488 0.042,-0.063 -0.837,1.485 0.795,-1.422 m 168.031,-0.168 -2.326,0.3 2.315,-0.314 0.011,0.014 m -180.493,46.173 1.217,0.646 -1.244,-0.634 0.027,-0.012 m 43.505,31.557 0.69,1.296 -0.715,-1.331 0.025,0.035 m -74.927,-9.91 -1.039,1.047 1.066,-1.083 -0.027,0.036 m -105.001,93.457 -0.171,1.726 0.158,-1.704 0.013,-0.022 m 189.337,-133.032 -0.049,-1.233 0.086,1.204 -0.037,0.029 m -89.2,11.76 -1.085,0.022 1.097,-0.045 -0.012,0.023 m 329.516,126.565 0.4,1.667 -0.427,-1.673 0.027,0.006 m -279.674,-247.492 -0.006,0.016 -0.263,-0.447 0.269,0.431 m 344.809,28.242 v 0 l -1.009,-1.11 1.011,1.11 m -82.369,72.495 0.033,0.019 -1.914,-0.075 1.881,0.056 m 50.429,-90.124 -1.513,-1.133 1.512,1.13 10e-4,0.003 m -42.734,104.555 -0.04,-0.039 1.535,1.182 -1.495,-1.143 m -368.279,65.277 -0.945,0.837 0.96,-0.899 -0.015,0.062 m 419.349,-76.025 v -0.007 l 1.028,0.981 -1.025,-0.974 m -353.996,28.889 0.023,0.017 -1.251,-0.464 1.228,0.447 m 101.092,66.745 0.027,-0.01 -0.768,1.43 0.741,-1.42 m -122.179,-6.954 -1.084,0.922 1.094,-0.963 -0.01,0.041 m 60.147,-138.126 1.263,-0.522 -1.28,0.551 0.017,-0.029 m 17.293,15.623 -0.888,-0.807 0.916,0.801 -0.028,0.006 m -2.827,-73.782 0.765,-0.788 -0.762,0.789 -0.003,-10e-4 m 459.8,303.054 0.045,1.661 -0.055,-1.657 0.01,-0.004 m -537.927,-95.87 0.002,-0.029 0.51,1.863 -0.512,-1.834 m -69.127,-48.193 -1.162,0.827 1.185,-0.855 -0.023,0.028 m 104.28,4.873 -0.694,-1.071 0.75,1.052 -0.056,0.019 m -0.412,-15.25 -1.481,0.264 1.495,-0.271 -0.014,0.007 m 282.789,-41.558 -1.295,-0.262 1.315,0.25 -0.02,0.012 m 41.566,151.62 0.01,-0.01 -0.094,1.373 0.085,-1.363 M 745.64,736.464 h 0.007 l -1.779,1.144 1.772,-1.144 m 62.54,65.574 -0.569,1.495 0.552,-1.457 0.017,-0.038 m -58.213,-89.25 1.897,-0.744 -1.911,0.757 0.014,-0.013 m 49.875,40.319 -1.192,0.938 1.197,-0.951 -0.005,0.013 m -155.869,-4.998 -1.411,1.063 1.41,-1.083 10e-4,0.02 m 138.338,-71.224 -0.377,-0.962 0.402,0.938 -0.025,0.024 m 250.863,51.091 1.849,0.323 -1.876,-0.326 0.027,0.003 m -33.796,-134.297 1.083,-0.051 -1.067,0.053 -0.016,-0.002 m -377.103,204.416 0.019,-0.034 -0.312,1.865 0.293,-1.831 m 178.22,-41.074 -0.798,1.165 0.812,-1.194 -0.014,0.029 m 428.494,219.573 v -0.006 l 0.551,-0.97 -0.549,0.976 m -514.574,-244.096 -1.146,0.136 1.164,-0.146 -0.018,0.01 m 110.785,71.507 -1.386,-0.069 1.35,0.024 0.036,0.045 m -175.066,26.56 0.028,-0.006 -1.385,0.317 1.357,-0.311 m 430.37,-200.263 1.129,0.871 -1.141,-0.855 0.012,-0.016 m -246.534,213.041 0.033,-0.011 -1.374,0.563 1.341,-0.552 m -86.438,-169.066 1.129,-0.98 -1.114,0.988 -0.015,-0.008 m 49.378,454.323 h -0.007 l 1.412,-0.58 -1.405,0.582 m 397.6,-375.916 0.331,1.458 -0.342,-1.492 0.011,0.034 m -459.472,8.435 -0.815,-0.979 0.827,0.988 -0.012,-0.009 m 307.336,-67.286 -0.899,-1.145 0.919,1.148 -0.02,-0.003 m -266.577,113.288 -1.554,0.632 1.565,-0.672 -0.011,0.04 m -56.597,-87.666 -0.904,1.037 0.885,-1.065 0.019,0.028 m 42.921,-60.083 1.583,-0.608 -1.613,0.631 0.03,-0.023 m -23.216,43.156 -0.042,0.008 1.551,-0.855 -1.509,0.847 m 7.235,455.472 0.012,1.089 -0.026,-1.097 0.014,0.01 m -16.635,-410.752 0.033,-0.009 -2.066,0.647 2.033,-0.638 m 9.444,301.16 1.41,0.34 -1.394,-0.314 -0.016,-0.026 m 63.985,-354.284 -1.311,0.738 1.304,-0.767 0.007,0.029 m 222.634,19.663 1.526,0.713 -1.547,-0.696 0.021,-0.017 M 743.464,674.22 v 0.008 l -0.461,-0.735 0.461,0.727 m 283.459,0.274 2.008,0.788 -2.021,-0.787 0.013,-10e-4 m -293.355,15.134 0.516,-1.504 -0.504,1.51 -0.012,-0.006 m 402.557,315.352 1.441,0.229 -1.454,-0.202 0.013,-0.027 m -387.487,-328.362 0.844,-1.232 -0.849,1.243 0.005,-0.011 m -16.299,70.252 -1.313,-0.148 1.406,0.118 -0.093,0.03 m 308.728,-9.704 1.353,0.865 -1.391,-0.864 0.038,-10e-4 m 80.489,259.006 1.151,0.89 -1.15,-0.863 -10e-4,-0.027 m -375.877,-382.661 -1.39,0.987 1.421,-1.01 -0.031,0.023 m 10.029,-7.807 0.711,-1.183 -0.717,1.202 0.006,-0.019 m 43.157,523.185 -0.005,-10e-4 0.43,-0.993 -0.425,0.994 m 441.251,-209.036 -0.029,1.731 0.02,-1.748 0.01,0.017 m -117.355,-257.386 0.845,1.094 -0.855,-1.091 0.01,-0.003 m -346.77,405.13 -1.541,0.079 1.513,-0.09 0.028,0.011 m -19.746,149.987 -0.016,-0.01 0.871,0.495 -0.855,-0.486 m -36.795,-484.537 -1.145,-0.17 1.148,0.169 -0.003,0.001 m 106.437,393.771 1.895,0.339 -1.956,-0.332 0.061,-0.01 m -65.497,-435.354 -1.152,0.827 1.172,-0.883 -0.02,0.056 m 9.062,112.024 -1.163,-0.544 1.189,0.539 -0.026,0.005 m -44.344,192.581 -0.019,-0.034 1.467,1.041 -1.448,-1.007 m -69.256,-230.135 -1.229,0.498 1.253,-0.527 -0.024,0.029 m 82.905,-19.503 -1.551,-0.311 1.59,0.29 -0.039,0.021 m -81.623,135.579 -0.794,1.112 0.79,-1.142 0.004,0.03 m 373.433,-162.229 -0.022,-0.028 1.495,0.414 -1.473,-0.386 m -399.964,32.878 -0.629,1.368 0.635,-1.41 -0.006,0.042 m 93.537,-6.799 -0.9,-0.63 0.957,0.62 -0.057,0.01 m 290.589,-51.334 -1.507,0.828 1.521,-0.836 -0.014,0.008 m -326.043,23.948 -0.707,1.424 0.709,-1.454 -0.002,0.03 m -16.79,35.202 -0.991,1.57 1.016,-1.625 -0.025,0.055 m 139.807,20.309 -0.745,1.783 0.756,-1.811 -0.011,0.028 m -93.402,260.385 0.15,1.386 -0.172,-1.376 0.022,-0.01 m 7.223,-248.138 -0.002,0.017 -1.357,-0.211 1.359,0.194 m 44.059,-77.483 -10e-4,0.035 -1.437,0.157 1.438,-0.192 m 250.964,5.755 -1.376,-0.616 1.407,0.611 -0.031,0.005 m -256.239,507.966 h 0.002 l -1.29,-0.574 1.288,0.573 m -29.43,-507.118 -0.279,-1.046 0.291,1.048 -0.012,-0.002 m 383.353,-88.974 -0.01,-0.004 1.081,0.869 -1.075,-0.865 m -375.324,102.169 0.831,0.87 -0.85,-0.883 0.019,0.013 m 25.473,495.655 -1.365,-0.554 1.362,0.552 h 0.003 m -27.434,-526.527 1.213,0.089 -1.249,-0.074 0.036,-0.015 m 295.432,41.029 1.568,1.151 -1.601,-1.156 0.033,0.005 m -297.368,42.069 0.024,0.021 -1.304,-0.454 1.28,0.433 m 15.758,-116.644 1.199,-1.141 -1.225,1.176 0.026,-0.035 m 114.263,70.843 1.554,-0.565 -1.583,0.588 0.029,-0.023 m -139.38,-4.884 h 0.008 l -1.33,0.702 1.322,-0.702 m 7.055,29.963 -1.241,-0.721 1.289,0.709 -0.048,0.012 m -3.69,25.467 -0.006,0.008 -1.047,-0.579 1.053,0.571 m 458.155,305.271 0.929,-1.385 -0.91,1.36 -0.019,0.025 m -150.597,-73.422 -1.336,1.329 1.36,-1.373 -0.024,0.044 m -230.209,-248.799 0.04,0.003 -1.611,0.132 1.571,-0.135 m -29.16,-64.205 0.02,0.003 -1.471,0.781 1.451,-0.784 m -28.262,-22.47 h 0.016 l -1.445,0.3 1.429,-0.3 m 77.735,157.249 -0.025,0.034 -1.694,0.953 1.719,-0.987 m -158.662,-117.661 1.242,-0.934 -1.241,0.937 -10e-4,-0.003 m 154.059,404.765 -1.52,0.454 1.512,-0.475 0.008,0.021 m 86.919,-458.419 -1.28,1.274 1.282,-1.278 -0.002,0.004 m -102.223,10.819 0.005,1.207 -0.041,-1.215 0.036,0.008 m -63.484,-65.673 0.031,-0.018 -0.646,0.998 0.615,-0.98 m 58.157,195.214 -0.397,1.755 0.392,-1.808 0.005,0.053 m 422.244,214.412 -0.344,0.996 0.336,-0.979 0.01,-0.017 m -409.108,-323.415 -2.073,-0.069 2.118,0.034 -0.045,0.035 m -73.772,-2.533 1.026,0.516 -1.046,-0.514 0.02,-0.002 m 427.105,361.707 h -0.932 l 0.934,-0.01 v 0 m -399.36,-268.009 -1.164,-0.431 1.207,0.437 -0.043,-0.006 m 46.3,-0.394 -0.717,1.737 0.717,-1.764 v 0.027 m -117.034,28.554 -0.941,1.43 0.917,-1.449 0.024,0.019 m 345.749,-130.841 1.282,0.462 -1.276,-0.458 -0.01,-0.004 m -302.764,162.81 -1.084,0.969 1.094,-0.989 -0.01,0.02 m -8.347,-149.395 -0.032,0.023 1.214,-1.138 -1.182,1.115 m 71.82,80.992 -0.775,1.167 0.778,-1.21 -0.003,0.043 m 312.056,211.301 -0.187,1.877 0.163,-1.852 0.024,-0.025 m -311.496,223.394 1.272,-0.038 -1.244,0.055 -0.028,-0.017 m 202.479,-519.676 -1.437,-0.332 1.459,0.333 -0.022,-10e-4 m -267.036,-83.303 0.061,-0.026 -1.303,0.717 1.242,-0.691 m 127.227,142.247 1.704,-0.074 -1.73,0.094 0.026,-0.02 m -90.011,85.553 v -0.029 l 0.421,1.331 -0.421,-1.302 m 59.99,294.466 0.02,0.012 0.063,1.372 -0.083,-1.384 m 359.854,-413.001 0.717,1.198 -0.726,-1.213 0.01,0.015 m -184.432,-19.359 -1.365,-0.259 1.409,0.224 -0.044,0.035 m -207.694,510.869 h 0.027 l 1.441,0.416 -1.468,-0.418 m 38.01,10.514 0.902,-0.365 -0.82,0.388 -0.082,-0.023 m 193.605,-488.989 1.507,1 -1.537,-1.008 0.03,0.008 m -279.083,426.908 0.477,0.903 -0.486,-0.918 0.009,0.015 m -8.216,-460.757 0.537,0.912 -0.573,-0.915 0.036,0.003 m 18.107,-55.744 1.302,-0.174 -1.317,0.184 0.015,-0.01 m -52.48,96.094 -0.771,-0.689 0.795,0.686 -0.024,0.003 m 425.866,-92.044 0.961,1.002 -0.971,-1.012 0.01,0.01 M 617.977,858.944 h -0.032 l -0.784,-0.755 0.816,0.755 m 191.588,-92.823 -1.33,-0.101 1.353,0.077 -0.023,0.024 m -75.708,-45.236 -1.344,0.283 1.394,-0.306 -0.05,0.023 m -37.495,73.128 -1.429,0.497 1.432,-0.513 -0.003,0.016 m 42.582,-9.412 -0.399,-1.319 0.407,1.288 -0.008,0.031 m -16.112,-35.534 -1.379,0.614 1.404,-0.645 -0.025,0.031 m 293.9,-41.465 0.021,0.01 -1.374,0.021 1.353,-0.031 m -274.439,-73.931 -10e-4,0.002 -1.091,-0.083 1.092,0.081 m 281.224,100.127 1.229,-0.836 -1.255,0.859 0.026,-0.023 m -9.109,-31.26 0.015,-0.035 0.876,-0.71 -0.891,0.745 m -288.206,48.566 0.009,0.007 -1.022,-0.492 1.013,0.485 m 271.513,-160.352 0.076,-0.014 -0.721,0.502 0.645,-0.488 m 35.987,154.822 1.224,1.355 -1.259,-1.362 0.035,0.007 m -1.956,-3.512 1.427,0.752 -1.445,-0.748 0.018,-0.004 m -275.058,33.098 0.009,-0.008 -1.296,1.155 1.287,-1.147 m -154.829,129.572 0.536,1.481 -0.554,-1.469 0.018,-0.012 m 565.82,-214.452 10e-4,0.003 0.01,0.55 -0.01,-0.553 m -412.787,4.249 1.248,0.029 -1.279,-0.011 0.031,-0.018 m -9.33,145.213 -1.392,0.395 1.434,-0.417 -0.042,0.022 m -120.069,-47.245 0.022,-0.029 -0.741,1.223 0.719,-1.194 m 219.19,332.101 -0.3,1.21 0.295,-1.245 0.005,0.035 m 198.253,-422.223 -1.342,-0.417 1.391,0.417 h -0.049 m 1.772,-115.287 -0.897,-0.597 0.899,0.599 v -0.002 m -284.546,632.136 -1.068,-0.382 1.07,0.378 h -0.002 m 304.139,-533.968 10e-4,-0.003 1.169,1.09 -1.17,-1.087 m -233.622,119.124 -0.027,-0.01 1.379,-0.089 -1.352,0.099 m 198.797,-73.547 1.372,1.059 -1.394,-1.065 0.022,0.006 m 107.938,-55.664 -0.583,-1.019 0.607,1.028 -0.024,-0.009 m -408.545,109.101 -1.231,0.368 1.24,-0.375 -0.009,0.007 m 195.243,-99.674 1.457,1.082 -1.506,-1.095 0.049,0.013 m -163.297,535.356 -0.064,-0.031 1.381,0.633 -1.317,-0.602 m 14.191,-153.033 1.513,0.065 -1.509,-0.035 -0.004,-0.03 m -82.59,-285.039 -0.912,-0.466 0.917,0.46 -0.005,0.006 m 469.15,9.663 1.478,1.482 -1.502,-1.489 0.024,0.007 m -339.146,-86.279 -0.005,-0.027 0.557,1.135 -0.552,-1.108 m 200.022,18.824 -0.92,0.839 0.887,-0.843 0.033,0.004 m -284.867,-103.923 -0.918,0.854 0.924,-0.863 -0.006,0.009 m 18.145,597.298 1.311,0.612 -1.345,-0.627 0.034,0.015 m 301.22,-630.03 -0.866,-0.473 0.88,0.479 -0.014,-0.006 m -424.317,178.715 -0.827,1.121 0.844,-1.168 -0.017,0.047 m 198.083,-207.076 -0.575,0.266 0.556,-0.264 0.019,-0.002 m 184.515,137.917 -1.153,0.254 1.165,-0.27 -0.012,0.016 m 24.106,37.984 1.236,0.886 -1.29,-0.884 0.054,-0.002 m 138.615,327.209 v 0 l -0.89,1.063 0.886,-1.065 m -408.102,162.701 -1.265,-0.506 1.273,0.51 h -0.008 m 58.827,-507.807 -0.008,-0.021 1.182,0.771 -1.174,-0.75 m -204.118,94.116 0.003,-0.019 0.043,1.362 -0.046,-1.343 m 443.22,-91.771 1.308,1.201 -1.324,-1.201 h 0.016 m 90.669,-54.911 -0.01,-0.006 0.523,0.492 -0.517,-0.486 m -124.396,84.365 1.042,1.003 -1.096,-1.024 0.054,0.021 m -141.174,-83.218 0.426,1.099 -0.448,-1.134 0.022,0.035 m -36.248,-91.135 -0.003,-10e-4 1.646,-0.059 -1.643,0.06 m 227.627,235.79 -0.263,-2.33 0.271,2.351 -0.01,-0.021 m -245.043,-78.521 -0.986,-0.934 1.025,0.927 -0.039,0.007 m 168.901,-130.888 v -0.003 l 1.274,-0.201 -1.275,0.204 m 24.371,150.394 0.733,1.168 -0.76,-1.187 0.027,0.019"
+           inkscape:connector-curvature="0"
+           style="fill:#000000;fill-opacity:1" />
+      </g>
+      <g
+         id="layer3-0-8">
+        <radialGradient
+           id="radialGradient8507-8"
+           cx="7976.3457"
+           cy="-10508.842"
+           r="13293.867"
+           gradientTransform="matrix(0.0222,0,0,-0.0248,721.1671,674.6745)"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="0"
+             style="stop-color:#80FF80"
+             id="stop8503-8" />
+          <stop
+             offset="1"
+             style="stop-color:#0f0"
+             id="stop8505-6" />
+        </radialGradient>
+        <path
+           id="polygon413-8"
+           d="m 738.059,824.52 -4.896,-2.991 3.183,4.563 1.697,-1.541 0.016,-0.031 m 315.115,-124.435 -0.383,1.419 1.727,0.363 -1.317,-1.773 -0.027,-0.009 m -257.087,112.336 -2.255,0.589 0.465,1.879 1.814,-2.44 -0.024,-0.028 m -70.86,-12.684 -3.059,0.086 3.033,-0.077 0.026,-0.009 m 507.893,171.781 -0.121,-1.182 0.118,1.188 v -0.006 m 1.431,4.062 -0.34,-0.164 0.341,0.166 -10e-4,-0.002 m -490.636,-279.995 -1.29,-0.768 1.215,0.783 0.075,-0.015 m 461.488,304.626 1.548,-2.094 -1.536,2.067 -0.012,0.027 m -461.774,-304.148 -2.035,-0.956 2.023,0.955 0.012,10e-4 m 305.072,4.142 -1.344,-0.514 1.317,0.515 0.027,-10e-4 m 186.587,263.978 v -0.003 l -0.166,-0.673 0.163,0.676 m -97.138,-286.087 0.064,0.801 -0.063,-0.798 -10e-4,-0.003 m -373.039,161.109 -2.353,0.707 2.337,-0.677 0.016,-0.03 m 46.254,289.391 -0.434,-1.414 0.419,1.393 0.015,0.021 m -40.176,-62.291 -1.831,-0.333 1.871,0.346 -0.04,-0.013 m 61.266,62.881 1.77,0.989 -1.741,-0.978 -0.029,-0.011 m 399.868,-148.699 -0.027,1.02 0.03,-1.032 v 0.012 m -85.152,-270.635 1.13,0.812 -1.113,-0.81 -0.017,-0.002 m -427.622,49.937 -0.003,10e-4 -1.005,1.075 1.008,-1.076 m 9.885,37.886 -1.26,0.07 1.234,-0.036 0.026,-0.034 m 411.98,-115.919 -0.672,-1.176 0.654,1.173 0.018,0.003 m -343.025,536.588 0.573,0.66 -0.549,-0.659 -0.024,-10e-4 m 260.171,-528.531 1.178,0.889 -1.171,-0.889 h -0.01 M 939.115,568.803 h -0.003 l -0.188,0.437 0.191,-0.437 m -4.625,-9.775 -1.369,-0.157 1.377,0.166 -0.008,-0.009"
+           inkscape:connector-curvature="0"
+           style="fill:url(#polygon413_1_-2)" />
+      </g>
+      <path
+         style="opacity:0.496774;fill:url(#path3517_1_-8)"
+         inkscape:connector-curvature="0"
+         id="path3517-3"
+         d="m 1250,900 c 0,193.3 -156.701,350 -350,350 -193.3,0 -350,-156.7 -350,-350 0,-193.3 156.7,-350 350,-350 193.299,0 350,156.7 350,350 z" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This adds the monochrome variant of the NixOS lambdaflake.

The source includes two variants

 - monochrome globe
 - coloured globe


For #38.